### PR TITLE
Use Java 22 runtime for desktop packages

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -410,6 +410,7 @@ val macMediaKeysResourceDirName = providers.provider {
 compose.desktop {
     application {
         mainClass = "com.phoebe.app.MainKt"
+        desktopJavaLauncher.orNull?.metadata?.installationPath?.asFile?.absolutePath?.let { javaHome = it }
         jvmArgs += listOf(
             "-Xms32m",
             "-Xmx256m",


### PR DESCRIPTION
## Summary
- Configure Compose Desktop packaging to use the configured Java 22 toolchain as application.javaHome
- Ensures macOS runtime images can launch Java 22-compiled desktop classes during notarized DMG smoke tests

## Verification
- ./gradlew :composeApp:createReleaseDistributable -Pphoebe.versionName=2026.0629.0136
- composeApp/build/compose/binaries/main-release/app/Phoebe.app/Contents/MacOS/Phoebe --phoebe-playback-smoke=composeApp/src/commonTest/resources/test-audio/wikimedia-example.mp3 --phoebe-playback-smoke-timeout-ms=20000