### PR TITLE
[codex] Fix desktop radio map key referrer

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ phoebe.googleMaps.desktopApiKey=your-desktop-key
 phoebe.googleMaps.webApiKey=your-web-key
 ```
 
-The desktop map serves its embedded browser from a random local `127.0.0.1` port. If your desktop key uses HTTP referrer restrictions, allow `http://127.0.0.1:*/*` in Google Cloud Console and enable the Maps JavaScript API for that key.
+The desktop map serves its embedded browser from `127.0.0.1:41473` when that port is available. In Google Cloud Console, set the desktop key's application restriction to **Websites** / HTTP referrers, not **IP addresses**, then allow `127.0.0.1:41473/*` and enable the Maps JavaScript API for that key. IP address restrictions only accept CIDR addresses and cannot include the port or path used by the desktop map. If another process already has port `41473`, Phoebe falls back to a random free port; close the other process and restart Phoebe to use the restricted desktop key.
 
 You can also pass keys with environment variables for a single shell session:
 

--- a/feature/radio/src/desktopMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.desktop.kt
+++ b/feature/radio/src/desktopMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.desktop.kt
@@ -16,6 +16,7 @@ import java.awt.BorderLayout
 import java.awt.Component
 import java.awt.Desktop
 import java.io.File
+import java.io.IOException
 import java.net.InetSocketAddress
 import java.net.URI
 import java.net.URLDecoder
@@ -171,7 +172,7 @@ private class DesktopRadioMapBrowserServer(
     private val executor: ExecutorService = Executors.newSingleThreadExecutor { runnable ->
         Thread(runnable, "Phoebe-radio-map-browser").apply { isDaemon = true }
     }
-    private val server: HttpServer = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    private val server: HttpServer = createDesktopRadioMapServer()
     val url: String = "http://127.0.0.1:${server.address.port}/radio-map"
 
     @Volatile
@@ -355,6 +356,27 @@ private class DesktopRadioMapExternalLauncherPanel(
     }
 }
 
+private const val PreferredDesktopRadioMapPort = 41473
+
+private fun createDesktopRadioMapServer(): HttpServer =
+    try {
+        HttpServer.create(InetSocketAddress("127.0.0.1", PreferredDesktopRadioMapPort), 0)
+    } catch (_: IOException) {
+        HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    }
+
+private fun desktopRadioMapReferrerInstruction(url: String): String {
+    val port = runCatching { URI(url).port }
+        .getOrDefault(PreferredDesktopRadioMapPort)
+        .takeIf { it > 0 }
+        ?: PreferredDesktopRadioMapPort
+    return if (port == PreferredDesktopRadioMapPort) {
+        "allow 127.0.0.1:$port/*"
+    } else {
+        "allow 127.0.0.1:$port/*, or free port $PreferredDesktopRadioMapPort and restart Phoebe to use the stable desktop map port"
+    }
+}
+
 private class DesktopRadioMapChromiumHolder(
     initialUrl: String,
     private val onOpenExternal: () -> Unit,
@@ -417,8 +439,9 @@ private class DesktopRadioMapChromiumHolder(
                     ): Boolean {
                         log("console [$level] $source:$line $message")
                         if (message.contains("Google Maps JavaScript API error", ignoreCase = true)) {
+                            val referrerInstruction = desktopRadioMapReferrerInstruction(loadedUrl ?: pendingUrl)
                             showFallback(
-                                "Google Maps rejected the desktop map key. Check API restrictions, billing, and allow http://127.0.0.1:*/* for the desktop key.",
+                                "Google Maps rejected the desktop map key. Use Website restrictions, not IP address restrictions, and $referrerInstruction for the desktop key.",
                             )
                         }
                         return false


### PR DESCRIPTION
## Summary

- bind the desktop radio map server to a stable localhost port when available
- update the fallback error text to point users at Website / HTTP referrer restrictions instead of IP restrictions
- document the accepted Google Console referrer entry and the random-port fallback behavior

## Root cause

The desktop map previously used an ephemeral 127.0.0.1 port and told users to configure a wildcard-port referrer. Google Console rejects that shape, and IP address restrictions cannot include the port/path needed by the embedded browser referrer.

## Validation

- ./gradlew :feature:radio:desktopTest
