### PR TITLE
[codex] Fix desktop map key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ phoebe.googleMaps.desktopApiKey=your-desktop-key
 phoebe.googleMaps.webApiKey=your-web-key
 ```
 
+The desktop map serves its embedded browser from a random local `127.0.0.1` port. If your desktop key uses HTTP referrer restrictions, allow `http://127.0.0.1:*/*` in Google Cloud Console and enable the Maps JavaScript API for that key.
+
 You can also pass keys with environment variables for a single shell session:
 
 ```bash
@@ -205,7 +207,7 @@ export PHOEBE_GOOGLE_MAPS_DESKTOP_API_KEY=your-desktop-key
 export PHOEBE_GOOGLE_MAPS_WEB_API_KEY=your-web-key
 ```
 
-Platform-specific keys take precedence over the shared `phoebe.googleMaps.apiKey` / `PHOEBE_GOOGLE_MAPS_API_KEY` fallback. Keep these values out of git; release keys are configured separately as GitHub secrets in [docs/github-actions.md](docs/github-actions.md).
+Platform-specific keys take precedence over the shared `phoebe.googleMaps.apiKey` / `PHOEBE_GOOGLE_MAPS_API_KEY` fallback. Desktop environment variables are checked before build-time keys so you can override a packaged/local key for one run. Keep these values out of git; release keys are configured separately as GitHub secrets in [docs/github-actions.md](docs/github-actions.md).
 
 **iOS debug build:**
 

--- a/feature/radio/src/desktopMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.desktop.kt
+++ b/feature/radio/src/desktopMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.desktop.kt
@@ -141,12 +141,12 @@ internal actual fun radioMapGoogleMapsApiKey(): String? =
     if (System.getProperty("org.gradle.test.worker") != null) {
         null
     } else {
-        RadioMapBuildConfig.googleMapsDesktopApiKey.takeIf { it.isNotBlank() }
-            ?: RadioMapBuildConfig.googleMapsWebApiKey.takeIf { it.isNotBlank() }
-            ?: RadioMapBuildConfig.googleMapsApiKey.takeIf { it.isNotBlank() }
-            ?: System.getenv("PHOEBE_GOOGLE_MAPS_DESKTOP_API_KEY")?.takeIf { it.isNotBlank() }
+        System.getenv("PHOEBE_GOOGLE_MAPS_DESKTOP_API_KEY")?.takeIf { it.isNotBlank() }
+            ?: RadioMapBuildConfig.googleMapsDesktopApiKey.takeIf { it.isNotBlank() }
             ?: System.getenv("PHOEBE_GOOGLE_MAPS_WEB_API_KEY")?.takeIf { it.isNotBlank() }
+            ?: RadioMapBuildConfig.googleMapsWebApiKey.takeIf { it.isNotBlank() }
             ?: System.getenv("PHOEBE_GOOGLE_MAPS_API_KEY")?.takeIf { it.isNotBlank() }
+            ?: RadioMapBuildConfig.googleMapsApiKey.takeIf { it.isNotBlank() }
     }
 
 internal actual fun radioMapUsesExternalBrowser(): Boolean = !desktopRadioMapInlineBrowserEnabled()
@@ -416,6 +416,11 @@ private class DesktopRadioMapChromiumHolder(
                         line: Int,
                     ): Boolean {
                         log("console [$level] $source:$line $message")
+                        if (message.contains("Google Maps JavaScript API error", ignoreCase = true)) {
+                            showFallback(
+                                "Google Maps rejected the desktop map key. Check API restrictions, billing, and allow http://127.0.0.1:*/* for the desktop key.",
+                            )
+                        }
                         return false
                     }
                 },


### PR DESCRIPTION
## Summary
- prefer desktop Google Maps runtime environment keys before packaged web/shared fallbacks
- show a clearer inline desktop fallback when the Maps JavaScript API rejects the key
- document the local `127.0.0.1` referrer needed for desktop map keys

## Root Cause
The desktop map is served from a random local `127.0.0.1` port inside the embedded browser. A packaged web/shared key could be selected before a desktop-specific runtime override, and Google Maps failures surfaced only as the generic in-page error.

## Validation
- `./gradlew :feature:radio:desktopTest --tests com.phoebe.app.feature.radio.RadioMapItemTest`
