### PR TITLE
[codex] Improve popular mix loading

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
@@ -306,6 +306,7 @@ class AppState(
     private var recentAlbumWarmSignature: String? = null
     private var playedAlbumWarmSignature: String? = null
     private var mostPlayedWarmSignature: String? = null
+    private var popularMixWarmSignature: String? = null
     private val prefetchedArtistIds = mutableSetOf<String>()
     private val prefetchedAlbumIds = mutableSetOf<String>()
     private var catalogRefreshJob: Job? = null
@@ -1555,6 +1556,26 @@ class AppState(
         }
     }
 
+    fun warmPopularMixTracks() {
+        val currentSession = session.value
+        if (!currentSession.isPlex()) return
+        val signature = currentSession.popularMixSessionSignature() ?: return
+        if (signature == popularMixWarmSignature) return
+        popularMixWarmSignature = signature
+        scope.launch {
+            runCatching {
+                val tracks = dependencies.catalogRepository.popularTracksForLibrary(currentSession)
+                if (tracks.isEmpty()) {
+                    popularMixWarmSignature = null
+                }
+            }.onFailure { error ->
+                if (error is CancellationException) throw error
+                popularMixWarmSignature = null
+                PhoebeLog.d("AppState") { "popular mix warm failed: ${error.message}" }
+            }
+        }
+    }
+
     fun playDecadeMix(decade: Int) = scope.launch {
         mutableDecadeMixNotice.value = "Searching the ${decade}s…"
         val firstTracks = runCatching {
@@ -1590,22 +1611,46 @@ class AppState(
     }
 
     fun playPopularMix() = scope.launch {
-        val popularPool = runCatching {
-            dependencies.catalogRepository.popularTracksForLibrary(session.value)
-        }.getOrElse { error ->
-            val notice = error.message ?: "Couldn't load popular songs."
-            mutableMessage.value = notice
+        val currentSession = session.value
+        val cachedPool = dependencies.catalogRepository.cachedPopularTracksForLibrary(currentSession)
+        val signature = currentSession.popularMixSessionSignature()
+        val popularPool = cachedPool.takeIf { it.isNotEmpty() }
+            ?: if (signature == popularMixWarmSignature) {
+                emptyList()
+            } else {
+                runCatching {
+                    withTimeout(PopularMixInitialLoadTimeoutMs) {
+                        dependencies.catalogRepository.popularTracksForLibrary(currentSession)
+                    }
+                }.getOrElse { error ->
+                    if (error is CancellationException && error !is TimeoutCancellationException) throw error
+                    PhoebeLog.d("AppState") { "popular mix provider load skipped: ${error.message}" }
+                    emptyList()
+                }.also { tracks ->
+                    if (tracks.isNotEmpty()) {
+                        popularMixWarmSignature = signature
+                    }
+                }
+            }
+        if (popularPool.isEmpty()) {
+            warmPopularMixTracks()
+            mutableMessage.value = if (currentSession.isPlex()) {
+                "Popular songs are still loading."
+            } else {
+                "No popular songs found yet."
+            }
             return@launch
         }
-        val tracks = popularPool.weightedPopularMix()
-        if (tracks.isEmpty()) {
-            mutableMessage.value = "No provider top songs found."
+        val mix = popularPool.weightedPopularMix()
+        if (mix.isEmpty()) {
+            mutableMessage.value = "No popular songs found yet."
             return@launch
         }
-        if (playTracks(tracks, 0)) {
+        if (playTracks(mix, 0)) {
             requestNavigation(AppNavigationRequest.Player)
-            mutableMessage.value = "Playing ${tracks.size} popular songs."
+            mutableMessage.value = "Playing ${mix.size} popular songs."
         }
+        warmPopularMixTracks()
     }
 
     fun refreshRadioStations() = scope.launch {
@@ -2792,6 +2837,7 @@ class AppState(
         mostPlayedWarmSignature = null
         recentAlbumWarmSignature = null
         playedAlbumWarmSignature = null
+        popularMixWarmSignature = null
         prefetchedArtistIds.clear()
         prefetchedAlbumIds.clear()
         stopPlayback()
@@ -2882,6 +2928,12 @@ private fun PlexSession?.canUsePlexBackgroundFetches(): Boolean {
         server.connectionUris.isNotEmpty() ||
         server.advertisedConnectionUris.isNotEmpty() ||
         server.localConnectionUris.isNotEmpty()
+}
+
+private fun PlexSession?.popularMixSessionSignature(): String? {
+    val serverId = this?.selectedServer?.id?.takeIf { it.isNotBlank() } ?: return null
+    val libraryKey = selectedLibrary?.key?.takeIf { it.isNotBlank() } ?: return null
+    return "$serverId:$libraryKey"
 }
 
 internal fun List<Track>.withFreshPlaybackUrls(session: PlexSession?): List<Track> {
@@ -3011,6 +3063,7 @@ private data class PopularMixCandidate(
 private const val PlaybackHistoryDedupeWindowMs = 30_000L
 
 private const val PlayHistoryCatalogResolveTimeoutMs = 1_500L
+private const val PopularMixInitialLoadTimeoutMs = 2_500L
 
 private const val ProviderPlayHistoryDebounceMs = 8_000L
 

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeDesktopContracts.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeDesktopContracts.kt
@@ -7,6 +7,7 @@ import com.phoebe.app.data.PlayHistoryRankedEntries
 import com.phoebe.app.data.PlayHistorySnapshot
 import com.phoebe.app.data.rankedEntries
 import com.phoebe.app.feature.home.HomeUiState
+import com.phoebe.app.feature.home.HomePosterLoadingState
 import com.phoebe.app.feature.library.LibraryFilterTab
 import com.phoebe.app.feature.radio.RadioRouteMode
 import com.phoebe.app.feature.settings.SettingsCategory
@@ -128,6 +129,7 @@ internal data class BrowseUiState(
     val libraryFilter: LibraryFilterTab,
     val libraryUi: LibraryUiPreferences,
     val supportedCollectionEntries: Set<CollectionEntry> = defaultCollectionEntries.toSet(),
+    val homePosterLoading: HomePosterLoadingState = HomePosterLoadingState(),
     val decadeMixNotice: String? = null,
     val radioStations: List<PlexRadioStation> = emptyList(),
     val radioDirectory: RadioDirectoryState = RadioDirectoryState(),

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeDesktopPlayer.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeDesktopPlayer.kt
@@ -708,6 +708,7 @@ internal fun DesktopPlayer(
                                                 homeSections = libraryUi.homeSections,
                                                 supportedCollectionEntries = supportedCollectionEntries,
                                                 useBarePanels = appSettings.tintedBackgroundGradient,
+                                                posterLoading = browseState.homePosterLoading,
                                                 decadeMixNotice = decadeMixNotice,
                                                 radioStations = radioStations,
                                                 radioStartingIds = radioStartingIds,

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeMobile.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeMobile.kt
@@ -188,6 +188,7 @@ import com.phoebe.app.data.ListenBrainzFeedbackTarget
 import com.phoebe.app.data.catalogAlbumsForArtist
 import com.phoebe.app.data.catalogTracksForArtist
 import com.phoebe.app.feature.home.HomeUiState
+import com.phoebe.app.feature.home.HomePosterLoadingState
 import com.phoebe.app.domain.Album
 import com.phoebe.app.domain.AppSettings
 import com.phoebe.app.domain.AppScreen
@@ -282,6 +283,7 @@ internal fun MobileBrowseShell(
     onMostPlayed: () -> Unit,
     onCollections: (CollectionEntry) -> Unit,
     supportedCollectionEntries: Set<CollectionEntry> = defaultCollectionEntries.toSet(),
+    homePosterLoading: HomePosterLoadingState = HomePosterLoadingState(),
     onRefreshRandomArtists: () -> Unit,
     onRefreshRandomAlbums: () -> Unit,
     onPrefetchHomeArtist: (Artist) -> Unit = {},
@@ -657,6 +659,7 @@ internal fun MobileBrowseShell(
                         catalogRefreshing,
                         libraryUi.homeSections,
                         supportedCollectionEntries,
+                        homePosterLoading,
                         radioStations,
                         radioStartingIds,
                         decadeMixNotice,
@@ -666,6 +669,7 @@ internal fun MobileBrowseShell(
                             catalogRefreshing = catalogRefreshing,
                             homeSections = libraryUi.homeSections,
                             supportedCollectionEntries = supportedCollectionEntries,
+                            posterLoading = homePosterLoading,
                             radioStations = radioStations,
                             radioStartingIds = radioStartingIds,
                             decadeMixNotice = decadeMixNotice,

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeRoot.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeRoot.kt
@@ -195,6 +195,7 @@ import com.phoebe.app.feature.history.HistoryNowPlayingState
 import com.phoebe.app.feature.history.PlayHistoryRoute
 import com.phoebe.app.feature.history.PlayHistoryRouteState
 import com.phoebe.app.feature.home.HomeUiState
+import com.phoebe.app.feature.home.HomePosterLoadingState
 import com.phoebe.app.feature.home.RecentlyAddedNowPlayingState
 import com.phoebe.app.feature.home.RecentlyAddedRoute
 import com.phoebe.app.feature.home.RecentlyAddedRouteActions
@@ -450,6 +451,7 @@ private fun PhoebeRootStateHolder(
     var selectedPlaylistId by remember { mutableStateOf<String?>(null) }
     var replaceNextNavigationPath by remember { mutableStateOf(navigationPath != null) }
     var lastPublishedNavigationRoute by remember { mutableStateOf<PhoebeRoute?>(null) }
+    var pendingPublishedNavigationPath by remember { mutableStateOf<String?>(null) }
     var suppressNextRadioStationRouteEffect by remember { mutableStateOf(false) }
     fun ensureRadioPlaybackBackStack() {
         if (!radioPlayingFromSignIn) return
@@ -467,8 +469,34 @@ private fun PhoebeRootStateHolder(
             navigator.replaceAll(guardedRoutes)
         }
     }
-    LaunchedEffect(navigationPath, browseFallbackRoutes) {
+    val canonicalNavigationPath = remember(currentRoute, routeResolution) {
+        currentRoute.toPhoebeWebPath(routeResolution)
+    }
+    val currentOnNavigationPathChange by rememberUpdatedState(onNavigationPathChange)
+    LaunchedEffect(canonicalNavigationPath, currentRoute) {
+        val onPathChange = currentOnNavigationPathChange ?: return@LaunchedEffect
+        val routeChanged = lastPublishedNavigationRoute != null &&
+            lastPublishedNavigationRoute != currentRoute
+        val replace = replaceNextNavigationPath || !routeChanged
+        replaceNextNavigationPath = false
+        lastPublishedNavigationRoute = currentRoute
+        if (navigationPath != null && navigationPath != canonicalNavigationPath) {
+            pendingPublishedNavigationPath = canonicalNavigationPath
+        } else if (pendingPublishedNavigationPath == canonicalNavigationPath) {
+            pendingPublishedNavigationPath = null
+        }
+        onPathChange(canonicalNavigationPath, replace)
+    }
+    LaunchedEffect(navigationPath, browseFallbackRoutes, pendingPublishedNavigationPath) {
         val path = navigationPath ?: return@LaunchedEffect
+        val pendingPath = pendingPublishedNavigationPath
+        if (pendingPath != null) {
+            if (path == pendingPath) {
+                pendingPublishedNavigationPath = null
+            } else {
+                return@LaunchedEffect
+            }
+        }
         val parsedRoutes = phoebeWebRoutesForPath(path)
             .withUnavailableBrowseFallback(browseFallbackRoutes)
         if (currentTrack?.id?.startsWith("radio:") == true &&
@@ -488,19 +516,6 @@ private fun PhoebeRootStateHolder(
             currentRoute is PhoebeRoute.PlaylistDetail -> selectedPlaylistId = currentRoute.playlistId
             screen is AppScreen.PlaylistDetail -> selectedPlaylistId = screen.playlist.id
         }
-    }
-    val canonicalNavigationPath = remember(currentRoute, routeResolution) {
-        currentRoute.toPhoebeWebPath(routeResolution)
-    }
-    val currentOnNavigationPathChange by rememberUpdatedState(onNavigationPathChange)
-    LaunchedEffect(canonicalNavigationPath, currentRoute) {
-        val onPathChange = currentOnNavigationPathChange ?: return@LaunchedEffect
-        val routeChanged = lastPublishedNavigationRoute != null &&
-            lastPublishedNavigationRoute != currentRoute
-        val replace = replaceNextNavigationPath || !routeChanged
-        replaceNextNavigationPath = false
-        lastPublishedNavigationRoute = currentRoute
-        onPathChange(canonicalNavigationPath, replace)
     }
     val collapseMobilePlayer: () -> Unit = {
         if (!navigator.pop()) {
@@ -870,28 +885,50 @@ private fun PhoebeRootStateHolder(
     val pendingMobilePlaybackTrackId = pendingMobilePlaybackPreview?.currentTrack?.id
     val mobilePlaybackStarting = pendingMobilePlaybackTrackId != null &&
         pendingMobilePlaybackTrackId != currentTrack?.id
+    var homePosterLoading by remember { mutableStateOf(HomePosterLoadingState()) }
     val personalMixCatalog = rememberUpdatedState(catalog)
     val personalMixHomeUiState = rememberUpdatedState(homeUiState)
     val personalMixPreferences = rememberUpdatedState(libraryUi.personalMix)
     val personalMixPlayHistory = rememberUpdatedState(playHistory)
     var recentPersonalMixKeys by remember { mutableStateOf(emptySet<String>()) }
-    val personalMixScope = rememberCoroutineScope()
-    val playPersonalMix = remember(state, personalMixScope) {
+    val homePosterActionScope = rememberCoroutineScope()
+    val playPersonalMix = remember(state, homePosterActionScope) {
         {
-            personalMixScope.launch {
-                val preferences = personalMixPreferences.value.normalized()
-                state.ensurePersonalMixTracks(preferences.limit)
-                val tracks = personalMix(
-                    catalog = personalMixCatalog.value,
-                    state = personalMixHomeUiState.value,
-                    preferences = preferences,
-                    playHistory = personalMixPlayHistory.value,
-                    recentMixTrackKeys = recentPersonalMixKeys,
-                )
-                if (tracks.isEmpty()) return@launch
-                recentPersonalMixKeys = (recentPersonalMixKeys + tracks.map { it.personalMixIdentityKey() })
-                    .let { keys -> if (keys.size > 100) keys.drop(keys.size - 100).toSet() else keys.toSet() }
-                playTracksFromMobile(tracks, 0)
+            homePosterActionScope.launch {
+                homePosterLoading = homePosterLoading.copy(personalMix = true)
+                try {
+                    val preferences = personalMixPreferences.value.normalized()
+                    state.ensurePersonalMixTracks(preferences.limit)
+                    val tracks = personalMix(
+                        catalog = personalMixCatalog.value,
+                        state = personalMixHomeUiState.value,
+                        preferences = preferences,
+                        playHistory = personalMixPlayHistory.value,
+                        recentMixTrackKeys = recentPersonalMixKeys,
+                    )
+                    if (tracks.isNotEmpty()) {
+                        recentPersonalMixKeys = (recentPersonalMixKeys + tracks.map { it.personalMixIdentityKey() })
+                            .let { keys -> if (keys.size > 100) keys.drop(keys.size - 100).toSet() else keys.toSet() }
+                        playTracksFromMobile(tracks, 0)
+                    }
+                } finally {
+                    delay(700L)
+                    homePosterLoading = homePosterLoading.copy(personalMix = false)
+                }
+            }
+            Unit
+        }
+    }
+    val playPopularMix = remember(state, homePosterActionScope) {
+        {
+            homePosterActionScope.launch {
+                homePosterLoading = homePosterLoading.copy(popularMix = true)
+                try {
+                    state.playPopularMix().join()
+                } finally {
+                    delay(700L)
+                    homePosterLoading = homePosterLoading.copy(popularMix = false)
+                }
             }
             Unit
         }
@@ -901,6 +938,12 @@ private fun PhoebeRootStateHolder(
         if (screen == AppScreen.Home && browseSection == BrowseSection.Home) {
             delay(1_500L)
             state.warmRecentAlbumTracks(cutoffMs = nowMs - RecentlyAddedWindowMs, maxAlbums = 10)
+        }
+    }
+    LaunchedEffect(screen, browseSection, session?.selectedServer?.id, session?.selectedLibrary?.key) {
+        if (screen == AppScreen.Home && browseSection == BrowseSection.Home) {
+            delay(1_200L)
+            state.warmPopularMixTracks()
         }
     }
     LaunchedEffect(screen, browseSection, topMostPlayed, topRecentlyPlayed, session?.selectedServer) {
@@ -969,6 +1012,13 @@ private fun PhoebeRootStateHolder(
     }
     val openCollections: (CollectionEntry) -> Unit = { entry ->
         if (session.supportsCollectionEntry(entry)) {
+            homePosterLoading = homePosterLoading.copy(collectionEntry = entry)
+            homePosterActionScope.launch {
+                delay(700L)
+                if (homePosterLoading.collectionEntry == entry) {
+                    homePosterLoading = homePosterLoading.copy(collectionEntry = null)
+                }
+            }
             selectedPlaylistId = null
             navigator.openBrowse(BrowseSection.Home)
             libraryFilter = when (entry.target) {
@@ -1617,6 +1667,7 @@ private fun PhoebeRootStateHolder(
                         onMostPlayed = openMostPlayed,
                         onCollections = openCollections,
                         supportedCollectionEntries = supportedCollectionEntries,
+                        homePosterLoading = homePosterLoading,
                         onRefreshRandomArtists = homeFeatureState.onRefreshRandomArtists,
                         onRefreshRandomAlbums = homeFeatureState.onRefreshRandomAlbums,
                         onPrefetchHomeArtist = state::prefetchHomeArtistStats,
@@ -1647,7 +1698,7 @@ private fun PhoebeRootStateHolder(
                         onUpdateManualRadioStation = state::updateManualRadioStation,
                         onDeleteManualRadioStation = state::deleteManualRadioStation,
                         onPlayPersonalMix = playPersonalMix,
-                        onPlayPopularMix = state::playPopularMix,
+                        onPlayPopularMix = playPopularMix,
                         onPlayTracks = playTracksFromMobile,
                         onAddToUpNext = state::addToUpNext,
                         onDownload = state::download,
@@ -1981,6 +2032,7 @@ private fun PhoebeRootStateHolder(
                         libraryFilter = libraryFilter,
                         libraryUi = libraryUi,
                         supportedCollectionEntries = supportedCollectionEntries,
+                        homePosterLoading = homePosterLoading,
                         decadeMixNotice = decadeMixNotice,
                         radioStations = radioStations,
                         radioDirectory = radioDirectory,
@@ -2070,7 +2122,7 @@ private fun PhoebeRootStateHolder(
                         onRadioUpdateManualStation = state::updateManualRadioStation,
                         onRadioDeleteManualStation = state::deleteManualRadioStation,
                         onPlayPersonalMix = playPersonalMix,
-                        onPlayPopularMix = state::playPopularMix,
+                        onPlayPopularMix = playPopularMix,
                         onPopDetail = { navigator.pop() },
                         onPlayTracks = playTracks,
                         onPlayAllTracks = playAllTracks,

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeRoot.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeRoot.kt
@@ -487,15 +487,14 @@ private fun PhoebeRootStateHolder(
         }
         onPathChange(canonicalNavigationPath, replace)
     }
-    LaunchedEffect(navigationPath, browseFallbackRoutes, pendingPublishedNavigationPath) {
+    LaunchedEffect(navigationPath, browseFallbackRoutes) {
         val path = navigationPath ?: return@LaunchedEffect
         val pendingPath = pendingPublishedNavigationPath
         if (pendingPath != null) {
             if (path == pendingPath) {
                 pendingPublishedNavigationPath = null
-            } else {
-                return@LaunchedEffect
             }
+            return@LaunchedEffect
         }
         val parsedRoutes = phoebeWebRoutesForPath(path)
             .withUnavailableBrowseFallback(browseFallbackRoutes)
@@ -896,6 +895,7 @@ private fun PhoebeRootStateHolder(
         {
             homePosterActionScope.launch {
                 homePosterLoading = homePosterLoading.copy(personalMix = true)
+                val loadingStartedAtMs = currentTimeMs()
                 try {
                     val preferences = personalMixPreferences.value.normalized()
                     state.ensurePersonalMixTracks(preferences.limit)
@@ -912,7 +912,10 @@ private fun PhoebeRootStateHolder(
                         playTracksFromMobile(tracks, 0)
                     }
                 } finally {
-                    delay(700L)
+                    val remainingLoadingMs = HomePosterLoadingMinDurationMs - (currentTimeMs() - loadingStartedAtMs)
+                    if (remainingLoadingMs > 0L) {
+                        delay(remainingLoadingMs)
+                    }
                     homePosterLoading = homePosterLoading.copy(personalMix = false)
                 }
             }
@@ -923,10 +926,14 @@ private fun PhoebeRootStateHolder(
         {
             homePosterActionScope.launch {
                 homePosterLoading = homePosterLoading.copy(popularMix = true)
+                val loadingStartedAtMs = currentTimeMs()
                 try {
                     state.playPopularMix().join()
                 } finally {
-                    delay(700L)
+                    val remainingLoadingMs = HomePosterLoadingMinDurationMs - (currentTimeMs() - loadingStartedAtMs)
+                    if (remainingLoadingMs > 0L) {
+                        delay(remainingLoadingMs)
+                    }
                     homePosterLoading = homePosterLoading.copy(popularMix = false)
                 }
             }
@@ -2674,6 +2681,8 @@ private fun MobilePlayerHost(
         modifier = modifier,
     )
 }
+
+private const val HomePosterLoadingMinDurationMs = 700L
 
 private fun Track?.withRadioNowPlaying(metadata: RadioNowPlayingMetadata?): Track? {
     val track = this ?: return null

--- a/composeApp/src/desktopTest/kotlin/com/phoebe/app/DatabaseWiperDesktopTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/phoebe/app/DatabaseWiperDesktopTest.kt
@@ -86,6 +86,7 @@ class DatabaseWiperDesktopTest {
                     parentAlbumId = "album",
                 )
                 database.catalogQueries.upsertTrackParent("album", "track", 0L, null)
+                database.catalogQueries.upsertLibraryPopularTrack("plex:server:library", "track", 0L, 1L)
                 database.catalogQueries.upsertCollectionValue("Albums", "Genre", "Rock", "genre=1", null, null, 1L)
                 database.catalogQueries.upsertCollectionTag("Albums", "Genre", "album", "Rock")
                 database.catalogQueries.upsertCollectionValueLoad("Albums", "Genre")
@@ -124,6 +125,7 @@ class DatabaseWiperDesktopTest {
             assertTrue(database.catalogQueries.selectPlaylists().awaitAsList().isEmpty())
             assertTrue(database.catalogQueries.selectAllTracks().awaitAsList().isEmpty())
             assertTrue(database.catalogQueries.selectTrackParents().awaitAsList().isEmpty())
+            assertTrue(database.catalogQueries.selectLibraryPopularTracks().awaitAsList().isEmpty())
             assertTrue(database.catalogQueries.selectCollectionValues().awaitAsList().isEmpty())
             assertTrue(database.catalogQueries.selectCollectionTags().awaitAsList().isEmpty())
             assertTrue(database.catalogQueries.selectCollectionValueLoads().awaitAsList().isEmpty())

--- a/data/catalog/src/commonMain/kotlin/com/phoebe/app/data/CatalogRepository.kt
+++ b/data/catalog/src/commonMain/kotlin/com/phoebe/app/data/CatalogRepository.kt
@@ -579,6 +579,7 @@ class CatalogRepository(
                     mutableCatalog.value = withSmartPlaylists(
                         restoredShell.copy(
                             tracksByParent = restoredTracks?.tracksByParent.orEmpty(),
+                            popularTracksByLibrary = restoredTracks?.popularTracksByLibrary.orEmpty(),
                             downloads = restoredDownloads,
                         ),
                     )
@@ -2930,6 +2931,7 @@ class CatalogRepository(
             mutableCatalog.value = withSmartPlaylists(
                 cur.copy(
                     tracksByParent = tracks.tracksByParent,
+                    popularTracksByLibrary = tracks.popularTracksByLibrary,
                     downloads = restoredDownloads,
                 ),
             )
@@ -2964,6 +2966,7 @@ class CatalogRepository(
             mutableCatalog.value = withSmartPlaylists(
                 cur.copy(
                     tracksByParent = mergedTracksByParent,
+                    popularTracksByLibrary = cur.popularTracksByLibrary + tracks.popularTracksByLibrary,
                     downloads = restoredDownloads,
                 ),
             )
@@ -3586,11 +3589,24 @@ class CatalogRepository(
         return tracks
     }
 
+    suspend fun cachedPopularTracksForLibrary(session: PlexSession?): List<Track> {
+        val libraryKey = session.libraryPopularTrackCacheKey() ?: return emptyList()
+        mutableCatalog.value.popularTracksByLibrary[libraryKey]
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { return it }
+        val tracks = readPopularTracksForLibraryFromDatabase(libraryKey)
+        if (tracks.isNotEmpty()) {
+            publishLibraryPopularTracks(libraryKey, tracks)
+        }
+        return tracks
+    }
+
     suspend fun popularTracksForLibrary(session: PlexSession?, limit: Int = LibraryPopularTrackLimit): List<Track> {
         val plexSession = session?.takeIf { it.isPlex() } ?: return emptyList()
         val server = plexSession.selectedServer ?: return emptyList()
         val library = plexSession.selectedLibrary ?: return emptyList()
         val token = plexSession.serverAuthToken() ?: return emptyList()
+        val libraryKey = plexSession.libraryPopularTrackCacheKey() ?: return emptyList()
         val tracks = plexClient.popularTracksForLibrary(
             server = server,
             library = library,
@@ -3599,9 +3615,27 @@ class CatalogRepository(
         ).map { it.withPlexPrefix() }
         if (tracks.isNotEmpty()) {
             publishIndexedPlexTracks(tracks)
-            runCatalogDbWrite { persistTrackBatch(tracks) }
+        }
+        publishLibraryPopularTracks(libraryKey, tracks)
+        runCatalogDbWrite {
+            if (tracks.isNotEmpty()) {
+                persistTrackBatch(tracks)
+            }
+            persistLibraryPopularTracks(libraryKey, tracks)
         }
         return tracks
+    }
+
+    private suspend fun publishLibraryPopularTracks(libraryKey: String, tracks: List<Track>) {
+        catalogMergeMutex.withLock {
+            val cur = mutableCatalog.value
+            val popularTracksByLibrary = if (tracks.isEmpty()) {
+                cur.popularTracksByLibrary - libraryKey
+            } else {
+                cur.popularTracksByLibrary + (libraryKey to tracks.distinctBy { it.id })
+            }
+            mutableCatalog.value = cur.copy(popularTracksByLibrary = popularTracksByLibrary)
+        }
     }
 
     suspend fun ensureSimilarArtistsForArtist(session: PlexSession?, artist: Artist): List<Artist> {
@@ -7147,6 +7181,13 @@ class CatalogRepository(
         rows.map { row -> row.toTrack() }
     }
 
+    private suspend fun readPopularTracksForLibraryFromDatabase(libraryKey: String): List<Track> =
+        withContext(Dispatchers.Default) {
+            database.catalogQueries.selectPopularTracksForLibrary(libraryKey)
+                .awaitAsList()
+                .map { row -> row.toTrack() }
+        }
+
     private fun TrackRow.toTrack(): Track =
         Track(
             id = id,
@@ -7188,6 +7229,9 @@ class CatalogRepository(
                     if (mutableCatalog.value.tracksByParent[albumId].isNullOrEmpty()) {
                         snapshot.albums.find { it.id == albumId }?.let { album ->
                             runCatching { tracksForAlbum(session, album) }
+                                .onFailure { error ->
+                                    if (error is CancellationException) throw error
+                                }
                         }
                     }
                 }
@@ -7197,7 +7241,15 @@ class CatalogRepository(
                 if (playlists.isNotEmpty()) {
                     warmPlaylistTracksParallel(session, playlists, updateSyncProgress = false)
                 }
+                runCatching { popularTracksForLibrary(session) }
+                    .onFailure { error ->
+                        if (error is CancellationException) throw error
+                        PhoebeLog.d("CatalogRepository") {
+                            "background popular tracks warm failed: ${error.message}"
+                        }
+                    }
             }.onFailure { error ->
+                if (error is CancellationException) throw error
                 PhoebeLog.d("CatalogRepository") {
                     "background warm failed: ${error.message}"
                 }
@@ -7356,6 +7408,21 @@ class CatalogRepository(
                         playlistItemId = mergedTrack?.playlistItemId,
                     )
                 }
+            }
+        }
+    }
+
+    private suspend fun persistLibraryPopularTracks(libraryKey: String, tracks: List<Track>) {
+        val nowMs = currentTimeMs()
+        database.transaction {
+            database.catalogQueries.deleteLibraryPopularTracksForLibrary(libraryKey)
+            tracks.distinctBy { it.id }.forEachIndexed { index, track ->
+                database.catalogQueries.upsertLibraryPopularTrack(
+                    libraryKey = libraryKey,
+                    trackId = track.id,
+                    position = index.toLong(),
+                    updatedAtMs = nowMs,
+                )
             }
         }
     }
@@ -7914,6 +7981,7 @@ class CatalogRepository(
         val tracks = readTracksFromDatabase()
         return shell.copy(
             tracksByParent = tracks.tracksByParent,
+            popularTracksByLibrary = tracks.popularTracksByLibrary,
             downloads = tracks.downloads,
         )
     }
@@ -8037,9 +8105,17 @@ class CatalogRepository(
                         tracksById[entry.trackId]?.copy(playlistItemId = entry.playlistItemId)
                     }
             }
+        val popularTracksByLibrary: Map<String, List<Track>> = database.catalogQueries.selectLibraryPopularTracks()
+            .awaitAsList()
+            .groupBy { it.libraryKey }
+            .mapValues { (_, entries) ->
+                entries.sortedBy { it.position }
+                    .mapNotNull { entry -> tracksById[entry.trackId] }
+            }
         val downloads = database.downloadsQueries.selectAll().awaitAsList().map { row -> row.toDownloadItem() }
         return CatalogSnapshot(
             tracksByParent = tracksByParent,
+            popularTracksByLibrary = popularTracksByLibrary,
             downloads = downloads,
         )
     }
@@ -8112,6 +8188,12 @@ class CatalogRepository(
      */
     private fun Track.withPlexPrefix(): Track =
         if (id.startsWith("plex:")) this else copy(id = "plex:$id")
+
+    private fun PlexSession?.libraryPopularTrackCacheKey(): String? {
+        val serverId = this?.selectedServer?.id?.takeIf { it.isNotBlank() } ?: return null
+        val libraryKey = selectedLibrary?.key?.takeIf { it.isNotBlank() } ?: return null
+        return "plex:$serverId:$libraryKey"
+    }
 
     private fun publishRadioTracksInBackground(tracks: List<Track>) {
         if (tracks.isEmpty()) return
@@ -8346,6 +8428,8 @@ private fun CatalogSnapshot.withoutProviderShell(prefix: String): CatalogSnapsho
         artists = artists.filterNot { it.id.startsWith(providerPrefix) },
         albums = albums.filterNot { it.id.startsWith(providerPrefix) },
         playlists = playlists.filterNot { it.id.startsWith(providerPrefix) },
+        popularTracksByArtist = popularTracksByArtist.filterKeys { !it.startsWith(providerPrefix) },
+        popularTracksByLibrary = popularTracksByLibrary.filterKeys { !it.startsWith(providerPrefix) },
         collectionTags = collectionTags.filterNot { it.itemId.startsWith(providerPrefix) },
     )
 }

--- a/data/catalog/src/commonMain/kotlin/com/phoebe/app/sources/CatalogMerge.kt
+++ b/data/catalog/src/commonMain/kotlin/com/phoebe/app/sources/CatalogMerge.kt
@@ -33,6 +33,16 @@ object CatalogMerge {
                         )
                     }
                 },
+            popularTracksByLibrary = snapshot.popularTracksByLibrary
+                .mapKeys { (k, _) -> k.withPrefix(p) }
+                .mapValues { (_, tracks) ->
+                    tracks.map { t ->
+                        t.copy(
+                            id = t.id.withPrefix(p),
+                            parentAlbumId = t.parentAlbumId?.let { if (it.startsWith(p)) it else p + it },
+                        )
+                    }
+                },
             similarArtistsByArtist = snapshot.similarArtistsByArtist
                 .mapKeys { (k, _) -> k.withPrefix(p) }
                 .mapValues { (_, artists) -> artists.map { artist -> artist.copy(id = artist.id.withPrefix(p)) } },
@@ -56,6 +66,7 @@ object CatalogMerge {
             playlists = all.flatMap { it.playlists }.distinctBy { it.id },
             tracksByParent = all.fold(emptyMap()) { acc, s -> acc + s.tracksByParent },
             popularTracksByArtist = all.fold(emptyMap()) { acc, s -> acc + s.popularTracksByArtist },
+            popularTracksByLibrary = all.fold(emptyMap()) { acc, s -> acc + s.popularTracksByLibrary },
             similarArtistsByArtist = all.fold(emptyMap()) { acc, s -> acc + s.similarArtistsByArtist },
             collectionValues = all.flatMap { it.collectionValues }.distinct(),
             collectionValueLoads = all.flatMap { it.collectionValueLoads }.distinct(),

--- a/data/database/src/commonMain/kotlin/com/phoebe/app/data/db/DatabaseWiper.kt
+++ b/data/database/src/commonMain/kotlin/com/phoebe/app/data/db/DatabaseWiper.kt
@@ -21,6 +21,7 @@ suspend fun PhoebeDatabase.clearAllAppData(clearPlayHistory: Boolean = true) = w
         userArtifactsQueries.clearSavedSearches()
         userArtifactsQueries.clearLocalMetadataOverrides()
 
+        catalogQueries.clearLibraryPopularTracks()
         catalogQueries.clearTrackParents()
         catalogQueries.clearTracks()
         catalogQueries.clearCollectionTags()

--- a/data/database/src/commonMain/sqldelight/com/phoebe/app/db/Catalog.sq
+++ b/data/database/src/commonMain/sqldelight/com/phoebe/app/db/Catalog.sq
@@ -99,6 +99,16 @@ CREATE TABLE TrackParentRow (
 
 CREATE INDEX TrackParentRow_parent_position ON TrackParentRow(parentId, position);
 
+CREATE TABLE LibraryPopularTrackRow (
+    libraryKey TEXT NOT NULL,
+    trackId TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    updatedAtMs INTEGER NOT NULL,
+    PRIMARY KEY (libraryKey, position)
+);
+
+CREATE INDEX LibraryPopularTrackRow_library_position ON LibraryPopularTrackRow(libraryKey, position);
+
 CREATE TABLE CollectionTagRow (
     target TEXT NOT NULL,
     facet TEXT NOT NULL,
@@ -189,6 +199,16 @@ SELECT id, dateAddedMs FROM TrackRow WHERE id IN :ids;
 selectTrackParents:
 SELECT parentId, trackId, position, playlistItemId FROM TrackParentRow ORDER BY parentId, position;
 
+selectLibraryPopularTracks:
+SELECT * FROM LibraryPopularTrackRow ORDER BY libraryKey, position;
+
+selectPopularTracksForLibrary:
+SELECT t.*
+FROM TrackRow t
+INNER JOIN LibraryPopularTrackRow p ON p.trackId = t.id
+WHERE p.libraryKey = ?
+ORDER BY p.position;
+
 selectCollectionTags:
 SELECT * FROM CollectionTagRow;
 
@@ -259,6 +279,9 @@ INSERT OR REPLACE INTO TrackRow(
 upsertTrackParent:
 INSERT OR REPLACE INTO TrackParentRow(parentId, trackId, position, playlistItemId) VALUES (?, ?, ?, ?);
 
+upsertLibraryPopularTrack:
+INSERT OR REPLACE INTO LibraryPopularTrackRow(libraryKey, trackId, position, updatedAtMs) VALUES (?, ?, ?, ?);
+
 upsertCollectionTag:
 INSERT OR REPLACE INTO CollectionTagRow(target, facet, itemId, value) VALUES (?, ?, ?, ?);
 
@@ -270,6 +293,12 @@ INSERT OR REPLACE INTO CollectionValueLoadRow(target, facet) VALUES (?, ?);
 
 deleteTrackParents:
 DELETE FROM TrackParentRow WHERE parentId = ?;
+
+deleteLibraryPopularTracksForLibrary:
+DELETE FROM LibraryPopularTrackRow WHERE libraryKey = ?;
+
+clearLibraryPopularTracks:
+DELETE FROM LibraryPopularTrackRow;
 
 clearCollectionTags:
 DELETE FROM CollectionTagRow;

--- a/data/database/src/commonMain/sqldelight/migrations/34.sqm
+++ b/data/database/src/commonMain/sqldelight/migrations/34.sqm
@@ -1,0 +1,9 @@
+CREATE TABLE LibraryPopularTrackRow (
+    libraryKey TEXT NOT NULL,
+    trackId TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    updatedAtMs INTEGER NOT NULL,
+    PRIMARY KEY (libraryKey, position)
+);
+
+CREATE INDEX LibraryPopularTrackRow_library_position ON LibraryPopularTrackRow(libraryKey, position);

--- a/domain/src/commonMain/kotlin/com/phoebe/app/domain/Models.kt
+++ b/domain/src/commonMain/kotlin/com/phoebe/app/domain/Models.kt
@@ -1521,6 +1521,7 @@ data class CatalogSnapshot(
     val playlists: List<Playlist> = emptyList(),
     val tracksByParent: Map<String, List<Track>> = emptyMap(),
     val popularTracksByArtist: Map<String, List<Track>> = emptyMap(),
+    val popularTracksByLibrary: Map<String, List<Track>> = emptyMap(),
     val similarArtistsByArtist: Map<String, List<Artist>> = emptyMap(),
     val collectionValues: List<CatalogCollectionValue> = emptyList(),
     val collectionValueLoads: List<CatalogCollectionValueLoad> = emptyList(),

--- a/feature/home/src/commonMain/kotlin/com/phoebe/app/feature/home/HomeRoutes.kt
+++ b/feature/home/src/commonMain/kotlin/com/phoebe/app/feature/home/HomeRoutes.kt
@@ -23,9 +23,17 @@ data class DesktopHomeRouteState(
     val homeSections: List<HomeSection>,
     val supportedCollectionEntries: Set<CollectionEntry>,
     val useBarePanels: Boolean = false,
+    val posterLoading: HomePosterLoadingState = HomePosterLoadingState(),
     val decadeMixNotice: String? = null,
     val radioStations: List<PlexRadioStation> = emptyList(),
     val radioStartingIds: Set<String> = emptySet(),
+)
+
+@Immutable
+data class HomePosterLoadingState(
+    val personalMix: Boolean = false,
+    val popularMix: Boolean = false,
+    val collectionEntry: CollectionEntry? = null,
 )
 
 data class DesktopHomeRouteActions(
@@ -91,6 +99,7 @@ fun DesktopHomeRoute(
         radioStations = state.radioStations,
         radioStartingIds = state.radioStartingIds,
         onPlayRadioStation = actions.onPlayRadioStation,
+        posterLoading = state.posterLoading,
         onPlayPersonalMix = actions.onPlayPersonalMix,
         onPlayPopularMix = actions.onPlayPopularMix,
         onPlayTracks = actions.onPlayTracks,

--- a/feature/home/src/commonMain/kotlin/com/phoebe/app/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/phoebe/app/feature/home/HomeScreen.kt
@@ -143,6 +143,7 @@ data class MobileHomeRouteState(
     val catalogRefreshing: Boolean,
     val homeSections: List<HomeSection>,
     val supportedCollectionEntries: Set<CollectionEntry>,
+    val posterLoading: HomePosterLoadingState = HomePosterLoadingState(),
     val radioStations: List<PlexRadioStation>,
     val radioStartingIds: Set<String>,
     val decadeMixNotice: String?,
@@ -209,6 +210,7 @@ fun MobileHomeRoute(
         radioStations = routeState.radioStations,
         radioStartingIds = routeState.radioStartingIds,
         onPlayRadioStation = callbacks.onPlayRadioStation,
+        posterLoading = routeState.posterLoading,
         onPlayPersonalMix = callbacks.onPlayPersonalMix,
         onPlayPopularMix = callbacks.onPlayPopularMix,
         onPlayTracks = callbacks.onPlayTracks,
@@ -264,6 +266,7 @@ fun DesktopHomeScreen(
     radioStations: List<PlexRadioStation> = emptyList(),
     radioStartingIds: Set<String> = emptySet(),
     onPlayRadioStation: (PlexRadioStation) -> Unit = {},
+    posterLoading: HomePosterLoadingState = HomePosterLoadingState(),
     onPlayPersonalMix: () -> Unit = {},
     onPlayPopularMix: () -> Unit = {},
     onPlayTracks: (List<Track>, Int) -> Unit,
@@ -319,14 +322,14 @@ fun DesktopHomeScreen(
         normalizedHomeSections(homeSections).forEach { section ->
             when (section) {
                 HomeSection.Mixes -> item("mixes") {
-                    DesktopMixesPanel(onPlayPersonalMix, onPlayPopularMix, radioStations, radioStartingIds, onPlayRadioStation, onClearDecadeMixNotice, panelStyle = panelStyle) {
+                    DesktopMixesPanel(onPlayPersonalMix, onPlayPopularMix, posterLoading, radioStations, radioStartingIds, onPlayRadioStation, onClearDecadeMixNotice, panelStyle = panelStyle) {
                         showDecadeMix = true
                     }
                 }
                 HomeSection.Collections -> item("collections") {
                     HomePanel(Modifier.fillMaxWidth(), style = panelStyle) {
                         HomeSectionLabel("COLLECTIONS")
-                        DesktopCollectionsGrid(supportedCollectionEntries, onCollections)
+                        DesktopCollectionsGrid(supportedCollectionEntries, posterLoading.collectionEntry, onCollections)
                     }
                 }
                 HomeSection.Favorites -> {
@@ -400,6 +403,7 @@ fun MobileHomeScreen(
     radioStations: List<PlexRadioStation> = emptyList(),
     radioStartingIds: Set<String> = emptySet(),
     onPlayRadioStation: (PlexRadioStation) -> Unit = {},
+    posterLoading: HomePosterLoadingState = HomePosterLoadingState(),
     onPlayPersonalMix: () -> Unit = {},
     onPlayPopularMix: () -> Unit = {},
     onPlayTracks: (List<Track>, Int) -> Unit,
@@ -463,6 +467,7 @@ fun MobileHomeScreen(
                 onMostPlayed = onMostPlayed,
                 onRefreshArtists = onRefreshArtists,
                 onRefreshAlbums = onRefreshAlbums,
+                posterLoading = posterLoading,
                 onPlayPersonalMix = onPlayPersonalMix,
                 onPlayPopularMix = onPlayPopularMix,
                 radioStations = radioStations,
@@ -505,6 +510,7 @@ fun MobileHomeScreen(
                 onMostPlayed = onMostPlayed,
                 onRefreshArtists = onRefreshArtists,
                 onRefreshAlbums = onRefreshAlbums,
+                posterLoading = posterLoading,
                 onPlayPersonalMix = onPlayPersonalMix,
                 onPlayPopularMix = onPlayPopularMix,
                 radioStations = radioStations,
@@ -713,6 +719,7 @@ private fun MobileHomeContent(
     onMostPlayed: () -> Unit,
     onRefreshArtists: () -> Unit,
     onRefreshAlbums: () -> Unit,
+    posterLoading: HomePosterLoadingState,
     onPlayPersonalMix: () -> Unit,
     onPlayPopularMix: () -> Unit,
     radioStations: List<PlexRadioStation>,
@@ -798,6 +805,7 @@ private fun MobileHomeContent(
                                 },
                                 onPlayPersonalMix = onPlayPersonalMix,
                                 onPlayPopularMix = onPlayPopularMix,
+                                posterLoading = posterLoading,
                                 radioStations = radioStations,
                                 radioStartingIds = radioStartingIds,
                                 onPlayRadioStation = onPlayRadioStation,
@@ -805,7 +813,7 @@ private fun MobileHomeContent(
                                 onShowDecadeMix = onShowDecadeMix,
                             )
                         } else {
-                            MobileMixesSection(onPlayPersonalMix, onPlayPopularMix, radioStations, radioStartingIds, onPlayRadioStation, onClearDecadeMixNotice, onShowDecadeMix)
+                            MobileMixesSection(onPlayPersonalMix, onPlayPopularMix, posterLoading, radioStations, radioStartingIds, onPlayRadioStation, onClearDecadeMixNotice, onShowDecadeMix)
                         }
                     }
                     HomeSection.Collections -> item(key = "collections", contentType = "collections-section") {
@@ -818,10 +826,11 @@ private fun MobileHomeContent(
                                     toggledPhoneHomeAccordion(expandedPhoneSection, PhoneHomeAccordionSection.Collections),
                                 )
                             },
+                            loadingCollectionEntry = posterLoading.collectionEntry,
                             onCollections = onCollections,
                         )
                     } else {
-                        MobileCollectionsSection(collectionRows, onCollections)
+                        MobileCollectionsSection(collectionRows, posterLoading.collectionEntry, onCollections)
                     }
                 }
                 HomeSection.Favorites -> {
@@ -929,6 +938,7 @@ private fun MobileExpandedHomeContent(
     onMostPlayed: () -> Unit,
     onRefreshArtists: () -> Unit,
     onRefreshAlbums: () -> Unit,
+    posterLoading: HomePosterLoadingState,
     onPlayPersonalMix: () -> Unit,
     onPlayPopularMix: () -> Unit,
     radioStations: List<PlexRadioStation>,
@@ -1028,6 +1038,7 @@ private fun MobileExpandedHomeContent(
                         ExpandedMixesShelf(
                             onPlayPersonalMix = onPlayPersonalMix,
                             onPlayPopularMix = onPlayPopularMix,
+                            posterLoading = posterLoading,
                             radioStations = radioStations,
                             radioStartingIds = radioStartingIds,
                             onPlayRadioStation = onPlayRadioStation,
@@ -1036,7 +1047,7 @@ private fun MobileExpandedHomeContent(
                         )
                     }
                     HomeSection.Collections -> item(key = "expanded-collections", contentType = "expanded-collections") {
-                        ExpandedCollectionsShelf(collectionEntries, onCollections)
+                        ExpandedCollectionsShelf(collectionEntries, posterLoading.collectionEntry, onCollections)
                     }
                     HomeSection.Played -> item(key = "expanded-played", contentType = "expanded-played") {
                         ExpandedPlayedTables(
@@ -1092,6 +1103,7 @@ private fun ExpandedHomeShelf(
 private fun ExpandedMixesShelf(
     onPlayPersonalMix: () -> Unit,
     onPlayPopularMix: () -> Unit,
+    posterLoading: HomePosterLoadingState,
     radioStations: List<PlexRadioStation>,
     radioStartingIds: Set<String>,
     onPlayRadioStation: (PlexRadioStation) -> Unit,
@@ -1100,10 +1112,24 @@ private fun ExpandedMixesShelf(
 ) {
     ExpandedHomeShelf("CREATE A MIX", horizontalSpacing = 9.dp) {
         item(key = "personal-mix", contentType = "expanded-mix-action") {
-            HomeMixPosterCard("Personal Mix", PhoebeIcon.Person, Res.drawable.mix_personal, Modifier.width(MobileHomePosterCardSize), onClick = onPlayPersonalMix)
+            HomeMixPosterCard(
+                "Personal Mix",
+                PhoebeIcon.Person,
+                Res.drawable.mix_personal,
+                Modifier.width(MobileHomePosterCardSize),
+                loading = posterLoading.personalMix,
+                onClick = onPlayPersonalMix,
+            )
         }
         item(key = "popular-mix", contentType = "expanded-mix-action") {
-            HomeMixPosterCard("popular", PhoebeIcon.PlaylistPlay, Res.drawable.mix_popular, Modifier.width(MobileHomePosterCardSize), onClick = onPlayPopularMix)
+            HomeMixPosterCard(
+                "popular",
+                PhoebeIcon.PlaylistPlay,
+                Res.drawable.mix_popular,
+                Modifier.width(MobileHomePosterCardSize),
+                loading = posterLoading.popularMix,
+                onClick = onPlayPopularMix,
+            )
         }
         item(key = "decade-mix", contentType = "expanded-mix-action") {
             HomeMixPosterCard("Decade Mix", PhoebeIcon.Calendar, Res.drawable.mix_decade, Modifier.width(MobileHomePosterCardSize)) {
@@ -1143,6 +1169,7 @@ private fun ExpandedMixesShelf(
 @Composable
 private fun ExpandedCollectionsShelf(
     collectionEntries: List<HomeCollectionEntry>,
+    loadingCollectionEntry: CollectionEntry?,
     onCollections: (CollectionEntry) -> Unit,
 ) {
     if (collectionEntries.isEmpty()) {
@@ -1156,6 +1183,8 @@ private fun ExpandedCollectionsShelf(
                     icon = entry.icon,
                     artwork = entry.artwork,
                     modifier = Modifier.width(MobileHomePosterCardSize),
+                    enabled = entry.collectionEntry != loadingCollectionEntry,
+                    loading = entry.collectionEntry == loadingCollectionEntry,
                     titleFormatter = ::collectionPosterTitle,
                 ) {
                     onCollections(entry.collectionEntry)
@@ -1593,6 +1622,7 @@ private data class PhoneHomePosterAction(
     val icon: PhoebeIcon,
     val artwork: DrawableResource?,
     val enabled: Boolean = true,
+    val loading: Boolean = false,
     val titleFormatter: (String) -> String = ::mixPosterTitle,
     val onClick: () -> Unit,
 )
@@ -1603,6 +1633,7 @@ private fun PhoneMixesAccordionSection(
     onToggle: () -> Unit,
     onPlayPersonalMix: () -> Unit,
     onPlayPopularMix: () -> Unit,
+    posterLoading: HomePosterLoadingState,
     radioStations: List<PlexRadioStation>,
     radioStartingIds: Set<String>,
     onPlayRadioStation: (PlexRadioStation) -> Unit,
@@ -1610,8 +1641,22 @@ private fun PhoneMixesAccordionSection(
     onShowDecadeMix: () -> Unit,
 ) {
     val actions = listOf(
-        PhoneHomePosterAction("Personal Mix", PhoebeIcon.Person, Res.drawable.mix_personal, onClick = onPlayPersonalMix),
-        PhoneHomePosterAction("popular", PhoebeIcon.PlaylistPlay, Res.drawable.mix_popular, onClick = onPlayPopularMix),
+        PhoneHomePosterAction(
+            "Personal Mix",
+            PhoebeIcon.Person,
+            Res.drawable.mix_personal,
+            enabled = !posterLoading.personalMix,
+            loading = posterLoading.personalMix,
+            onClick = onPlayPersonalMix,
+        ),
+        PhoneHomePosterAction(
+            "popular",
+            PhoebeIcon.PlaylistPlay,
+            Res.drawable.mix_popular,
+            enabled = !posterLoading.popularMix,
+            loading = posterLoading.popularMix,
+            onClick = onPlayPopularMix,
+        ),
         PhoneHomePosterAction(
             label = "Decade Mix",
             icon = PhoebeIcon.Calendar,
@@ -1647,6 +1692,7 @@ private fun PhoneCollectionsAccordionSection(
     collectionEntries: List<HomeCollectionEntry>,
     expanded: Boolean,
     onToggle: () -> Unit,
+    loadingCollectionEntry: CollectionEntry?,
     onCollections: (CollectionEntry) -> Unit,
 ) {
     PhoneHomeAccordionGroup(
@@ -1665,6 +1711,8 @@ private fun PhoneCollectionsAccordionSection(
                         label = entry.mobileTitle,
                         icon = entry.icon,
                         artwork = entry.artwork,
+                        enabled = entry.collectionEntry != loadingCollectionEntry,
+                        loading = entry.collectionEntry == loadingCollectionEntry,
                         titleFormatter = ::collectionPosterTitle,
                         onClick = { onCollections(entry.collectionEntry) },
                     )
@@ -1940,6 +1988,7 @@ private fun PhoneHomePosterActionGrid(actions: List<PhoneHomePosterAction>) {
                             artwork = action.artwork,
                             modifier = Modifier.weight(1f),
                             enabled = action.enabled,
+                            loading = action.loading,
                             titleFormatter = action.titleFormatter,
                             onClick = action.onClick,
                         )
@@ -2039,6 +2088,7 @@ private fun normalizedHomeSections(sections: List<HomeSection>): List<HomeSectio
 @Composable
 private fun MobileCollectionsSection(
     collectionRows: List<List<HomeCollectionEntry>>,
+    loadingCollectionEntry: CollectionEntry?,
     onCollections: (CollectionEntry) -> Unit,
 ) {
     HomeSectionLabel("COLLECTIONS")
@@ -2049,6 +2099,8 @@ private fun MobileCollectionsSection(
                 icon = entry.icon,
                 artwork = entry.artwork,
                 modifier = Modifier.width(MobileHomePosterCardSize),
+                enabled = entry.collectionEntry != loadingCollectionEntry,
+                loading = entry.collectionEntry == loadingCollectionEntry,
                 titleFormatter = ::collectionPosterTitle,
             ) {
                 onCollections(entry.collectionEntry)
@@ -2153,6 +2205,7 @@ private fun MobilePlayedHistoryShortcuts(
 private fun DesktopMixesPanel(
     onPlayPersonalMix: () -> Unit,
     onPlayPopularMix: () -> Unit,
+    posterLoading: HomePosterLoadingState,
     radioStations: List<PlexRadioStation>,
     radioStartingIds: Set<String>,
     onPlayRadioStation: (PlexRadioStation) -> Unit,
@@ -2172,6 +2225,7 @@ private fun DesktopMixesPanel(
                     PhoebeIcon.Person,
                     Res.drawable.mix_personal,
                     Modifier.width(148.dp),
+                    loading = posterLoading.personalMix,
                     onClick = onPlayPersonalMix,
                 )
             }
@@ -2181,6 +2235,7 @@ private fun DesktopMixesPanel(
                     PhoebeIcon.PlaylistPlay,
                     Res.drawable.mix_popular,
                     Modifier.width(148.dp),
+                    loading = posterLoading.popularMix,
                     onClick = onPlayPopularMix,
                 )
             }
@@ -2229,6 +2284,7 @@ private fun DesktopMixesPanel(
 private fun MobileMixesSection(
     onPlayPersonalMix: () -> Unit,
     onPlayPopularMix: () -> Unit,
+    posterLoading: HomePosterLoadingState,
     radioStations: List<PlexRadioStation>,
     radioStartingIds: Set<String>,
     onPlayRadioStation: (PlexRadioStation) -> Unit,
@@ -2238,10 +2294,24 @@ private fun MobileMixesSection(
     HomeSectionLabel("CREATE A MIX")
     HomeHorizontalCarousel(Modifier.fillMaxWidth(), horizontalSpacing = 9.dp) {
         item(key = "personal-mix", contentType = "mobile-mix-action") {
-            HomeMixPosterCard("Personal Mix", PhoebeIcon.Person, Res.drawable.mix_personal, Modifier.width(MobileHomePosterCardSize), onClick = onPlayPersonalMix)
+            HomeMixPosterCard(
+                "Personal Mix",
+                PhoebeIcon.Person,
+                Res.drawable.mix_personal,
+                Modifier.width(MobileHomePosterCardSize),
+                loading = posterLoading.personalMix,
+                onClick = onPlayPersonalMix,
+            )
         }
         item(key = "popular-mix", contentType = "mobile-mix-action") {
-            HomeMixPosterCard("popular", PhoebeIcon.PlaylistPlay, Res.drawable.mix_popular, Modifier.width(MobileHomePosterCardSize), onClick = onPlayPopularMix)
+            HomeMixPosterCard(
+                "popular",
+                PhoebeIcon.PlaylistPlay,
+                Res.drawable.mix_popular,
+                Modifier.width(MobileHomePosterCardSize),
+                loading = posterLoading.popularMix,
+                onClick = onPlayPopularMix,
+            )
         }
         item(key = "decade-mix", contentType = "mobile-mix-action") {
             HomeMixPosterCard("Decade Mix", PhoebeIcon.Calendar, Res.drawable.mix_decade, Modifier.width(MobileHomePosterCardSize)) {
@@ -2710,6 +2780,7 @@ private fun allHomeCollectionEntries(): List<HomeCollectionEntry> =
 @Composable
 private fun DesktopCollectionsGrid(
     supportedCollectionEntries: Set<CollectionEntry>,
+    loadingCollectionEntry: CollectionEntry?,
     onCollections: (CollectionEntry) -> Unit,
 ) {
     HomeHorizontalCarousel(Modifier.fillMaxWidth(), horizontalSpacing = 12.dp) {
@@ -2719,6 +2790,8 @@ private fun DesktopCollectionsGrid(
                 icon = entry.icon,
                 artwork = entry.artwork,
                 modifier = Modifier.width(148.dp),
+                enabled = entry.collectionEntry != loadingCollectionEntry,
+                loading = entry.collectionEntry == loadingCollectionEntry,
                 titleFormatter = ::collectionPosterTitle,
             ) {
                 onCollections(entry.collectionEntry)
@@ -2768,6 +2841,7 @@ private fun HomeMixPosterCard(
     artwork: DrawableResource,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    loading: Boolean = false,
     titleFormatter: (String) -> String = ::mixPosterTitle,
     onClick: () -> Unit,
 ) {
@@ -2777,7 +2851,7 @@ private fun HomeMixPosterCard(
         modifier
             .aspectRatio(HomeMixCardAspectRatio)
             .clip(shape)
-            .combinedClickable(enabled = enabled, onClick = onClick)
+            .combinedClickable(enabled = enabled && !loading, onClick = onClick)
             .background(Color.Black)
             .border(BorderStroke(1.dp, colors.border.copy(alpha = 0.68f)), shape),
     ) {
@@ -2799,7 +2873,7 @@ private fun HomeMixPosterCard(
                 ),
         )
         Text(
-            text = titleFormatter(title),
+            text = if (loading) "LOADING" else titleFormatter(title),
             color = Color.White,
             fontSize = 20.sp,
             lineHeight = 21.sp,

--- a/playback/src/wasmJsMain/kotlin/com/phoebe/app/player/WebAudioPlayer.kt
+++ b/playback/src/wasmJsMain/kotlin/com/phoebe/app/player/WebAudioPlayer.kt
@@ -1221,11 +1221,12 @@ private external fun setWebAudioOutputGain(audio: HTMLAudioElement, gain: Double
                     analyser.getByteFrequencyData(data);
                     let sum = 0;
                     const bands = [];
-                    const group = Math.max(1, Math.floor(data.length / 32));
-                    for (let i = 0; i < 32; i++) {
+                    const bandCount = 128;
+                    const group = Math.max(1, Math.floor(data.length / bandCount));
+                    for (let i = 0; i < bandCount; i++) {
                         let peak = 0;
                         const start = i * group;
-                        const end = i === 31 ? data.length : Math.min(data.length, start + group);
+                        const end = i === bandCount - 1 ? data.length : Math.min(data.length, start + group);
                         for (let j = start; j < end; j++) peak = Math.max(peak, data[j] || 0);
                         const v = Math.max(0, Math.min(1, peak / 255));
                         bands.push(v);


### PR DESCRIPTION
## Summary
- Persist library-level popular track caches with a SQLDelight migration so Popular Mix can use cached catalog data before hitting the provider.
- Warm Popular Mix from the home screen and show temporary loading states on mix and collection poster actions.
- Guard pending web navigation path publication and increase wasm audio analyser band granularity.

## Validation
- `./gradlew :data:database:verifySqlDelightMigration :data:database:desktopTest :data:catalog:desktopTest :feature:home:desktopTest :composeApp:desktopTest :composeApp:compileKotlinDesktop :composeApp:compileKotlinWasmJs :playback:compileKotlinWasmJs`