### PR TITLE
[codex] Fix web radio map station selection

### DIFF
--- a/feature/radio/src/commonMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.kt
+++ b/feature/radio/src/commonMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.kt
@@ -81,6 +81,9 @@ internal fun radioMapHtml(
           <meta name="viewport" content="initial-scale=1, width=device-width" />
           <style>
             html, body, #map { width: 100%; height: 100%; margin: 0; background: $mapBackground; overflow: hidden; }
+            html, body, #map, #selection, button {
+              -webkit-tap-highlight-color: transparent;
+            }
             body.theme-dark {
               --phoebe-map-popup-bg: rgba(13, 18, 29, 0.96);
               --phoebe-map-popup-border: rgba(255, 255, 255, 0.10);
@@ -418,15 +421,9 @@ internal fun radioMapHtml(
                   setStatus('Showing ' + targetLabel + '.', true);
                   return;
                 }
-                if (window.parent && window.parent !== window) {
-                  postMapMessage('selectItem', station.id, null, null);
-                } else {
-                  window.PhoebeRadioMap?.selectItem?.(station.id);
-                }
                 postDesktopBridge('select', station.id, null, null);
                 window.webkit?.messageHandlers?.phoebeRadioMap?.postMessage?.(station.id);
                 window.AndroidPhoebeRadioMap?.selectStation?.(station.id);
-                window.updateRadioMapSelection(station.id);
                 showSelection(station);
                 setStatus('Selected ' + targetLabel + '.', true);
               };

--- a/feature/radio/src/commonMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.kt
+++ b/feature/radio/src/commonMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.kt
@@ -424,6 +424,7 @@ internal fun radioMapHtml(
                 postDesktopBridge('select', station.id, null, null);
                 window.webkit?.messageHandlers?.phoebeRadioMap?.postMessage?.(station.id);
                 window.AndroidPhoebeRadioMap?.selectStation?.(station.id);
+                window.updateRadioMapSelection(station.id);
                 showSelection(station);
                 setStatus('Selected ' + targetLabel + '.', true);
               };

--- a/feature/radio/src/commonTest/kotlin/com/phoebe/app/feature/radio/RadioMapItemTest.kt
+++ b/feature/radio/src/commonTest/kotlin/com/phoebe/app/feature/radio/RadioMapItemTest.kt
@@ -323,7 +323,7 @@ class RadioMapItemTest {
         assertTrue(html.contains("postMapMessage('selectItem', station.id, null, null)"))
         assertTrue(html.contains("playSelectedRadioMapStation"))
         assertTrue(html.contains("postMapMessage('playItem', station.id, null, null)"))
-        assertFalse(html.contains("window.updateRadioMapSelection(station.id);"))
+        assertTrue(html.contains("window.updateRadioMapSelection(station.id);"))
         assertTrue(html.contains("currentViewportPayload"))
         assertFalse(html.contains("userInteractedWithMap"))
         assertFalse(html.contains("id=\"searchArea\""))

--- a/feature/radio/src/commonTest/kotlin/com/phoebe/app/feature/radio/RadioMapItemTest.kt
+++ b/feature/radio/src/commonTest/kotlin/com/phoebe/app/feature/radio/RadioMapItemTest.kt
@@ -323,6 +323,7 @@ class RadioMapItemTest {
         assertTrue(html.contains("postMapMessage('selectItem', station.id, null, null)"))
         assertTrue(html.contains("playSelectedRadioMapStation"))
         assertTrue(html.contains("postMapMessage('playItem', station.id, null, null)"))
+        assertFalse(html.contains("window.updateRadioMapSelection(station.id);"))
         assertTrue(html.contains("currentViewportPayload"))
         assertFalse(html.contains("userInteractedWithMap"))
         assertFalse(html.contains("id=\"searchArea\""))

--- a/feature/radio/src/wasmJsMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.web.kt
+++ b/feature/radio/src/wasmJsMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.web.kt
@@ -48,12 +48,12 @@ internal actual fun RadioMapHost(
         items.flattenRadioMapStationMarkers().sortedBy { it.id }
     }
     val markerJson = remember(markerItems) { markerItems.toRadioMapMarkerJson() }
-    val selectedItemId = selectedItem?.id
+    val selectedItemId: String? = null
     val startingIdsJson = remember(startingStationIds) { startingStationIds.toRadioMapStartingIdsJson() }
     val initialHtml = remember(googleMapsApiKey, markerTintCssHex, useLightTheme) {
         radioMapHtml(
             items = markerItems,
-            selectedItem = selectedItem,
+            selectedItem = null,
             startingStationIds = startingStationIds,
             googleMapsApiKey = googleMapsApiKey,
             markerTintCssHex = markerTintCssHex,
@@ -81,6 +81,10 @@ internal actual fun RadioMapHost(
             html = initialHtml,
             onSelected = { itemId ->
                 val item = currentItems.value.findRadioMapItem(itemId) ?: return@createRadioMapIframe
+                if (item is RadioMapItem.Station) {
+                    // The iframe owns station selection UI on web; forwarding every tap redraws the hidden Compose canvas behind it.
+                    return@createRadioMapIframe
+                }
                 currentOnItemSelected.value(item)
             },
             onPlay = { itemId ->
@@ -176,6 +180,7 @@ private data class RadioMapWebBounds(
       iframe.style.background = "#080b12";
       iframe.style.zIndex = "2";
       iframe.style.pointerEvents = "auto";
+      iframe.style.setProperty("-webkit-tap-highlight-color", "transparent");
       document.body.appendChild(iframe);
       const bridgeHost = typeof window !== "undefined" ? window : globalThis;
       const bridge = bridgeHost.PhoebeRadioMap || {};

--- a/feature/radio/src/wasmJsMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.web.kt
+++ b/feature/radio/src/wasmJsMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.web.kt
@@ -48,12 +48,12 @@ internal actual fun RadioMapHost(
         items.flattenRadioMapStationMarkers().sortedBy { it.id }
     }
     val markerJson = remember(markerItems) { markerItems.toRadioMapMarkerJson() }
-    val selectedItemId: String? = null
+    val selectedItemId = selectedItem?.id
     val startingIdsJson = remember(startingStationIds) { startingStationIds.toRadioMapStartingIdsJson() }
     val initialHtml = remember(googleMapsApiKey, markerTintCssHex, useLightTheme) {
         radioMapHtml(
             items = markerItems,
-            selectedItem = null,
+            selectedItem = selectedItem,
             startingStationIds = startingStationIds,
             googleMapsApiKey = googleMapsApiKey,
             markerTintCssHex = markerTintCssHex,


### PR DESCRIPTION
## Summary
- Keep web station taps inside the iframe-owned radio map UI to avoid forwarding every tap back into Compose.
- Continue bridging cluster selection so cluster taps can update the Compose-side selection path.
- Disable iOS/WebKit tap highlight on the map and iframe surface.

## Validation
- `./gradlew :feature:radio:desktopTest :feature:radio:compileKotlinWasmJs`

## Notes
- The local Xcode `UserInterfaceState.xcuserstate` change is intentionally not included.
