### PR TITLE
[codex] Fix Windows radio map and live radio startup

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -415,8 +415,8 @@ compose.desktop {
         mainClass = "com.phoebe.app.MainKt"
         javaHome = desktopJavaHome.get()
         jvmArgs += listOf(
-            "-Xms32m",
-            "-Xmx256m",
+            "-Xms64m",
+            "-Xmx768m",
             "-XX:MinHeapFreeRatio=5",
             "-XX:MaxHeapFreeRatio=20",
             "-XX:+UseStringDeduplication",

--- a/core/platform/src/desktopMain/kotlin/com/phoebe/app/platform/DesktopInlineRadioMapCoordinator.kt
+++ b/core/platform/src/desktopMain/kotlin/com/phoebe/app/platform/DesktopInlineRadioMapCoordinator.kt
@@ -45,22 +45,31 @@ object DesktopInlineRadioMapCoordinator {
         resumeListeners.add(listener)
     }
 
+    fun removeScriptsResumeListener(listener: () -> Unit) {
+        resumeListeners.remove(listener)
+    }
+
     fun beginLiveRadioStartup() {
-        liveRadioStartupActive = true
-        autoEndFuture?.cancel(false)
-        autoEndFuture = autoEndExecutor.schedule(
-            { endLiveRadioStartup() },
-            LiveRadioStartupAutoEndMs,
-            TimeUnit.MILLISECONDS,
-        )
+        synchronized(this) {
+            liveRadioStartupActive = true
+            autoEndFuture?.cancel(false)
+            autoEndFuture = autoEndExecutor.schedule(
+                { endLiveRadioStartup() },
+                LiveRadioStartupAutoEndMs,
+                TimeUnit.MILLISECONDS,
+            )
+        }
     }
 
     fun endLiveRadioStartup() {
-        if (!liveRadioStartupActive) return
-        val shouldResumeScripts = isInlineMapActive
-        liveRadioStartupActive = false
-        autoEndFuture?.cancel(false)
-        autoEndFuture = null
+        val shouldResumeScripts = synchronized(this) {
+            if (!liveRadioStartupActive) return
+            val shouldResume = isInlineMapActive
+            liveRadioStartupActive = false
+            autoEndFuture?.cancel(false)
+            autoEndFuture = null
+            shouldResume
+        }
         if (shouldResumeScripts) {
             resumeListeners.forEach { listener -> runCatching(listener) }
         }

--- a/core/platform/src/desktopMain/kotlin/com/phoebe/app/platform/DesktopInlineRadioMapCoordinator.kt
+++ b/core/platform/src/desktopMain/kotlin/com/phoebe/app/platform/DesktopInlineRadioMapCoordinator.kt
@@ -1,0 +1,68 @@
+package com.phoebe.app.platform
+
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Tracks when the desktop inline radio map (JCEF) is mounted and when live radio playback
+ * is starting. While both are active, browser script injection should be deferred so
+ * Chromium does not starve JavaFX / Java Sound startup on Windows.
+ */
+object DesktopInlineRadioMapCoordinator {
+    private const val LiveRadioStartupAutoEndMs = 32_000L
+
+    private val inlineMapHosts = AtomicInteger(0)
+    @Volatile
+    private var liveRadioStartupActive = false
+    private val autoEndExecutor = Executors.newSingleThreadScheduledExecutor { runnable ->
+        Thread(runnable, "Phoebe-radio-map-playback-coordinator").apply { isDaemon = true }
+    }
+    private val resumeListeners = CopyOnWriteArrayList<() -> Unit>()
+    @Volatile
+    private var autoEndFuture: ScheduledFuture<*>? = null
+
+    val isInlineMapActive: Boolean
+        get() = inlineMapHosts.get() > 0
+
+    val shouldDeferBrowserScripts: Boolean
+        get() = isInlineMapActive && liveRadioStartupActive
+
+    fun onInlineMapHostMounted() {
+        inlineMapHosts.incrementAndGet()
+    }
+
+    fun onInlineMapHostUnmounted() {
+        inlineMapHosts.updateAndGet { current -> (current - 1).coerceAtLeast(0) }
+        if (!isInlineMapActive) {
+            endLiveRadioStartup()
+        }
+    }
+
+    fun onScriptsResume(listener: () -> Unit) {
+        resumeListeners.add(listener)
+    }
+
+    fun beginLiveRadioStartup() {
+        liveRadioStartupActive = true
+        autoEndFuture?.cancel(false)
+        autoEndFuture = autoEndExecutor.schedule(
+            { endLiveRadioStartup() },
+            LiveRadioStartupAutoEndMs,
+            TimeUnit.MILLISECONDS,
+        )
+    }
+
+    fun endLiveRadioStartup() {
+        if (!liveRadioStartupActive) return
+        val shouldResumeScripts = isInlineMapActive
+        liveRadioStartupActive = false
+        autoEndFuture?.cancel(false)
+        autoEndFuture = null
+        if (shouldResumeScripts) {
+            resumeListeners.forEach { listener -> runCatching(listener) }
+        }
+    }
+}

--- a/feature/radio/build.gradle.kts
+++ b/feature/radio/build.gradle.kts
@@ -70,6 +70,7 @@ kotlin {
         }
         desktopMain {
             dependencies {
+                implementation(project(":core:platform"))
                 implementation("me.friwi:jcefmaven:146.0.10")
             }
         }

--- a/feature/radio/src/commonMain/kotlin/com/phoebe/app/feature/radio/RadioFeature.kt
+++ b/feature/radio/src/commonMain/kotlin/com/phoebe/app/feature/radio/RadioFeature.kt
@@ -697,12 +697,8 @@ private fun RadioMapRoute(
 
     val externalBrowserMap = radioMapUsesExternalBrowser()
     val minimalEmbeddedMap = radioMapUsesMinimalEmbeddedChrome()
-    val clusterThresholdDegrees = remember(mapZoom, externalBrowserMap, minimalEmbeddedMap) {
-        if (externalBrowserMap || minimalEmbeddedMap) {
-            1.5
-        } else {
-            radioMapClusterThresholdDegrees(mapZoom)
-        }
+    val clusterThresholdDegrees = remember(mapZoom) {
+        radioMapClusterThresholdDegrees(mapZoom)
     }
     var items by remember { mutableStateOf(emptyList<RadioMapItem>()) }
     LaunchedEffect(directory.globeStations, expandedClusterIds, clusterThresholdDegrees) {
@@ -728,16 +724,23 @@ private fun RadioMapRoute(
         directory.globeAutoPrefetching,
         directory.globeLoadedStationCount,
         directory.canLoadNextGlobePage,
+        minimalEmbeddedMap,
     ) {
-        val initialDenseBatchReady = directory.globeLoadedStationCount >= RadioMapInitialPresentationStationTarget
+        val presentationTarget = if (minimalEmbeddedMap) {
+            RadioMapEmbeddedDesktopPresentationStationTarget
+        } else {
+            RadioMapInitialPresentationStationTarget
+        }
+        val initialDenseBatchReady = directory.globeLoadedStationCount >= presentationTarget
         val loadingSettled = !directory.globeAutoPrefetching || !directory.canLoadNextGlobePage
-        if (!mapPresented && items.isNotEmpty() && !directory.globeLoading && (initialDenseBatchReady || loadingSettled)) {
+        val readyForEmbeddedMap = minimalEmbeddedMap && items.isNotEmpty() && !directory.globeLoading
+        if (!mapPresented && items.isNotEmpty() && !directory.globeLoading && (readyForEmbeddedMap || initialDenseBatchReady || loadingSettled)) {
             mapPresented = true
         }
     }
     val shouldWaitForMapMarkers = !externalBrowserMap &&
         !mapPresented &&
-        (items.isEmpty() || directory.globeLoading || directory.globeAutoPrefetching)
+        (items.isEmpty() || directory.globeLoading || (!minimalEmbeddedMap && directory.globeAutoPrefetching))
     val submitSearch: () -> Unit = {
         actions.onGlobeSearch(RadioStationSearchQuery(text = queryText.trim()), 0)
     }
@@ -1631,3 +1634,4 @@ internal fun expandedRadioMapClusterIds(
     }
 
 private const val RadioMapInitialPresentationStationTarget = 2_000
+private const val RadioMapEmbeddedDesktopPresentationStationTarget = 250

--- a/feature/radio/src/commonMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.kt
+++ b/feature/radio/src/commonMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.kt
@@ -362,6 +362,38 @@ internal fun radioMapHtml(
               const count = Number(marker?.phoebeStation?.count);
               return total + (Number.isFinite(count) && count > 0 ? count : 1);
             }, 0);
+            const clusterPositions = (station) => {
+              if (station.isCluster && Array.isArray(station.children) && station.children.length > 0) {
+                return station.children
+                  .filter((child) => Number.isFinite(Number(child.lat)) && Number.isFinite(Number(child.lng)))
+                  .map((child) => ({ lat: Number(child.lat), lng: Number(child.lng) }));
+              }
+              if (Number.isFinite(Number(station.lat)) && Number.isFinite(Number(station.lng))) {
+                return [{ lat: Number(station.lat), lng: Number(station.lng) }];
+              }
+              return [];
+            };
+            const focusMapOnPositions = (positions) => {
+              if (!map || positions.length === 0) return false;
+              if (positions.length === 1) {
+                map.setCenter(positions[0]);
+                map.setZoom(Math.max(Number(map.getZoom()) || 2, 14));
+                return true;
+              }
+              const bounds = new google.maps.LatLngBounds();
+              positions.forEach((position) => bounds.extend(position));
+              if (bounds.isEmpty()) return false;
+              map.fitBounds(bounds, 48);
+              const listener = map.addListener('idle', () => {
+                google.maps.event.removeListener(listener);
+                const zoom = Number(map.getZoom());
+                if (Number.isFinite(zoom) && zoom > 18) {
+                  map.setZoom(18);
+                }
+              });
+              return true;
+            };
+            const focusMapOnStation = (station) => focusMapOnPositions(clusterPositions(station));
             const markerIcon = (station, selected) => {
               const count = station.isCluster ? String(station.count) : '';
               const digitCount = count.length;
@@ -403,8 +435,7 @@ internal fun radioMapHtml(
                     window.PhoebeRadioMap?.selectItem?.(station.id);
                   }
                   postDesktopBridge('select', station.id, null, null);
-                  map.setCenter({ lat: station.lat, lng: station.lng });
-                  map.setZoom(Math.min((map.getZoom() || 2) + 2, 18));
+                  focusMapOnStation(station);
                   setStatus('Showing ' + targetLabel + '.', true);
                   return;
                 }
@@ -425,7 +456,7 @@ internal fun radioMapHtml(
             window.initRadioMap = async () => {
               try {
                 setStatus('Loading radio stations...');
-                const [{ Map }, { MarkerClusterer }] = await Promise.all([
+                const [{ Map }, { MarkerClusterer, SuperClusterAlgorithm }] = await Promise.all([
                   google.maps.importLibrary('maps'),
                   import('https://cdn.jsdelivr.net/npm/@googlemaps/markerclusterer/+esm'),
                 ]);
@@ -467,6 +498,7 @@ internal fun radioMapHtml(
                   clusterer = new MarkerClusterer({
                     map,
                     markers: currentMarkers,
+                    algorithm: new SuperClusterAlgorithm({ maxZoom: 11 }),
                     renderer: {
                       render: ({ markers, position }) => {
                         const count = representedMarkerCount(markers || []);
@@ -491,8 +523,14 @@ internal fun radioMapHtml(
                         }
                         postDesktopBridge('select', sourceCluster.id, null, null);
                       }
-                      map.setCenter(cluster.position);
-                      map.setZoom(Math.min((map.getZoom() || 2) + 2, 18));
+                      const markerPositions = markers
+                        .map((marker) => marker?.getPosition?.())
+                        .filter((position) => position != null)
+                        .map((position) => ({ lat: position.lat(), lng: position.lng() }));
+                      if (!focusMapOnPositions(markerPositions)) {
+                        map.setCenter(cluster.position);
+                        map.setZoom(Math.min((map.getZoom() || 2) + 2, 18));
+                      }
                     },
                   });
                   setStatus('Loaded ' + representedStationCount(sourceMarkers) + ' radio stations.', true);
@@ -524,7 +562,7 @@ internal fun radioMapHtml(
               }
             };
           </script>
-          <script async src="https://maps.googleapis.com/maps/api/js?key=${googleMapsApiKey.escapeJs()}&v=weekly&callback=initRadioMap"></script>
+          <script async defer src="https://maps.googleapis.com/maps/api/js?key=${googleMapsApiKey.escapeJs()}&v=weekly&loading=async&callback=initRadioMap"></script>
         </head>
         <body class="$bodyClass">
           <div id="map"></div>

--- a/feature/radio/src/desktopMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.desktop.kt
+++ b/feature/radio/src/desktopMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.desktop.kt
@@ -447,13 +447,10 @@ private class DesktopRadioMapChromiumHolder(
     private val jsExecutor: ExecutorService = Executors.newSingleThreadExecutor { runnable ->
         Thread(runnable, "Phoebe-radio-map-js").apply { isDaemon = true }
     }
-
-    init {
-        DesktopInlineRadioMapCoordinator.onScriptsResume {
-            jsExecutor.execute {
-                if (!disposed) {
-                    flushPendingSnapshot()
-                }
+    private val resumeListener: () -> Unit = {
+        jsExecutor.execute {
+            if (!disposed) {
+                flushPendingSnapshot()
             }
         }
     }
@@ -471,6 +468,7 @@ private class DesktopRadioMapChromiumHolder(
     }
 
     init {
+        DesktopInlineRadioMapCoordinator.onScriptsResume(resumeListener)
         showMessage("Loading radio map browser...")
         val start = Runnable { startBrowser() }
         if (SwingUtilities.isEventDispatchThread()) {
@@ -668,6 +666,7 @@ private class DesktopRadioMapChromiumHolder(
 
     fun dispose() {
         disposed = true
+        DesktopInlineRadioMapCoordinator.removeScriptsResumeListener(resumeListener)
         jsExecutor.shutdownNow()
         SwingUtilities.invokeLater {
             panel.removeComponentListener(resizeListener)

--- a/feature/radio/src/desktopMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.desktop.kt
+++ b/feature/radio/src/desktopMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.desktop.kt
@@ -8,13 +8,17 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
+import com.phoebe.app.platform.DesktopInlineRadioMapCoordinator
 import com.phoebe.app.domain.RadioMapViewport
 import com.phoebe.app.ui.LocalPhoebePalette
 import com.sun.net.httpserver.HttpExchange
 import com.sun.net.httpserver.HttpServer
 import java.awt.BorderLayout
+import java.awt.Color as AwtColor
 import java.awt.Component
 import java.awt.Desktop
+import java.awt.event.ComponentAdapter
+import java.awt.event.ComponentEvent
 import java.io.File
 import java.io.IOException
 import java.net.InetSocketAddress
@@ -36,6 +40,7 @@ import org.cef.CefClient
 import org.cef.CefSettings
 import org.cef.browser.CefBrowser
 import org.cef.browser.CefFrame
+import org.cef.browser.CefMessageRouter
 import org.cef.handler.CefDisplayHandlerAdapter
 import org.cef.handler.CefLifeSpanHandlerAdapter
 import org.cef.handler.CefLoadHandler
@@ -82,7 +87,6 @@ internal actual fun RadioMapHost(
             },
             onPlay = { itemId ->
                 currentItems.value.findRadioMapItem(itemId)?.let { item ->
-                    currentOnItemSelected.value(item)
                     if (item is RadioMapItem.Station) {
                         currentOnItemPlay.value(item)
                     }
@@ -120,11 +124,16 @@ internal actual fun RadioMapHost(
     }
 
     DisposableEffect(browserHolder) {
-        onDispose { browserHolder.dispose() }
+        DesktopInlineRadioMapCoordinator.onInlineMapHostMounted()
+        onDispose {
+            DesktopInlineRadioMapCoordinator.onInlineMapHostUnmounted()
+            browserHolder.dispose()
+        }
     }
 
     SwingPanel(
         modifier = modifier,
+        background = Color(0xFF080B12),
         factory = {
             browserHolder.panel.also {
                 val snapshot = server.update(items, selectedItem, startingStationIds, mapLoading)
@@ -158,6 +167,11 @@ private fun desktopRadioMapInlineBrowserEnabled(): Boolean =
     System.getProperty("phoebe.radioMap.inlineBrowser")?.toBooleanStrictOrNull()
         ?: System.getenv("PHOEBE_RADIO_MAP_INLINE_BROWSER")?.toBooleanStrictOrNull()
         ?: true
+
+private fun desktopRadioMapDisableGpu(): Boolean =
+    System.getProperty("phoebe.radioMap.disableGpu")?.toBooleanStrictOrNull()
+        ?: System.getenv("PHOEBE_RADIO_MAP_DISABLE_GPU")?.toBooleanStrictOrNull()
+        ?: !System.getProperty("os.name").orEmpty().lowercase().contains("windows")
 
 private class DesktopRadioMapBrowserServer(
     private val googleMapsApiKey: String,
@@ -199,7 +213,7 @@ private class DesktopRadioMapBrowserServer(
             when (exchange.requestURI.path) {
                 "/", "/radio-map" -> exchange.sendHtml(currentHtml())
                 "/select" -> exchange.handleItemAction(onSelected)
-                "/play" -> exchange.handleItemAction(onPlay)
+                "/play" -> exchange.handlePlayAction(onPlay)
                 "/zoom" -> exchange.handleZoom()
                 "/viewport" -> exchange.handleViewport()
                 "/searchArea" -> exchange.handleSearchArea()
@@ -259,6 +273,14 @@ private class DesktopRadioMapBrowserServer(
         val itemId = queryParameters()["id"].orEmpty()
         if (itemId.isNotBlank()) {
             SwingUtilities.invokeLater { action(itemId) }
+        }
+        sendText("ok")
+    }
+
+    private fun HttpExchange.handlePlayAction(action: (String) -> Unit) {
+        val itemId = queryParameters()["id"].orEmpty()
+        if (itemId.isNotBlank()) {
+            executor.execute { action(itemId) }
         }
         sendText("ok")
     }
@@ -333,6 +355,20 @@ private fun DesktopRadioMapSnapshot.toJavaScript(): String {
     """.trimIndent()
 }
 
+private fun DesktopRadioMapSnapshot.toLightweightJavaScript(): String {
+    val startingIdsPayload = startingIdsJson.escapeJs()
+    return """
+        (function() {
+          if (window.setRadioMapSearchLoading) {
+            window.setRadioMapSearchLoading($mapLoading);
+          }
+          if (window.setRadioMapStartingStationIds) {
+            window.setRadioMapStartingStationIds(JSON.parse("$startingIdsPayload"));
+          }
+        })();
+    """.trimIndent()
+}
+
 private class DesktopRadioMapExternalLauncherPanel(
     onOpenExternal: () -> Unit,
 ) : JPanel() {
@@ -357,6 +393,8 @@ private class DesktopRadioMapExternalLauncherPanel(
 }
 
 private const val PreferredDesktopRadioMapPort = 41473
+private const val DesktopRadioMapFullMarkerUpdateDebounceMs = 350L
+private val DesktopRadioMapPanelBackground = AwtColor(0x08, 0x0B, 0x12)
 
 private fun createDesktopRadioMapServer(): HttpServer =
     try {
@@ -381,46 +419,89 @@ private class DesktopRadioMapChromiumHolder(
     initialUrl: String,
     private val onOpenExternal: () -> Unit,
 ) {
-    val panel: JPanel = JPanel(BorderLayout())
+    val panel: JPanel = JPanel(BorderLayout()).apply {
+        isOpaque = true
+        background = DesktopRadioMapPanelBackground
+    }
     private var browser: CefBrowser? = null
     private var client: CefClient? = null
     private var pendingUrl: String = initialUrl
+    private var pendingSnapshot: DesktopRadioMapSnapshot? = null
     private var loadedUrl: String? = null
-    private val cefExecutor: ExecutorService = Executors.newSingleThreadExecutor { runnable ->
-        Thread(runnable, "Phoebe-radio-map-cef").apply { isDaemon = true }
-    }
     @Volatile
     private var disposed: Boolean = false
+    @Volatile
+    private var activated: Boolean = false
+    @Volatile
+    private var browserCreated: Boolean = false
+    @Volatile
+    private var browserAttached: Boolean = false
+    @Volatile
+    private var lastInjectedScript: String? = null
+    @Volatile
+    private var lastLightweightScript: String? = null
+    @Volatile
+    private var lastMarkersJson: String? = null
+    @Volatile
+    private var pendingFullMarkerGeneration: Long = 0L
+    private val jsExecutor: ExecutorService = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "Phoebe-radio-map-js").apply { isDaemon = true }
+    }
+
+    init {
+        DesktopInlineRadioMapCoordinator.onScriptsResume {
+            jsExecutor.execute {
+                if (!disposed) {
+                    flushPendingSnapshot()
+                }
+            }
+        }
+    }
+
+    private val resizeListener = object : ComponentAdapter() {
+        override fun componentResized(event: ComponentEvent) {
+            syncBrowserSize()
+            activateBrowserIfReady()
+        }
+
+        override fun componentShown(event: ComponentEvent) {
+            syncBrowserSize()
+            activateBrowserIfReady()
+        }
+    }
 
     init {
         showMessage("Loading radio map browser...")
-        cefExecutor.execute {
-            runCatching {
-                log("starting jcefmaven browser")
-                DesktopRadioMapCef.instance()
-            }.onSuccess { app ->
-                SwingUtilities.invokeLater {
-                    if (!disposed) {
-                        createBrowser(app)
-                    }
-                }
-            }.onFailure { error ->
-                log("start failed: ${error.stackTraceToString()}")
-                showFallback("Could not start inline browser: ${error.message ?: error::class.simpleName}")
-            }
+        val start = Runnable { startBrowser() }
+        if (SwingUtilities.isEventDispatchThread()) {
+            start.run()
+        } else {
+            SwingUtilities.invokeLater(start)
+        }
+    }
+
+    private fun startBrowser() {
+        if (disposed) return
+        runCatching {
+            log("starting jcefmaven browser")
+            javax.swing.JPopupMenu.setDefaultLightWeightPopupEnabled(false)
+            createBrowser(DesktopRadioMapCef.instance())
+        }.onFailure { error ->
+            log("start failed: ${error.stackTraceToString()}")
+            showFallback("Could not start inline browser: ${error.message ?: error::class.simpleName}")
         }
     }
 
     private fun createBrowser(app: CefApp) {
         runCatching {
             val nextClient = app.createClient()
+            nextClient.addMessageRouter(CefMessageRouter.create())
             nextClient.addLifeSpanHandler(
                 object : CefLifeSpanHandlerAdapter() {
                     override fun onAfterCreated(createdBrowser: CefBrowser) {
-                        log("created browser; loading $pendingUrl")
-                        val url = pendingUrl
-                        loadedUrl = url
-                        createdBrowser.loadURL(url)
+                        log("browser created")
+                        browserCreated = true
+                        SwingUtilities.invokeLater { activateBrowserIfReady() }
                     }
 
                     override fun onBeforeClose(closingBrowser: CefBrowser) {
@@ -450,6 +531,19 @@ private class DesktopRadioMapChromiumHolder(
             )
             nextClient.addLoadHandler(
                 object : CefLoadHandlerAdapter() {
+                    override fun onLoadEnd(
+                        browser: CefBrowser,
+                        frame: CefFrame,
+                        httpStatusCode: Int,
+                    ) {
+                        if (!frame.isMain) return
+                        val url = frame.url.orEmpty()
+                        log("load end $url status=$httpStatusCode")
+                        if (url.isBlank() || url == "about:blank") return
+                        loadedUrl = url
+                        flushPendingSnapshot()
+                    }
+
                     override fun onLoadError(
                         browser: CefBrowser,
                         frame: CefFrame,
@@ -468,32 +562,115 @@ private class DesktopRadioMapChromiumHolder(
                     }
                 },
             )
-            val nextBrowser = nextClient.createBrowser("about:blank", true, false)
+            val nextBrowser = nextClient.createBrowser("about:blank", false, false)
             client = nextClient
             browser = nextBrowser
-            showBrowser(nextBrowser.uiComponent)
-            nextBrowser.createImmediately()
+            showBrowser(nextBrowser.uiComponent) {
+                browserAttached = true
+                activateBrowserIfReady()
+            }
         }.onFailure { error ->
             log("start failed: ${error.stackTraceToString()}")
             showFallback("Could not start inline browser: ${error.message ?: error::class.simpleName}")
         }
     }
 
+    private fun activateBrowserIfReady() {
+        if (activated || disposed || !browserCreated || !browserAttached) return
+        val currentBrowser = browser ?: return
+        if (panel.width <= 0 || panel.height <= 0) return
+        activated = true
+        syncBrowserSize()
+        currentBrowser.createImmediately()
+        log("loading $pendingUrl (${panel.width}x${panel.height})")
+        currentBrowser.loadURL(pendingUrl)
+    }
+
+    private fun syncBrowserSize() {
+        val currentBrowser = browser ?: return
+        val width = panel.width.coerceAtLeast(1)
+        val height = panel.height.coerceAtLeast(1)
+        val uiComponent = currentBrowser.uiComponent
+        if (uiComponent.width != width || uiComponent.height != height) {
+            uiComponent.setSize(width, height)
+            uiComponent.revalidate()
+            uiComponent.repaint()
+        }
+    }
+
     fun update(snapshot: DesktopRadioMapSnapshot) {
         pendingUrl = snapshot.url
-        val currentBrowser = browser
-        if (currentBrowser != null && loadedUrl == null) {
-            loadedUrl = snapshot.url
-            currentBrowser.loadURL(snapshot.url)
-        } else if (currentBrowser != null) {
-            currentBrowser.executeJavaScript(snapshot.toJavaScript(), loadedUrl.orEmpty(), 0)
+        pendingSnapshot = snapshot
+        val currentBrowser = browser ?: return
+        if (loadedUrl == null) {
+            return
+        }
+        applySnapshot(currentBrowser, snapshot)
+    }
+
+    private fun flushPendingSnapshot() {
+        val snapshot = pendingSnapshot ?: return
+        val currentBrowser = browser ?: return
+        if (loadedUrl.isNullOrBlank()) return
+        applySnapshot(currentBrowser, snapshot)
+    }
+
+    private fun applySnapshot(currentBrowser: CefBrowser, snapshot: DesktopRadioMapSnapshot) {
+        if (DesktopInlineRadioMapCoordinator.shouldDeferBrowserScripts) return
+        val markersChanged = snapshot.markersJson != lastMarkersJson
+        if (markersChanged) {
+            if (lastMarkersJson == null) {
+                applyFullSnapshot(currentBrowser, snapshot)
+            } else {
+                scheduleFullSnapshot(currentBrowser, snapshot)
+            }
+        }
+        applyLightweightSnapshot(currentBrowser, snapshot)
+    }
+
+    private fun applyFullSnapshot(currentBrowser: CefBrowser, snapshot: DesktopRadioMapSnapshot) {
+        val script = snapshot.toJavaScript()
+        if (script == lastInjectedScript) return
+        lastInjectedScript = script
+        lastLightweightScript = null
+        lastMarkersJson = snapshot.markersJson
+        executeBrowserScript(currentBrowser, script)
+    }
+
+    private fun applyLightweightSnapshot(currentBrowser: CefBrowser, snapshot: DesktopRadioMapSnapshot) {
+        val script = snapshot.toLightweightJavaScript()
+        if (script == lastLightweightScript) return
+        lastLightweightScript = script
+        executeBrowserScript(currentBrowser, script)
+    }
+
+    private fun scheduleFullSnapshot(currentBrowser: CefBrowser, snapshot: DesktopRadioMapSnapshot) {
+        val generation = System.nanoTime()
+        pendingFullMarkerGeneration = generation
+        jsExecutor.execute {
+            Thread.sleep(DesktopRadioMapFullMarkerUpdateDebounceMs)
+            if (disposed || pendingFullMarkerGeneration != generation) return@execute
+            val latest = pendingSnapshot ?: snapshot
+            if (latest.markersJson == lastMarkersJson) return@execute
+            val browser = browser ?: return@execute
+            applyFullSnapshot(browser, latest)
+        }
+    }
+
+    private fun executeBrowserScript(currentBrowser: CefBrowser, script: String) {
+        if (DesktopInlineRadioMapCoordinator.shouldDeferBrowserScripts) return
+        val frameUrl = loadedUrl.orEmpty()
+        jsExecutor.execute {
+            if (disposed) return@execute
+            currentBrowser.executeJavaScript(script, frameUrl, 0)
         }
     }
 
     fun dispose() {
         disposed = true
-        cefExecutor.shutdownNow()
+        jsExecutor.shutdownNow()
         SwingUtilities.invokeLater {
+            panel.removeComponentListener(resizeListener)
             runCatching { browser?.close(true) }
             runCatching { client?.dispose() }
             browser = null
@@ -501,12 +678,16 @@ private class DesktopRadioMapChromiumHolder(
         }
     }
 
-    private fun showBrowser(component: Component) {
+    private fun showBrowser(component: Component, onAttached: () -> Unit = {}) {
         SwingUtilities.invokeLater {
             panel.removeAll()
+            component.background = DesktopRadioMapPanelBackground
             panel.add(component, BorderLayout.CENTER)
+            panel.addComponentListener(resizeListener)
             panel.revalidate()
             panel.repaint()
+            syncBrowserSize()
+            onAttached()
         }
     }
 
@@ -559,11 +740,13 @@ private object DesktopRadioMapCef {
                     println("radio-map desktop browser: jcefmaven $progress$suffix")
                 }
                 addJcefArgs(
-                    "--disable-gpu",
                     "--disable-features=FontationsFontBackend",
                 )
+                if (desktopRadioMapDisableGpu()) {
+                    addJcefArgs("--disable-gpu")
+                }
                 getCefSettings().apply {
-                        windowless_rendering_enabled = true
+                    windowless_rendering_enabled = false
                     cache_path = File(System.getProperty("user.home"), ".phoebe/jcef-maven-cache").absolutePath
                     log_file = File(System.getProperty("user.home"), ".phoebe/jcef-maven.log").absolutePath
                     log_severity = CefSettings.LogSeverity.LOGSEVERITY_WARNING

--- a/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
+++ b/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
@@ -4,6 +4,7 @@ import com.phoebe.app.data.PlexClient
 import com.phoebe.app.domain.AudioAnalysisSource
 import com.phoebe.app.domain.EqualizerProfile
 import com.phoebe.app.domain.Track
+import com.phoebe.app.platform.DesktopInlineRadioMapCoordinator
 import com.phoebe.app.platform.PhoebeLog
 import javazoom.spi.mpeg.sampled.file.MpegAudioFileReader
 import javazoom.spi.vorbis.sampled.file.VorbisAudioFileReader
@@ -253,7 +254,7 @@ class DesktopAudioPlayer(
         preferJavaFxForLocalStreaming: Boolean,
     ) {
         if (uri.isBlank()) {
-            markPlaybackFailed()
+            finishPlaybackFailed()
             return
         }
         val generation = activePlayGeneration
@@ -277,13 +278,23 @@ class DesktopAudioPlayer(
                 }
                 val isLiveStream = file == null && state.value.durationMs <= 0L && isRemoteUri(activeUri)
                 if (isLiveStream) {
+                    DesktopInlineRadioMapCoordinator.beginLiveRadioStartup()
                     if (!isPlayRequestCurrent(generation)) return@execute
                     if (tryStartFfmpegPcmStream(activeUri, generation)) {
                         return@execute
                     }
-                    diagnostics.playbackError(PlaybackEnginePath.SampledStream, "FFmpeg live streaming failed to start")
-                    markPlaybackFailed(generation = generation)
-                    return@execute
+                    if (tryLiveRadioSampledPlayback(
+                            activeUri = activeUri,
+                            preferredStreamingExtension = preferredStreamingExtension,
+                            preferredSampledExtension = preferredSampledExtension,
+                            generation = generation,
+                        )
+                    ) {
+                        return@execute
+                    }
+                    PhoebeLog.d("DesktopAudioPlayer") {
+                        "ffmpeg live stream unavailable for $activeUri; trying JavaFX and sampled fallbacks"
+                    }
                 }
                 if (file == null) {
                     val streamingExtension = preferredStreamingExtension ?: streamingSampledExtensionFromUri(activeUri)
@@ -333,7 +344,7 @@ class DesktopAudioPlayer(
                         startSampledProgressProbe(clip, generation)
                         applyVolumesFromState()
                         updateBufferedPosition(trackDurationOrClipDuration(generation, clip), generation)
-                        markPlaybackReady(generation = generation)
+                        finishPlaybackReady(generation = generation)
                         return@execute
                     }
                 }
@@ -368,7 +379,7 @@ class DesktopAudioPlayer(
                         startSampledProgressProbe(clip, generation)
                         applyVolumesFromState()
                         updateBufferedPosition(trackDurationOrClipDuration(generation, clip), generation)
-                        markPlaybackReady(generation = generation)
+                        finishPlaybackReady(generation = generation)
                         return@execute
                     }
                     disposeSampled()
@@ -401,7 +412,7 @@ class DesktopAudioPlayer(
                                 generation = generation,
                             )
                         ) {
-                            markPlaybackFailed(generation = generation)
+                            finishPlaybackFailed(generation = generation)
                         }
                     }
                     if (!javaFxScheduled &&
@@ -414,7 +425,7 @@ class DesktopAudioPlayer(
                             generation = generation,
                         )
                     ) {
-                        markPlaybackFailed(generation = generation)
+                        finishPlaybackFailed(generation = generation)
                     }
                     return@execute
                 }
@@ -428,13 +439,13 @@ class DesktopAudioPlayer(
                     )
                 ) {
                     diagnostics.playbackError(PlaybackEnginePath.JavaFxMediaPlayer, "Desktop playback failed to start")
-                    markPlaybackFailed(generation = generation)
+                    finishPlaybackFailed(generation = generation)
                 }
             }.onFailure { error ->
                 if (!isPlayRequestCurrent(generation)) return@execute
                 logPlaybackFailure(error)
                 diagnostics.playbackError(PlaybackEnginePath.JavaFxMediaPlayer, error.message)
-                markPlaybackFailed(generation = generation)
+                finishPlaybackFailed(generation = generation)
             }
         }
     }
@@ -1024,6 +1035,42 @@ class DesktopAudioPlayer(
         return true
     }
 
+    private fun finishPlaybackReady(isPlaying: Boolean = true, generation: Int = activePlayGeneration) {
+        DesktopInlineRadioMapCoordinator.endLiveRadioStartup()
+        markPlaybackReady(isPlaying = isPlaying, generation = generation)
+    }
+
+    private fun finishPlaybackFailed(generation: Int = activePlayGeneration, message: String? = null) {
+        DesktopInlineRadioMapCoordinator.endLiveRadioStartup()
+        markPlaybackFailed(generation = generation, message = message)
+    }
+
+    private fun tryLiveRadioSampledPlayback(
+        activeUri: String,
+        preferredStreamingExtension: String?,
+        preferredSampledExtension: String?,
+        generation: Int,
+    ): Boolean {
+        val extensions = linkedSetOf<String?>()
+        preferredStreamingExtension?.let { extensions.add(it) }
+        streamingSampledExtensionFromUri(activeUri)?.let { extensions.add(it) }
+        preferredSampledExtension?.let { extensions.add(it) }
+        extensions.add(null)
+        for (extension in extensions) {
+            if (extension != null &&
+                !DesktopSandboxPlayback.shouldStreamRemoteSampledPlayback(activeUri) &&
+                DesktopSandboxPlayback.streamingSampledExtensionFromSuffix(extension) == null &&
+                DesktopSandboxPlayback.sampledPlaybackExtensionFromSuffix(extension) == null
+            ) {
+                continue
+            }
+            if (tryStartSampledStream(activeUri, extension, generation)) {
+                return true
+            }
+        }
+        return false
+    }
+
     private fun continuePlaybackAfterJavaFxFailure(
         activeUri: String,
         downloadUri: String?,
@@ -1092,13 +1139,30 @@ class DesktopAudioPlayer(
         val watchdogStop = AtomicBoolean(false)
         javaFxStartupWatchdogStop = watchdogStop
         val mediaReady = AtomicBoolean(false)
+        val playingStarted = AtomicBoolean(false)
+        val playingWatchdogStop = AtomicBoolean(false)
         val startupFailed = AtomicBoolean(false)
         fun failStartup() {
             if (!startupFailed.compareAndSet(false, true)) return
             cancelJavaFxStartupWatchdog()
+            playingWatchdogStop.set(true)
             playbackExecutor.execute {
                 if (!isPlayRequestCurrent(generation)) return@execute
                 onStartupFailed()
+            }
+        }
+        fun schedulePlayingWatchdog() {
+            CompletableFuture.delayedExecutor(JavaFxMediaPlayingTimeoutMs, TimeUnit.MILLISECONDS).execute {
+                if (playingWatchdogStop.get() || playingStarted.get()) return@execute
+                if (!isPlayRequestCurrent(generation)) return@execute
+                playingWatchdogStop.set(true)
+                playbackExecutor.execute {
+                    if (playingStarted.get() || !isPlayRequestCurrent(generation)) return@execute
+                    PhoebeLog.d("DesktopAudioPlayer") {
+                        "JavaFX media ready but never started playing within ${JavaFxMediaPlayingTimeoutMs}ms"
+                    }
+                    failStartup()
+                }
             }
         }
         scheduleJavaFxStartupWatchdog(
@@ -1144,12 +1208,14 @@ class DesktopAudioPlayer(
                         failStartup()
                     }
                     mediaPlayer.setOnPlaying {
+                        playingStarted.set(true)
+                        playingWatchdogStop.set(true)
                         cancelJavaFxStartupWatchdog()
                         syncJavaFxPlayback(mediaPlayer, generation, isBuffering = false)
                         playbackExecutor.execute {
                             if (!isPlayRequestCurrent(generation)) return@execute
                             applyVolumesFromState()
-                            markPlaybackReady(generation = generation)
+                            finishPlaybackReady(generation = generation)
                         }
                     }
                     mediaPlayer.setOnStalled {
@@ -1158,6 +1224,7 @@ class DesktopAudioPlayer(
                     mediaPlayer.setOnReady {
                         mediaReady.set(true)
                         cancelJavaFxStartupWatchdog()
+                        schedulePlayingWatchdog()
                         syncJavaFxPlayback(mediaPlayer, generation, isBuffering = false)
                         mediaPlayer.bufferProgressTimeProperty().addListener { _, _, _ ->
                             syncJavaFxPlayback(mediaPlayer, generation, isBuffering = false)
@@ -1209,7 +1276,7 @@ class DesktopAudioPlayer(
         startSampledProgressProbe(clip, generation)
         applyVolumesFromState()
         updateBufferedPosition(trackDurationOrClipDuration(generation, clip), generation)
-        markPlaybackReady(generation = generation)
+        finishPlaybackReady(generation = generation)
         return true
     }
 
@@ -1251,7 +1318,7 @@ class DesktopAudioPlayer(
                 startSampledProgressProbe(clip, generation)
                 applyVolumesFromState()
                 updateBufferedPosition(trackDurationOrClipDuration(generation, clip), generation)
-                markPlaybackReady(generation = generation)
+                finishPlaybackReady(generation = generation)
                 return true
             }
             disposeSampled()
@@ -1260,7 +1327,7 @@ class DesktopAudioPlayer(
         fullyBufferedPlayback = true
         return startJavaFxPlayback(downloaded.toURI().toString(), generation) {
             if (!trySampledFallbackAfterJavaFxFailure(downloaded, generation)) {
-                markPlaybackFailed(generation = generation)
+                finishPlaybackFailed(generation = generation)
             }
         }
     }
@@ -1387,11 +1454,13 @@ class DesktopAudioPlayer(
     }
 
     private fun findFfmpegExecutable(): String? {
+        val isWindows = System.getProperty("os.name").orEmpty().lowercase().contains("windows")
+        val executableNames = if (isWindows) listOf("ffmpeg.exe", "ffmpeg") else listOf("ffmpeg")
         val pathCandidates = System.getenv("PATH")
             .orEmpty()
             .split(File.pathSeparator)
             .filter { it.isNotBlank() }
-            .map { File(it, "ffmpeg") }
+            .flatMap { directory -> executableNames.map { name -> File(directory, name) } }
         return (pathCandidates + FfmpegFallbackPaths.map(::File))
             .firstOrNull { it.isFile && it.canExecute() }
             ?.absolutePath
@@ -1676,7 +1745,7 @@ class DesktopAudioPlayer(
                 if (isPlayRequestCurrent(generation) && sampledStream === playback && !playback.stopped.get()) {
                     logPlaybackFailure(error)
                     diagnostics.playbackError(PlaybackEnginePath.SampledStream, error.message)
-                    markPlaybackFailed(generation = generation)
+                    finishPlaybackFailed(generation = generation)
                 }
             } finally {
                 if (sampledStream === playback) {
@@ -1793,9 +1862,9 @@ class DesktopAudioPlayer(
         if (linePlaying) {
             diagnostics.platformPlaying(PlaybackEnginePath.SampledStream, positionMs, durationMs)
         }
-        if (!playback.reportedOutput && linePlaying && positionMs > 0L) {
+        if (!playback.reportedOutput && linePlaying && playback.writtenPcmBytes > 0L) {
             playback.reportedOutput = true
-            markPlaybackReady(generation = generation)
+            finishPlaybackReady(generation = generation)
         }
         val isStarting = !playback.paused && !playback.reportedOutput
         val isStarved = !playback.paused && !linePlaying && playback.reportedOutput
@@ -2420,6 +2489,7 @@ class DesktopAudioPlayer(
     private companion object {
         const val JavaFxEqualizerBandMatchTolerance = 0.045f
         const val JavaFxMediaReadyTimeoutMs = 3_000L
+        const val JavaFxMediaPlayingTimeoutMs = 8_000L
         const val JavaFxCrossfadeReadyTimeoutMs = 3_000L
         const val JavaFxDisposeSettleMs = 250L
         const val PlaybackUiSyncIntervalMs = 250L

--- a/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
+++ b/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
@@ -1208,6 +1208,7 @@ class DesktopAudioPlayer(
                         failStartup()
                     }
                     mediaPlayer.setOnPlaying {
+                        if (!isPlayRequestCurrent(generation)) return@setOnPlaying
                         playingStarted.set(true)
                         playingWatchdogStop.set(true)
                         cancelJavaFxStartupWatchdog()
@@ -1222,6 +1223,7 @@ class DesktopAudioPlayer(
                         syncJavaFxPlayback(mediaPlayer, generation, isBuffering = true)
                     }
                     mediaPlayer.setOnReady {
+                        if (!isPlayRequestCurrent(generation)) return@setOnReady
                         mediaReady.set(true)
                         cancelJavaFxStartupWatchdog()
                         schedulePlayingWatchdog()


### PR DESCRIPTION
## Summary
- Stabilizes the desktop inline radio map by creating and sizing the JCEF browser on the Swing side before loading the map.
- Tunes embedded radio map presentation and clustering so desktop maps become usable sooner and focus selected clusters/stations correctly.
- Improves desktop live radio startup by coordinating map script pressure with playback startup, adding Windows ffmpeg discovery, and falling back through sampled playback paths when JavaFX/live streaming stalls.

## Validation
- ./gradlew :feature:radio:compileKotlinDesktop :playback:compileKotlinDesktop :composeApp:compileKotlinDesktop
