### PR TITLE
[codex] Add radio stream links and web telemetry

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/phoebe/app/ui/RadioMapOverlayOcclusionEffect.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/phoebe/app/ui/RadioMapOverlayOcclusionEffect.android.kt
@@ -1,0 +1,6 @@
+package com.phoebe.app.ui
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal actual fun RadioMapOverlayOcclusionEffect(sheetTopPx: Float?) = Unit

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
@@ -122,6 +122,11 @@ data class PendingDuplicatePlaylistAdd(
     val message: String,
 )
 
+data class PlaybackSnackbarNotice(
+    val message: String,
+    val streamUrl: String? = null,
+)
+
 class AppState(
     private val dependencies: AppDependencies,
     private val scope: CoroutineScope,
@@ -276,8 +281,8 @@ class AppState(
     private val mutablePendingDuplicatePlaylistAdd = MutableStateFlow<PendingDuplicatePlaylistAdd?>(null)
     val pendingDuplicatePlaylistAdd: StateFlow<PendingDuplicatePlaylistAdd?> = mutablePendingDuplicatePlaylistAdd.asStateFlow()
 
-    private val mutablePlaybackSnackbar = MutableStateFlow<String?>(null)
-    val playbackSnackbar: StateFlow<String?> = mutablePlaybackSnackbar.asStateFlow()
+    private val mutablePlaybackSnackbar = MutableStateFlow<PlaybackSnackbarNotice?>(null)
+    val playbackSnackbar: StateFlow<PlaybackSnackbarNotice?> = mutablePlaybackSnackbar.asStateFlow()
 
     private val mutableDecadeMixNotice = MutableStateFlow<String?>(null)
     val decadeMixNotice: StateFlow<String?> = mutableDecadeMixNotice
@@ -508,7 +513,7 @@ class AppState(
                     ?: title?.let { "Couldn't play $it." }
                     ?: "Couldn't play that song."
                 mutableMessage.value = notice
-                mutablePlaybackSnackbar.value = notice
+                surfacePlaybackSnackbar(notice, state.currentTrack?.radioPlaybackStreamUrlOrNull())
             }
         }
         scope.launch {
@@ -518,7 +523,7 @@ class AppState(
                 lastSerial = state.playbackNoticeSerial
                 val notice = state.playbackNoticeMessage ?: return@collect
                 mutableMessage.value = notice
-                mutablePlaybackSnackbar.value = notice
+                surfacePlaybackSnackbar(notice)
             }
         }
     }
@@ -533,7 +538,7 @@ class AppState(
                     if (message == "Chromecast requires Chrome with Cast support.") return@collect
                     if (message.startsWith("Sending ") && message.endsWith(" to Chromecast...")) return@collect
                     mutableMessage.value = message
-                    mutablePlaybackSnackbar.value = message
+                    surfacePlaybackSnackbar(message)
                 }
         }
     }
@@ -542,9 +547,19 @@ class AppState(
         mutablePlaybackSnackbar.value = null
     }
 
+    private fun surfacePlaybackSnackbar(message: String, streamUrl: String? = null) {
+        mutablePlaybackSnackbar.value = PlaybackSnackbarNotice(
+            message = message,
+            streamUrl = streamUrl?.takeIf { it.isNotBlank() },
+        )
+    }
+
+    private fun Track.radioPlaybackStreamUrlOrNull(): String? =
+        streamUrl.takeIf { id.startsWith("radio:") && it.isNotBlank() }
+
     private fun surfaceTransientNotice(notice: String) {
         mutableMessage.value = notice
-        mutablePlaybackSnackbar.value = notice
+        surfacePlaybackSnackbar(notice)
     }
 
     /**
@@ -2150,7 +2165,7 @@ class AppState(
         if (station == null) {
             val message = "Radio station not found."
             mutableMessage.value = message
-            mutablePlaybackSnackbar.value = message
+            surfacePlaybackSnackbar(message)
             return@launch
         }
         playInternetRadioStation(station)
@@ -2181,7 +2196,7 @@ class AppState(
                 mutableInternetRadioStartingIds.value = mutableInternetRadioStartingIds.value - station.id
                 val message = error.message ?: "Couldn't start ${station.name}."
                 mutableMessage.value = message
-                mutablePlaybackSnackbar.value = message
+                surfacePlaybackSnackbar(message, station.streamUrl)
                 return@launch
         }
         try {
@@ -2202,7 +2217,7 @@ class AppState(
         dependencies.audioPlayer.stopPlayback()
         val message = "Couldn't start ${station.name}."
         mutableMessage.value = message
-        mutablePlaybackSnackbar.value = message
+        surfacePlaybackSnackbar(message, track.streamUrl.ifBlank { station.streamUrl })
     }
 
     fun prependRecentSearch(item: RecentSearchItem) = scope.launch {
@@ -2260,14 +2275,14 @@ class AppState(
         dependencies.appUpdateService.checkForUpdates { error ->
             val message = error.message ?: "Couldn't check for updates."
             mutableMessage.value = message
-            mutablePlaybackSnackbar.value = message
+            surfacePlaybackSnackbar(message)
         }
     }
 
     fun installAvailableUpdate() = scope.launch {
         dependencies.appUpdateService.installAvailableUpdate { message ->
             mutableMessage.value = message
-            mutablePlaybackSnackbar.value = message
+            surfacePlaybackSnackbar(message)
         }
     }
 
@@ -2447,7 +2462,7 @@ class AppState(
 
     private fun launchDownload(block: suspend () -> DownloadServiceResult): Job {
         cellularDownloadNotice()?.let { notice ->
-            mutablePlaybackSnackbar.value = notice
+            surfacePlaybackSnackbar(notice)
         }
         lateinit var downloadJob: Job
         downloadJob = scope.launch {
@@ -2456,7 +2471,7 @@ class AppState(
                 val result = block()
                 mutableMessage.value = result.message
                 if (result.message.startsWith("Downloads are paused")) {
-                    mutablePlaybackSnackbar.value = result.message
+                    surfacePlaybackSnackbar(result.message)
                 }
                 dependencies.downloadService.notifyDownloadFinishedIfNeeded(result.batch)
             } catch (error: CancellationException) {

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeDesktopPlayer.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeDesktopPlayer.kt
@@ -34,6 +34,7 @@ import com.phoebe.app.domain.RadioNowPlayingMetadata
 import com.phoebe.app.domain.Track
 import com.phoebe.app.domain.isEmbyFamily
 import com.phoebe.app.domain.isNavidrome
+import com.phoebe.app.domain.isPlex
 import com.phoebe.app.feature.auth.AuthWelcomeDesktopRoute
 import com.phoebe.app.feature.auth.AuthWelcomeRouteActions
 import com.phoebe.app.feature.auth.AuthWelcomeRouteState
@@ -712,6 +713,7 @@ internal fun DesktopPlayer(
                                                 decadeMixNotice = decadeMixNotice,
                                                 radioStations = radioStations,
                                                 radioStartingIds = radioStartingIds,
+                                                showPopularMix = shellState.session.isPlex(),
                                             ),
                                             actions = DesktopHomeRouteActions(
                                                 onTrack = onSong,

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeMobile.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeMobile.kt
@@ -230,6 +230,7 @@ import com.phoebe.app.player.CastState
 import com.phoebe.app.domain.isEmbyFamily
 import com.phoebe.app.domain.isJellyfin
 import com.phoebe.app.domain.isNavidrome
+import com.phoebe.app.domain.isPlex
 import com.phoebe.app.domain.isRemoteLibraryTrack
 import com.phoebe.app.domain.supportsPlexPlaylists
 import com.phoebe.app.platform.createPlatformHttpClient
@@ -663,6 +664,7 @@ internal fun MobileBrowseShell(
                         radioStations,
                         radioStartingIds,
                         decadeMixNotice,
+                        session?.providerType,
                     ) {
                         MobileHomeRouteState(
                             homeUiState = homeUiState,
@@ -674,6 +676,7 @@ internal fun MobileBrowseShell(
                             radioStartingIds = radioStartingIds,
                             decadeMixNotice = decadeMixNotice,
                             homeScreenLayoutMode = homeScreenLayoutMode,
+                            showPopularMix = session.isPlex(),
                         )
                     }
                     val mobileHomeCallbacks = remember(

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeRoot.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeRoot.kt
@@ -136,9 +136,11 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.composed
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -155,6 +157,7 @@ import androidx.compose.ui.zIndex
 import kotlin.math.roundToInt
 import com.phoebe.app.AppState
 import com.phoebe.app.PendingDuplicatePlaylistAdd
+import com.phoebe.app.PlaybackSnackbarNotice
 import com.phoebe.app.feature.auth.AuthWelcomeMobileRoute
 import com.phoebe.app.feature.auth.AuthWelcomeRouteActions
 import com.phoebe.app.feature.auth.AuthWelcomeRouteState
@@ -1805,6 +1808,12 @@ private fun PhoebeRootStateHolder(
                 BoxWithConstraints(Modifier.fillMaxSize()) {
                     val screenHeightPx = constraints.maxHeight.toFloat()
                     val dragRangePx = (screenHeightPx - actualBottomBarHeightPx - miniPlayerHeightPx).coerceAtLeast(1f)
+                    val radioMapOcclusionTopPx = if (contentRoute == PhoebeRoute.RadioMap && currentTrack != null) {
+                        dragRangePx * (1f - playerExpansionFraction.value)
+                    } else {
+                        null
+                    }
+                    RadioMapOverlayOcclusionEffect(radioMapOcclusionTopPx)
 
                     if (mobileChromeVisible) {
                         Box(
@@ -2302,7 +2311,7 @@ private fun PhoebeRootStateHolder(
             }
         }
         PlaybackFailureSnackbar(
-            message = playbackSnackbar,
+            notice = playbackSnackbar,
             onDismiss = state::dismissPlaybackSnackbar,
             modifier = Modifier.align(Alignment.BottomCenter),
         )
@@ -2330,12 +2339,23 @@ private fun PhoebeRootStateHolder(
 
 @Composable
 private fun PlaybackFailureSnackbar(
-    message: String?,
+    notice: PlaybackSnackbarNotice?,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LaunchedEffect(message) {
-        if (message != null) {
+    val message = notice?.message
+    val streamUrl = notice?.streamUrl
+    @Suppress("DEPRECATION")
+    val clipboardManager = LocalClipboardManager.current
+    var copied by remember(notice) { mutableStateOf(false) }
+    val snackbarMessage = if (streamUrl == null) {
+        message.orEmpty()
+    } else {
+        "${message.orEmpty()}\n$streamUrl"
+    }
+
+    LaunchedEffect(notice) {
+        if (notice != null) {
             delay(5_000L)
             onDismiss()
         }
@@ -2350,9 +2370,20 @@ private fun PlaybackFailureSnackbar(
             .zIndex(20f),
     ) {
         PhoebeActionSnackbar(
-            message = message.orEmpty(),
-            actionLabel = "Dismiss",
-            onAction = onDismiss,
+            message = snackbarMessage,
+            actionLabel = when {
+                streamUrl != null && copied -> "Copied"
+                streamUrl != null -> "Copy URL"
+                else -> "Dismiss"
+            },
+            onAction = {
+                if (streamUrl == null) {
+                    onDismiss()
+                } else {
+                    clipboardManager.setText(AnnotatedString(streamUrl))
+                    copied = true
+                }
+            },
         )
     }
 }
@@ -2420,6 +2451,8 @@ private fun PhoebeActionSnackbar(
                 color = PhoebeUi.primaryText,
                 fontSize = 14.sp,
                 lineHeight = 19.sp,
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f),
             )
             TextButton(onClick = onAction) {

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/RadioMapOverlayOcclusionEffect.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/RadioMapOverlayOcclusionEffect.kt
@@ -1,0 +1,6 @@
+package com.phoebe.app.ui
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal expect fun RadioMapOverlayOcclusionEffect(sheetTopPx: Float?)

--- a/composeApp/src/desktopMain/kotlin/com/phoebe/app/ui/RadioMapOverlayOcclusionEffect.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/phoebe/app/ui/RadioMapOverlayOcclusionEffect.desktop.kt
@@ -1,0 +1,6 @@
+package com.phoebe.app.ui
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal actual fun RadioMapOverlayOcclusionEffect(sheetTopPx: Float?) = Unit

--- a/composeApp/src/desktopTest/kotlin/com/phoebe/app/PlexPlaylistEndToEndDesktopTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/phoebe/app/PlexPlaylistEndToEndDesktopTest.kt
@@ -28,8 +28,11 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import org.junit.After
@@ -125,7 +128,11 @@ class PlexPlaylistEndToEndDesktopTest {
 
         val tracks = repo.tracksForPlaylist(testPlexSession(), playlist)
 
-        assertEquals(listOf("plex:t1", "plex:t2"), tracks.map { it.id })
+        val expected = listOf("plex:t1", "plex:t2")
+        assertEquals(
+            expected,
+            tracks.map { it.id }.ifEmpty { waitForPlaylistTrackIds(repo, playlist.id, expected) },
+        )
     }
 
     @Test
@@ -154,7 +161,7 @@ class PlexPlaylistEndToEndDesktopTest {
         assertEquals(null, movedAfterItemId)
         assertEquals(
             listOf("plex:t2", "plex:t1"),
-            repo.catalog.value.tracksByParent[playlist.id].orEmpty().map { it.id },
+            waitForPlaylistTrackIds(repo, playlist.id, listOf("plex:t2", "plex:t1")),
         )
     }
 
@@ -349,7 +356,10 @@ class PlexPlaylistEndToEndDesktopTest {
         repo.warmPlaylistTracks(testPlexSession())
 
         assertFalse(repo.catalogRefreshing.value)
-        assertEquals(listOf("plex:t1", "plex:t2"), repo.catalog.value.tracksByParent[playlist.id].orEmpty().map { it.id })
+        assertEquals(
+            listOf("plex:t1", "plex:t2"),
+            waitForPlaylistTrackIds(repo, playlist.id, listOf("plex:t1", "plex:t2")),
+        )
     }
 
     @Test
@@ -1006,6 +1016,23 @@ class PlexPlaylistEndToEndDesktopTest {
         assertEquals(DownloadState.Failed, downloaded.state)
         assertEquals(failureReason, downloaded.error)
         assertEquals(null, downloaded.localUri)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun TestScope.waitForPlaylistTrackIds(
+        repo: CatalogRepository,
+        playlistId: String,
+        expected: List<String>,
+    ): List<String> {
+        val deadline = System.nanoTime() + 2_000_000_000L
+        var actual = repo.catalog.value.tracksByParent[playlistId].orEmpty().map { it.id }
+        while (actual != expected) {
+            runCurrent()
+            if (System.nanoTime() >= deadline) return actual
+            Thread.sleep(1)
+            actual = repo.catalog.value.tracksByParent[playlistId].orEmpty().map { it.id }
+        }
+        return actual
     }
 
     private fun MockRequestHandleScope.respondJson(content: String) = respond(

--- a/composeApp/src/desktopTest/kotlin/com/phoebe/app/ui/PhoneHomeAccordionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/phoebe/app/ui/PhoneHomeAccordionTest.kt
@@ -104,6 +104,7 @@ class PhoneHomeAccordionTest {
         mainClock.advanceTimeBy(260)
         waitForIdle()
         assertTextExists("PERSONAL\nMIX")
+        assertTextExists("POPULAR")
         assertTextExists("DECADE\nMIX")
         assertTextExists("LIBRARY\nRADIO")
 
@@ -119,6 +120,50 @@ class PhoneHomeAccordionTest {
         assertTextDoesNotExist("ARTIST\nMOOD")
         assertTextExists("Recently Played")
         assertTextExists("Most Played")
+    }
+
+    @OptIn(ExperimentalTestApi::class, ExperimentalComposeUiApi::class)
+    @Test
+    fun phoneHomeMixesHidePopularWhenUnsupported() = runDesktopComposeUiTest(width = 430, height = 932) {
+        setContent {
+            PhoebeTheme {
+                Box(Modifier.size(430.dp, 932.dp)) {
+                    MobileHomeScreen(
+                        state = HomeUiState(),
+                        listState = rememberLazyListState(),
+                        layoutMode = HomeScreenLayoutMode.Compact,
+                        showPopularMix = false,
+                        homeSections = listOf(HomeSection.Mixes),
+                        onArtist = {},
+                        onAlbum = {},
+                        onPlaylist = {},
+                        onRecentSongs = {},
+                        onRecentArtists = {},
+                        onRecentAlbums = {},
+                        onFavoritePlaylists = {},
+                        onFavoriteArtists = {},
+                        onFavoriteAlbums = {},
+                        onCollections = {},
+                        onRecentlyPlayed = {},
+                        onMostPlayed = {},
+                        onRefreshArtists = {},
+                        onRefreshAlbums = {},
+                        onPlayTracks = { _, _ -> },
+                        onAddToUpNext = {},
+                        onDownload = {},
+                    )
+                }
+            }
+        }
+
+        waitForIdle()
+        onNodeWithText("Mixes").performClick()
+        mainClock.advanceTimeBy(260)
+        waitForIdle()
+
+        assertTrue(onAllNodesWithText("PERSONAL\nMIX").fetchSemanticsNodes().isNotEmpty())
+        assertFalse(onAllNodesWithText("POPULAR").fetchSemanticsNodes().isNotEmpty())
+        assertTrue(onAllNodesWithText("DECADE\nMIX").fetchSemanticsNodes().isNotEmpty())
     }
 
     @OptIn(ExperimentalTestApi::class, ExperimentalComposeUiApi::class)

--- a/composeApp/src/desktopTest/kotlin/com/phoebe/app/ui/RadioRouteDesktopTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/phoebe/app/ui/RadioRouteDesktopTest.kt
@@ -200,7 +200,7 @@ class RadioRouteDesktopTest {
             }
 
             waitForIdle()
-            onNodeWithText("Google Maps map").assertIsDisplayed()
+            onNodeWithText("Google Maps map", useUnmergedTree = true).assertIsDisplayed()
             assertFalse(onAllNodesWithText("Search this area").fetchSemanticsNodes().isNotEmpty())
             onNode(hasText("KEXP") and hasClickAction()).performClick()
             assertEquals(

--- a/composeApp/src/iosMain/kotlin/com/phoebe/app/ui/RadioMapOverlayOcclusionEffect.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/phoebe/app/ui/RadioMapOverlayOcclusionEffect.ios.kt
@@ -1,0 +1,6 @@
+package com.phoebe.app.ui
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal actual fun RadioMapOverlayOcclusionEffect(sheetTopPx: Float?) = Unit

--- a/composeApp/src/wasmJsMain/kotlin/com/phoebe/app/ui/RadioMapOverlayOcclusionEffect.web.kt
+++ b/composeApp/src/wasmJsMain/kotlin/com/phoebe/app/ui/RadioMapOverlayOcclusionEffect.web.kt
@@ -1,0 +1,59 @@
+package com.phoebe.app.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
+
+@Composable
+internal actual fun RadioMapOverlayOcclusionEffect(sheetTopPx: Float?) {
+    SideEffect {
+        setPhoebeRadioMapOcclusionTop(sheetTopPx?.toDouble() ?: -1.0)
+    }
+    DisposableEffect(Unit) {
+        onDispose {
+            setPhoebeRadioMapOcclusionTop(-1.0)
+        }
+    }
+}
+
+@OptIn(ExperimentalWasmJsInterop::class)
+@JsFun(
+    """
+    (sheetTopPx) => {
+      const bridgeHost = typeof window !== "undefined" ? window : globalThis;
+      const bridge = bridgeHost.PhoebeRadioMap || {};
+      bridgeHost.PhoebeRadioMap = bridge;
+      globalThis.PhoebeRadioMap = bridge;
+      const parsed = Number(sheetTopPx);
+      bridge.occlusionTopPx = Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+      const scale = window.devicePixelRatio || 1;
+
+      const applyBounds = (iframe) => {
+        const requestedLeft = Number(iframe.dataset.phoebeMapLeft || 0);
+        const requestedTop = Number(iframe.dataset.phoebeMapTop || 0);
+        const requestedWidth = Number(iframe.dataset.phoebeMapWidth || 0);
+        const requestedHeight = Number(iframe.dataset.phoebeMapHeight || 0);
+        const requestedRight = requestedLeft + requestedWidth;
+        const requestedBottom = requestedTop + requestedHeight;
+        const viewportRight = window.innerWidth || requestedRight;
+        const viewportBottom = window.innerHeight || requestedBottom;
+        const occlusionTop = bridge.occlusionTopPx == null ? null : Math.max(0, Number(bridge.occlusionTopPx) / scale);
+        const clippedRight = Math.min(viewportRight, requestedRight);
+        const clippedBottom = Math.min(viewportBottom, requestedBottom, occlusionTop == null ? requestedBottom : occlusionTop);
+        const clippedWidth = Math.max(0, clippedRight - requestedLeft);
+        const clippedHeight = Math.max(0, clippedBottom - requestedTop);
+        iframe.style.left = requestedLeft + "px";
+        iframe.style.top = requestedTop + "px";
+        iframe.style.width = clippedWidth + "px";
+        iframe.style.height = clippedHeight + "px";
+        iframe.style.display = clippedWidth > 0 && clippedHeight > 0 ? "block" : "none";
+        if (iframe.contentWindow) {
+          iframe.contentWindow.dispatchEvent(new Event("resize"));
+        }
+      };
+
+      document.querySelectorAll('iframe[id^="phoebe-radio-map-"]').forEach(applyBounds);
+    }
+    """,
+)
+private external fun setPhoebeRadioMapOcclusionTop(sheetTopPx: Double)

--- a/composeApp/src/wasmJsMain/resources/index.html
+++ b/composeApp/src/wasmJsMain/resources/index.html
@@ -25,11 +25,21 @@
 <div id="composeApp"></div>
 <script>
     window.__onGCastApiAvailable = function(isAvailable) {
-        if (!isAvailable || !window.cast || !window.cast.framework) return;
-        window.cast.framework.CastContext.getInstance().setOptions({
-            receiverApplicationId: chrome.cast.media.DEFAULT_MEDIA_RECEIVER_APP_ID,
-            autoJoinPolicy: chrome.cast.AutoJoinPolicy.ORIGIN_SCOPED
-        });
+        try {
+            const castContext = window.cast && window.cast.framework && window.cast.framework.CastContext;
+            if (!isAvailable || !castContext || typeof castContext.getInstance !== "function") return;
+            const chromeCast = window.chrome && window.chrome.cast;
+            const options = {
+                receiverApplicationId:
+                    (chromeCast && chromeCast.media && chromeCast.media.DEFAULT_MEDIA_RECEIVER_APP_ID) ||
+                    "CC1AD845"
+            };
+            const autoJoinPolicy = chromeCast && chromeCast.AutoJoinPolicy && chromeCast.AutoJoinPolicy.ORIGIN_SCOPED;
+            if (autoJoinPolicy) options.autoJoinPolicy = autoJoinPolicy;
+            castContext.getInstance().setOptions(options);
+        } catch (error) {
+            console.warn("Phoebe Chromecast bootstrap failed.", error);
+        }
     };
 </script>
 <script async src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"></script>

--- a/core/platform/src/commonMain/kotlin/com/phoebe/app/telemetry/ManualSentryEnvelope.kt
+++ b/core/platform/src/commonMain/kotlin/com/phoebe/app/telemetry/ManualSentryEnvelope.kt
@@ -1,0 +1,287 @@
+package com.phoebe.app.telemetry
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.random.Random
+
+internal data class ManualSentryClient(
+    val endpoint: String,
+    val environment: String,
+    val appPlatform: String,
+    val eventPlatform: String,
+    val sdkName: String,
+)
+
+internal data class ManualSentryEnvelope(
+    val endpoint: String,
+    val body: String,
+)
+
+internal data class ManualSentryBreadcrumb(
+    val timestampSeconds: Double,
+    val level: String,
+    val category: String,
+    val message: String,
+    val data: Map<String, String> = emptyMap(),
+)
+
+private val manualSentryJson = Json {
+    explicitNulls = false
+}
+
+private val dsnPattern = Regex("""^(https?)://([^@]+)@([^/]+)/(\d+).*$""")
+
+internal fun createManualSentryClient(
+    dsn: String,
+    environment: String,
+    platform: String,
+): ManualSentryClient? {
+    val match = dsnPattern.matchEntire(dsn.trim()) ?: return null
+    val scheme = match.groupValues[1]
+    val publicKey = match.groupValues[2].substringBefore(':')
+    val host = match.groupValues[3]
+    val projectId = match.groupValues[4]
+    val sdkName = "phoebe-kmp-manual"
+    val endpoint = "$scheme://$host/api/$projectId/envelope/" +
+        "?sentry_key=$publicKey&sentry_version=7&sentry_client=$sdkName/1.0"
+    return ManualSentryClient(
+        endpoint = endpoint,
+        environment = environment,
+        appPlatform = platform,
+        eventPlatform = sentryEventPlatform(platform),
+        sdkName = sdkName,
+    )
+}
+
+internal fun manualSentryLogEnvelope(
+    client: ManualSentryClient,
+    timestampSeconds: Double,
+    level: String,
+    body: String,
+    attributes: Map<String, String>,
+): ManualSentryEnvelope {
+    val item = buildJsonObject {
+        put("timestamp", timestampSeconds)
+        put("trace_id", randomSentryHex(byteCount = 16))
+        put("level", level)
+        put("body", body)
+        put("severity_number", severityNumber(level))
+        put("attributes", sentryLogAttributes(attributes + baseAttributes(client)))
+    }
+    val payload = buildJsonObject {
+        put("items", buildJsonArray { add(item) })
+    }
+    return client.envelope(
+        envelopeHeader = client.envelopeHeader(),
+        itemHeader = buildJsonObject {
+            put("type", "log")
+            put("item_count", 1)
+            put("content_type", "application/vnd.sentry.items.log+json")
+        },
+        payload = payload,
+    )
+}
+
+internal fun manualSentryEventEnvelope(
+    client: ManualSentryClient,
+    timestampSeconds: Double,
+    level: String,
+    logger: String,
+    message: String,
+    attributes: Map<String, String>,
+    breadcrumbs: List<ManualSentryBreadcrumb>,
+    exceptionType: String? = null,
+    exceptionValue: String? = null,
+    stack: String? = null,
+    handled: Boolean = true,
+    requestUrl: String? = null,
+    userAgent: String? = null,
+): ManualSentryEnvelope {
+    val eventId = randomSentryHex(byteCount = 16)
+    val event = buildJsonObject {
+        put("event_id", eventId)
+        put("timestamp", timestampSeconds)
+        put("platform", client.eventPlatform)
+        put("level", level)
+        put("logger", logger)
+        put("environment", client.environment)
+        put(
+            "message",
+            buildJsonObject {
+                put("message", message)
+            },
+        )
+        put("tags", sentryTags(attributes + baseAttributes(client)))
+        if (breadcrumbs.isNotEmpty()) {
+            put("breadcrumbs", sentryBreadcrumbs(breadcrumbs))
+        }
+        if (exceptionType != null || exceptionValue != null) {
+            put(
+                "exception",
+                buildJsonObject {
+                    put(
+                        "values",
+                        buildJsonArray {
+                            add(
+                                buildJsonObject {
+                                    put("type", exceptionType ?: "Error")
+                                    put("value", exceptionValue ?: message)
+                                    put(
+                                        "mechanism",
+                                        buildJsonObject {
+                                            put("type", logger)
+                                            put("handled", handled)
+                                        },
+                                    )
+                                },
+                            )
+                        },
+                    )
+                },
+            )
+        }
+        if (!stack.isNullOrBlank()) {
+            put(
+                "extra",
+                buildJsonObject {
+                    put("stack", stack)
+                },
+            )
+        }
+        if (!requestUrl.isNullOrBlank() || !userAgent.isNullOrBlank()) {
+            put(
+                "request",
+                buildJsonObject {
+                    requestUrl?.takeIf(String::isNotBlank)?.let { put("url", it) }
+                    userAgent?.takeIf(String::isNotBlank)?.let {
+                        put(
+                            "headers",
+                            buildJsonObject {
+                                put("User-Agent", it)
+                            },
+                        )
+                    }
+                },
+            )
+        }
+    }
+    return client.envelope(
+        envelopeHeader = buildJsonObject {
+            put("event_id", eventId)
+            put(
+                "sdk",
+                buildJsonObject {
+                    put("name", client.sdkName)
+                    put("version", "1.0")
+                },
+            )
+        },
+        itemHeader = buildJsonObject {
+            put("type", "event")
+            put("content_type", "application/json")
+        },
+        payload = event,
+    )
+}
+
+private fun ManualSentryClient.envelope(
+    itemHeader: JsonObject,
+    payload: JsonObject,
+    envelopeHeader: JsonObject,
+): ManualSentryEnvelope =
+    ManualSentryEnvelope(
+        endpoint = endpoint,
+        body = listOf(envelopeHeader, itemHeader, payload)
+            .joinToString(separator = "\n", postfix = "\n") { jsonObject ->
+                manualSentryJson.encodeToString(JsonObject.serializer(), jsonObject)
+            },
+    )
+
+private fun ManualSentryClient.envelopeHeader(): JsonObject =
+    buildJsonObject {
+        put(
+            "sdk",
+            buildJsonObject {
+                put("name", sdkName)
+                put("version", "1.0")
+            },
+        )
+    }
+
+private fun sentryTags(attributes: Map<String, String>): JsonObject =
+    buildJsonObject {
+        attributes.forEach { (key, value) ->
+            put(key, value)
+        }
+    }
+
+private fun sentryLogAttributes(attributes: Map<String, String>): JsonObject =
+    buildJsonObject {
+        attributes.forEach { (key, value) ->
+            put(
+                key,
+                buildJsonObject {
+                    put("value", value)
+                    put("type", "string")
+                },
+            )
+        }
+    }
+
+private fun sentryBreadcrumbs(breadcrumbs: List<ManualSentryBreadcrumb>): JsonObject =
+    buildJsonObject {
+        put(
+            "values",
+            buildJsonArray {
+                breadcrumbs.forEach { breadcrumb ->
+                    add(
+                        buildJsonObject {
+                            put("timestamp", breadcrumb.timestampSeconds)
+                            put("type", "default")
+                            put("category", breadcrumb.category)
+                            put("level", breadcrumb.level)
+                            put("message", breadcrumb.message)
+                            if (breadcrumb.data.isNotEmpty()) {
+                                put("data", sentryTags(breadcrumb.data))
+                            }
+                        },
+                    )
+                }
+            },
+        )
+    }
+
+private fun baseAttributes(client: ManualSentryClient): Map<String, String> =
+    mapOf("app.platform" to client.appPlatform)
+
+private fun sentryEventPlatform(appPlatform: String): String =
+    when (appPlatform) {
+        "web" -> "javascript"
+        "ios" -> "cocoa"
+        else -> appPlatform
+    }
+
+private fun severityNumber(level: String): Int =
+    when (level) {
+        "trace" -> 1
+        "debug" -> 5
+        "info" -> 9
+        "warn" -> 13
+        "error" -> 17
+        "fatal" -> 21
+        else -> 9
+    }
+
+private fun randomSentryHex(byteCount: Int): String {
+    val hex = "0123456789abcdef"
+    return buildString(byteCount * 2) {
+        repeat(byteCount) {
+            val value = Random.nextInt(0, 256)
+            append(hex[value ushr 4])
+            append(hex[value and 0x0f])
+        }
+    }
+}

--- a/core/platform/src/iosMain/kotlin/com/phoebe/app/telemetry/Telemetry.ios.kt
+++ b/core/platform/src/iosMain/kotlin/com/phoebe/app/telemetry/Telemetry.ios.kt
@@ -1,15 +1,188 @@
 package com.phoebe.app.telemetry
 
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.darwin.Darwin
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import platform.Foundation.NSDate
+import platform.Foundation.timeIntervalSince1970
+
+private const val TelemetryPlatform = "ios"
+private const val MaxBreadcrumbs = 80
+
+private var sentryClient: ManualSentryClient? = null
+private var httpClient: HttpClient? = null
+private var currentScreen: String? = null
+private val breadcrumbs = ArrayDeque<ManualSentryBreadcrumb>()
+private val telemetryScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
 internal actual fun platformInitializeTelemetry(
     dsn: String,
     debug: Boolean,
     environment: String,
-) = Unit
+) {
+    if (httpClient == null) {
+        httpClient = HttpClient(Darwin)
+    }
+    sentryClient = createManualSentryClient(
+        dsn = dsn,
+        environment = environment,
+        platform = TelemetryPlatform,
+    )
+    recordBreadcrumb(
+        level = "debug",
+        category = "telemetry",
+        message = "Sentry initialized",
+        data = mapOf("debug" to debug.toString()),
+    )
+}
 
-internal actual fun platformTrackScreen(name: String, previous: String?) = Unit
+internal actual fun platformTrackScreen(name: String, previous: String?) {
+    currentScreen = name
+    val attributes = screenAttributes(name, previous)
+    recordBreadcrumb(
+        level = "info",
+        category = "navigation",
+        message = "screen.view",
+        data = attributes,
+    )
+    sendLog(
+        level = "info",
+        body = "screen.view",
+        attributes = attributes,
+    )
+}
 
-internal actual fun platformLogTelemetry(tag: String, message: String) = Unit
+internal actual fun platformLogTelemetry(tag: String, message: String) {
+    val attributes = mapOf(
+        "log.tag" to tag,
+    ) + currentScreenAttribute()
+    recordBreadcrumb(
+        level = "debug",
+        category = "log.$tag",
+        message = message,
+        data = attributes,
+    )
+    sendLog(
+        level = "debug",
+        body = message,
+        attributes = attributes,
+    )
+}
 
-internal actual fun platformCaptureException(throwable: Throwable) = Unit
+internal actual fun platformCaptureException(throwable: Throwable) {
+    val message = throwable.message ?: throwable.toString()
+    sendEvent(
+        level = "error",
+        logger = "exception",
+        message = message,
+        attributes = currentScreenAttribute(),
+        exceptionType = throwable.telemetryType(),
+        exceptionValue = message,
+        stack = throwable.stackTraceToString(),
+        handled = true,
+    )
+}
 
-internal actual fun platformCloseTelemetry() = Unit
+internal actual fun platformCloseTelemetry() {
+    sentryClient = null
+    currentScreen = null
+    breadcrumbs.clear()
+    httpClient?.close()
+    httpClient = null
+}
+
+private fun sendLog(
+    level: String,
+    body: String,
+    attributes: Map<String, String>,
+) {
+    val client = sentryClient ?: return
+    val envelope = manualSentryLogEnvelope(
+        client = client,
+        timestampSeconds = timestampSeconds(),
+        level = level,
+        body = body,
+        attributes = attributes,
+    )
+    sendEnvelope(envelope)
+}
+
+private fun sendEvent(
+    level: String,
+    logger: String,
+    message: String,
+    attributes: Map<String, String>,
+    exceptionType: String?,
+    exceptionValue: String?,
+    stack: String?,
+    handled: Boolean,
+) {
+    val client = sentryClient ?: return
+    val envelope = manualSentryEventEnvelope(
+        client = client,
+        timestampSeconds = timestampSeconds(),
+        level = level,
+        logger = logger,
+        message = message,
+        attributes = attributes,
+        breadcrumbs = breadcrumbs.toList(),
+        exceptionType = exceptionType,
+        exceptionValue = exceptionValue,
+        stack = stack,
+        handled = handled,
+    )
+    sendEnvelope(envelope)
+}
+
+private fun sendEnvelope(envelope: ManualSentryEnvelope) {
+    val client = httpClient ?: return
+    telemetryScope.launch {
+        runCatching {
+            client.post(envelope.endpoint) {
+                contentType(ContentType.Text.Plain)
+                setBody(envelope.body)
+            }
+        }
+    }
+}
+
+private fun recordBreadcrumb(
+    level: String,
+    category: String,
+    message: String,
+    data: Map<String, String> = emptyMap(),
+) {
+    breadcrumbs.addLast(
+        ManualSentryBreadcrumb(
+            timestampSeconds = timestampSeconds(),
+            level = level,
+            category = category,
+            message = message,
+            data = data,
+        ),
+    )
+    while (breadcrumbs.size > MaxBreadcrumbs) {
+        breadcrumbs.removeFirst()
+    }
+}
+
+private fun screenAttributes(name: String, previous: String?): Map<String, String> =
+    mapOf("screen.name" to name) + previous
+        ?.let { mapOf("screen.previous" to it) }
+        .orEmpty()
+
+private fun currentScreenAttribute(): Map<String, String> =
+    currentScreen?.let { mapOf("screen.name" to it) }.orEmpty()
+
+private fun timestampSeconds(): Double =
+    NSDate().timeIntervalSince1970
+
+private fun Throwable.telemetryType(): String =
+    toString().substringBefore(':').ifBlank { "Throwable" }

--- a/core/platform/src/iosMain/kotlin/com/phoebe/app/telemetry/Telemetry.ios.kt
+++ b/core/platform/src/iosMain/kotlin/com/phoebe/app/telemetry/Telemetry.ios.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import platform.Foundation.NSDate
+import platform.Foundation.NSLock
 import platform.Foundation.timeIntervalSince1970
 
 private const val TelemetryPlatform = "ios"
@@ -20,6 +21,7 @@ private var sentryClient: ManualSentryClient? = null
 private var httpClient: HttpClient? = null
 private var currentScreen: String? = null
 private val breadcrumbs = ArrayDeque<ManualSentryBreadcrumb>()
+private val breadcrumbsLock = NSLock()
 private val telemetryScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
 internal actual fun platformInitializeTelemetry(
@@ -93,7 +95,9 @@ internal actual fun platformCaptureException(throwable: Throwable) {
 internal actual fun platformCloseTelemetry() {
     sentryClient = null
     currentScreen = null
-    breadcrumbs.clear()
+    breadcrumbsLock.withLock {
+        breadcrumbs.clear()
+    }
     httpClient?.close()
     httpClient = null
 }
@@ -125,6 +129,9 @@ private fun sendEvent(
     handled: Boolean,
 ) {
     val client = sentryClient ?: return
+    val breadcrumbsSnapshot = breadcrumbsLock.withLock {
+        breadcrumbs.toList()
+    }
     val envelope = manualSentryEventEnvelope(
         client = client,
         timestampSeconds = timestampSeconds(),
@@ -132,7 +139,7 @@ private fun sendEvent(
         logger = logger,
         message = message,
         attributes = attributes,
-        breadcrumbs = breadcrumbs.toList(),
+        breadcrumbs = breadcrumbsSnapshot,
         exceptionType = exceptionType,
         exceptionValue = exceptionValue,
         stack = stack,
@@ -159,17 +166,27 @@ private fun recordBreadcrumb(
     message: String,
     data: Map<String, String> = emptyMap(),
 ) {
-    breadcrumbs.addLast(
-        ManualSentryBreadcrumb(
-            timestampSeconds = timestampSeconds(),
-            level = level,
-            category = category,
-            message = message,
-            data = data,
-        ),
+    val breadcrumb = ManualSentryBreadcrumb(
+        timestampSeconds = timestampSeconds(),
+        level = level,
+        category = category,
+        message = message,
+        data = data,
     )
-    while (breadcrumbs.size > MaxBreadcrumbs) {
-        breadcrumbs.removeFirst()
+    breadcrumbsLock.withLock {
+        breadcrumbs.addLast(breadcrumb)
+        while (breadcrumbs.size > MaxBreadcrumbs) {
+            breadcrumbs.removeFirst()
+        }
+    }
+}
+
+private inline fun <T> NSLock.withLock(block: () -> T): T {
+    lock()
+    return try {
+        block()
+    } finally {
+        unlock()
     }
 }
 

--- a/core/platform/src/wasmJsMain/kotlin/com/phoebe/app/telemetry/Telemetry.wasmJs.kt
+++ b/core/platform/src/wasmJsMain/kotlin/com/phoebe/app/telemetry/Telemetry.wasmJs.kt
@@ -1,15 +1,254 @@
 package com.phoebe.app.telemetry
 
+private const val TelemetryPlatform = "web"
+private const val MaxBreadcrumbs = 80
+
+private var sentryClient: ManualSentryClient? = null
+private var currentScreen: String? = null
+private val breadcrumbs = ArrayDeque<ManualSentryBreadcrumb>()
+
 internal actual fun platformInitializeTelemetry(
     dsn: String,
     debug: Boolean,
     environment: String,
-) = Unit
+) {
+    sentryClient = createManualSentryClient(
+        dsn = dsn,
+        environment = environment,
+        platform = TelemetryPlatform,
+    )
+    installGlobalErrorHandlers { message, type, stack, url, userAgent ->
+        val attributes = currentScreenAttribute()
+        recordBreadcrumb(
+            level = "error",
+            category = "global",
+            message = message,
+            data = attributes,
+        )
+        sendEvent(
+            level = "error",
+            logger = "global",
+            message = message,
+            attributes = attributes,
+            exceptionType = type.ifBlank { "Error" },
+            exceptionValue = message,
+            stack = stack,
+            handled = false,
+            requestUrl = url,
+            userAgent = userAgent,
+        )
+    }
+    recordBreadcrumb(
+        level = "debug",
+        category = "telemetry",
+        message = "Sentry initialized",
+        data = mapOf("debug" to debug.toString()),
+    )
+}
 
-internal actual fun platformTrackScreen(name: String, previous: String?) = Unit
+internal actual fun platformTrackScreen(name: String, previous: String?) {
+    currentScreen = name
+    val attributes = screenAttributes(name, previous)
+    recordBreadcrumb(
+        level = "info",
+        category = "navigation",
+        message = "screen.view",
+        data = attributes,
+    )
+    sendLog(
+        level = "info",
+        body = "screen.view",
+        attributes = attributes,
+    )
+}
 
-internal actual fun platformLogTelemetry(tag: String, message: String) = Unit
+internal actual fun platformLogTelemetry(tag: String, message: String) {
+    val attributes = mapOf(
+        "log.tag" to tag,
+    ) + currentScreenAttribute()
+    recordBreadcrumb(
+        level = "debug",
+        category = "log.$tag",
+        message = message,
+        data = attributes,
+    )
+    sendLog(
+        level = "debug",
+        body = message,
+        attributes = attributes,
+    )
+}
 
-internal actual fun platformCaptureException(throwable: Throwable) = Unit
+internal actual fun platformCaptureException(throwable: Throwable) {
+    val message = throwable.message ?: throwable.toString()
+    sendEvent(
+        level = "error",
+        logger = "exception",
+        message = message,
+        attributes = currentScreenAttribute(),
+        exceptionType = throwable.telemetryType(),
+        exceptionValue = message,
+        stack = throwable.stackTraceToString(),
+        handled = true,
+        requestUrl = currentBrowserUrl(),
+        userAgent = currentUserAgent(),
+    )
+}
 
-internal actual fun platformCloseTelemetry() = Unit
+internal actual fun platformCloseTelemetry() {
+    sentryClient = null
+    currentScreen = null
+    breadcrumbs.clear()
+}
+
+private fun sendLog(
+    level: String,
+    body: String,
+    attributes: Map<String, String>,
+) {
+    val client = sentryClient ?: return
+    val envelope = manualSentryLogEnvelope(
+        client = client,
+        timestampSeconds = timestampSeconds(),
+        level = level,
+        body = body,
+        attributes = attributes,
+    )
+    sendEnvelope(envelope)
+}
+
+private fun sendEvent(
+    level: String,
+    logger: String,
+    message: String,
+    attributes: Map<String, String>,
+    exceptionType: String?,
+    exceptionValue: String?,
+    stack: String?,
+    handled: Boolean,
+    requestUrl: String?,
+    userAgent: String?,
+) {
+    val client = sentryClient ?: return
+    val envelope = manualSentryEventEnvelope(
+        client = client,
+        timestampSeconds = timestampSeconds(),
+        level = level,
+        logger = logger,
+        message = message,
+        attributes = attributes,
+        breadcrumbs = breadcrumbs.toList(),
+        exceptionType = exceptionType,
+        exceptionValue = exceptionValue,
+        stack = stack,
+        handled = handled,
+        requestUrl = requestUrl,
+        userAgent = userAgent,
+    )
+    sendEnvelope(envelope)
+}
+
+private fun sendEnvelope(envelope: ManualSentryEnvelope) {
+    sendSentryEnvelope(envelope.endpoint, envelope.body)
+}
+
+private fun recordBreadcrumb(
+    level: String,
+    category: String,
+    message: String,
+    data: Map<String, String> = emptyMap(),
+) {
+    breadcrumbs.addLast(
+        ManualSentryBreadcrumb(
+            timestampSeconds = timestampSeconds(),
+            level = level,
+            category = category,
+            message = message,
+            data = data,
+        ),
+    )
+    while (breadcrumbs.size > MaxBreadcrumbs) {
+        breadcrumbs.removeFirst()
+    }
+}
+
+private fun screenAttributes(name: String, previous: String?): Map<String, String> =
+    mapOf("screen.name" to name) + previous
+        ?.let { mapOf("screen.previous" to it) }
+        .orEmpty()
+
+private fun currentScreenAttribute(): Map<String, String> =
+    currentScreen?.let { mapOf("screen.name" to it) }.orEmpty()
+
+@OptIn(ExperimentalWasmJsInterop::class)
+@JsFun("() => Date.now() / 1000")
+private external fun timestampSeconds(): Double
+
+@OptIn(ExperimentalWasmJsInterop::class)
+@JsFun("() => typeof location !== 'undefined' ? String(location.href || '') : ''")
+private external fun currentBrowserUrl(): String
+
+@OptIn(ExperimentalWasmJsInterop::class)
+@JsFun("() => typeof navigator !== 'undefined' ? String(navigator.userAgent || '') : ''")
+private external fun currentUserAgent(): String
+
+@OptIn(ExperimentalWasmJsInterop::class)
+@JsFun(
+    """
+    (endpoint, body) => {
+      try {
+        const payload = String(body || "");
+        if (typeof navigator !== "undefined" && navigator.sendBeacon && payload.length < 60000) {
+          const blob = new Blob([payload], { type: "text/plain;charset=UTF-8" });
+          if (navigator.sendBeacon(endpoint, blob)) return;
+        }
+        if (typeof fetch !== "undefined") {
+          fetch(endpoint, {
+            method: "POST",
+            body: payload,
+            keepalive: true,
+            headers: { "Content-Type": "text/plain;charset=UTF-8" },
+          }).catch(() => {});
+        }
+      } catch (_error) {}
+    }
+    """,
+)
+private external fun sendSentryEnvelope(endpoint: String, body: String)
+
+@OptIn(ExperimentalWasmJsInterop::class)
+@JsFun(
+    """
+    (callback) => {
+      if (globalThis.__phoebeSentryGlobalHandlersInstalled) return;
+      globalThis.__phoebeSentryGlobalHandlersInstalled = true;
+      const url = () => typeof location !== "undefined" ? String(location.href || "") : "";
+      const userAgent = () => typeof navigator !== "undefined" ? String(navigator.userAgent || "") : "";
+      const errorMessage = (error, fallback) => {
+        if (error && error.message) return String(error.message);
+        return String(fallback || error || "Unknown browser error");
+      };
+      const errorType = (error, fallback) => {
+        if (error && error.name) return String(error.name);
+        return String(fallback || "Error");
+      };
+      const errorStack = (error) => error && error.stack ? String(error.stack) : "";
+      window.addEventListener("error", (event) => {
+        const error = event.error;
+        const message = errorMessage(error, event.message);
+        callback(message, errorType(error, "Error"), errorStack(error), url(), userAgent());
+      });
+      window.addEventListener("unhandledrejection", (event) => {
+        const reason = event.reason;
+        const message = errorMessage(reason, reason);
+        callback(message, errorType(reason, "UnhandledRejection"), errorStack(reason), url(), userAgent());
+      });
+    }
+    """,
+)
+private external fun installGlobalErrorHandlers(
+    callback: (String, String, String, String, String) -> Unit,
+)
+
+private fun Throwable.telemetryType(): String =
+    toString().substringBefore(':').ifBlank { "Throwable" }

--- a/feature/home/src/commonMain/kotlin/com/phoebe/app/feature/home/HomeRoutes.kt
+++ b/feature/home/src/commonMain/kotlin/com/phoebe/app/feature/home/HomeRoutes.kt
@@ -27,6 +27,7 @@ data class DesktopHomeRouteState(
     val decadeMixNotice: String? = null,
     val radioStations: List<PlexRadioStation> = emptyList(),
     val radioStartingIds: Set<String> = emptySet(),
+    val showPopularMix: Boolean = true,
 )
 
 @Immutable
@@ -102,6 +103,7 @@ fun DesktopHomeRoute(
         posterLoading = state.posterLoading,
         onPlayPersonalMix = actions.onPlayPersonalMix,
         onPlayPopularMix = actions.onPlayPopularMix,
+        showPopularMix = state.showPopularMix,
         onPlayTracks = actions.onPlayTracks,
         onAddToUpNext = actions.onAddToUpNext,
         onDownload = actions.onDownload,

--- a/feature/home/src/commonMain/kotlin/com/phoebe/app/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/phoebe/app/feature/home/HomeScreen.kt
@@ -148,6 +148,7 @@ data class MobileHomeRouteState(
     val radioStartingIds: Set<String>,
     val decadeMixNotice: String?,
     val homeScreenLayoutMode: HomeScreenLayoutMode = HomeScreenLayoutMode.Default,
+    val showPopularMix: Boolean = true,
 )
 
 @Immutable
@@ -213,6 +214,7 @@ fun MobileHomeRoute(
         posterLoading = routeState.posterLoading,
         onPlayPersonalMix = callbacks.onPlayPersonalMix,
         onPlayPopularMix = callbacks.onPlayPopularMix,
+        showPopularMix = routeState.showPopularMix,
         onPlayTracks = callbacks.onPlayTracks,
         onAddToUpNext = callbacks.onAddToUpNext,
         onDownload = callbacks.onDownload,
@@ -269,6 +271,7 @@ fun DesktopHomeScreen(
     posterLoading: HomePosterLoadingState = HomePosterLoadingState(),
     onPlayPersonalMix: () -> Unit = {},
     onPlayPopularMix: () -> Unit = {},
+    showPopularMix: Boolean = true,
     onPlayTracks: (List<Track>, Int) -> Unit,
     onAddToUpNext: (Track) -> Unit,
     onDownload: (Track) -> Unit,
@@ -322,7 +325,7 @@ fun DesktopHomeScreen(
         normalizedHomeSections(homeSections).forEach { section ->
             when (section) {
                 HomeSection.Mixes -> item("mixes") {
-                    DesktopMixesPanel(onPlayPersonalMix, onPlayPopularMix, posterLoading, radioStations, radioStartingIds, onPlayRadioStation, onClearDecadeMixNotice, panelStyle = panelStyle) {
+                    DesktopMixesPanel(onPlayPersonalMix, onPlayPopularMix, showPopularMix, posterLoading, radioStations, radioStartingIds, onPlayRadioStation, onClearDecadeMixNotice, panelStyle = panelStyle) {
                         showDecadeMix = true
                     }
                 }
@@ -406,6 +409,7 @@ fun MobileHomeScreen(
     posterLoading: HomePosterLoadingState = HomePosterLoadingState(),
     onPlayPersonalMix: () -> Unit = {},
     onPlayPopularMix: () -> Unit = {},
+    showPopularMix: Boolean = true,
     onPlayTracks: (List<Track>, Int) -> Unit,
     onAddToUpNext: (Track) -> Unit,
     onDownload: (Track) -> Unit,
@@ -470,6 +474,7 @@ fun MobileHomeScreen(
                 posterLoading = posterLoading,
                 onPlayPersonalMix = onPlayPersonalMix,
                 onPlayPopularMix = onPlayPopularMix,
+                showPopularMix = showPopularMix,
                 radioStations = radioStations,
                 radioStartingIds = radioStartingIds,
                 onPlayRadioStation = onPlayRadioStation,
@@ -513,6 +518,7 @@ fun MobileHomeScreen(
                 posterLoading = posterLoading,
                 onPlayPersonalMix = onPlayPersonalMix,
                 onPlayPopularMix = onPlayPopularMix,
+                showPopularMix = showPopularMix,
                 radioStations = radioStations,
                 radioStartingIds = radioStartingIds,
                 onPlayRadioStation = onPlayRadioStation,
@@ -722,6 +728,7 @@ private fun MobileHomeContent(
     posterLoading: HomePosterLoadingState,
     onPlayPersonalMix: () -> Unit,
     onPlayPopularMix: () -> Unit,
+    showPopularMix: Boolean,
     radioStations: List<PlexRadioStation>,
     radioStartingIds: Set<String>,
     onPlayRadioStation: (PlexRadioStation) -> Unit,
@@ -808,12 +815,13 @@ private fun MobileHomeContent(
                                 posterLoading = posterLoading,
                                 radioStations = radioStations,
                                 radioStartingIds = radioStartingIds,
+                                showPopularMix = showPopularMix,
                                 onPlayRadioStation = onPlayRadioStation,
                                 onClearDecadeMixNotice = onClearDecadeMixNotice,
                                 onShowDecadeMix = onShowDecadeMix,
                             )
                         } else {
-                            MobileMixesSection(onPlayPersonalMix, onPlayPopularMix, posterLoading, radioStations, radioStartingIds, onPlayRadioStation, onClearDecadeMixNotice, onShowDecadeMix)
+                            MobileMixesSection(onPlayPersonalMix, onPlayPopularMix, showPopularMix, posterLoading, radioStations, radioStartingIds, onPlayRadioStation, onClearDecadeMixNotice, onShowDecadeMix)
                         }
                     }
                     HomeSection.Collections -> item(key = "collections", contentType = "collections-section") {
@@ -941,6 +949,7 @@ private fun MobileExpandedHomeContent(
     posterLoading: HomePosterLoadingState,
     onPlayPersonalMix: () -> Unit,
     onPlayPopularMix: () -> Unit,
+    showPopularMix: Boolean,
     radioStations: List<PlexRadioStation>,
     radioStartingIds: Set<String>,
     onPlayRadioStation: (PlexRadioStation) -> Unit,
@@ -1038,6 +1047,7 @@ private fun MobileExpandedHomeContent(
                         ExpandedMixesShelf(
                             onPlayPersonalMix = onPlayPersonalMix,
                             onPlayPopularMix = onPlayPopularMix,
+                            showPopularMix = showPopularMix,
                             posterLoading = posterLoading,
                             radioStations = radioStations,
                             radioStartingIds = radioStartingIds,
@@ -1103,6 +1113,7 @@ private fun ExpandedHomeShelf(
 private fun ExpandedMixesShelf(
     onPlayPersonalMix: () -> Unit,
     onPlayPopularMix: () -> Unit,
+    showPopularMix: Boolean,
     posterLoading: HomePosterLoadingState,
     radioStations: List<PlexRadioStation>,
     radioStartingIds: Set<String>,
@@ -1121,15 +1132,17 @@ private fun ExpandedMixesShelf(
                 onClick = onPlayPersonalMix,
             )
         }
-        item(key = "popular-mix", contentType = "expanded-mix-action") {
-            HomeMixPosterCard(
-                "popular",
-                PhoebeIcon.PlaylistPlay,
-                Res.drawable.mix_popular,
-                Modifier.width(MobileHomePosterCardSize),
-                loading = posterLoading.popularMix,
-                onClick = onPlayPopularMix,
-            )
+        if (showPopularMix) {
+            item(key = "popular-mix", contentType = "expanded-mix-action") {
+                HomeMixPosterCard(
+                    "popular",
+                    PhoebeIcon.PlaylistPlay,
+                    Res.drawable.mix_popular,
+                    Modifier.width(MobileHomePosterCardSize),
+                    loading = posterLoading.popularMix,
+                    onClick = onPlayPopularMix,
+                )
+            }
         }
         item(key = "decade-mix", contentType = "expanded-mix-action") {
             HomeMixPosterCard("Decade Mix", PhoebeIcon.Calendar, Res.drawable.mix_decade, Modifier.width(MobileHomePosterCardSize)) {
@@ -1633,6 +1646,7 @@ private fun PhoneMixesAccordionSection(
     onToggle: () -> Unit,
     onPlayPersonalMix: () -> Unit,
     onPlayPopularMix: () -> Unit,
+    showPopularMix: Boolean,
     posterLoading: HomePosterLoadingState,
     radioStations: List<PlexRadioStation>,
     radioStartingIds: Set<String>,
@@ -1640,24 +1654,26 @@ private fun PhoneMixesAccordionSection(
     onClearDecadeMixNotice: () -> Unit,
     onShowDecadeMix: () -> Unit,
 ) {
-    val actions = listOf(
-        PhoneHomePosterAction(
+    val actions = buildList {
+        add(PhoneHomePosterAction(
             "Personal Mix",
             PhoebeIcon.Person,
             Res.drawable.mix_personal,
             enabled = !posterLoading.personalMix,
             loading = posterLoading.personalMix,
             onClick = onPlayPersonalMix,
-        ),
-        PhoneHomePosterAction(
-            "popular",
-            PhoebeIcon.PlaylistPlay,
-            Res.drawable.mix_popular,
-            enabled = !posterLoading.popularMix,
-            loading = posterLoading.popularMix,
-            onClick = onPlayPopularMix,
-        ),
-        PhoneHomePosterAction(
+        ))
+        if (showPopularMix) {
+            add(PhoneHomePosterAction(
+                "popular",
+                PhoebeIcon.PlaylistPlay,
+                Res.drawable.mix_popular,
+                enabled = !posterLoading.popularMix,
+                loading = posterLoading.popularMix,
+                onClick = onPlayPopularMix,
+            ))
+        }
+        add(PhoneHomePosterAction(
             label = "Decade Mix",
             icon = PhoebeIcon.Calendar,
             artwork = Res.drawable.mix_decade,
@@ -1665,8 +1681,8 @@ private fun PhoneMixesAccordionSection(
                 onClearDecadeMixNotice()
                 onShowDecadeMix()
             },
-        ),
-    ) + radioStations.map { station ->
+        ))
+    } + radioStations.map { station ->
         val starting = station.key in radioStartingIds
         PhoneHomePosterAction(
             label = if (starting) "Starting..." else station.mixTitle(),
@@ -2205,6 +2221,7 @@ private fun MobilePlayedHistoryShortcuts(
 private fun DesktopMixesPanel(
     onPlayPersonalMix: () -> Unit,
     onPlayPopularMix: () -> Unit,
+    showPopularMix: Boolean,
     posterLoading: HomePosterLoadingState,
     radioStations: List<PlexRadioStation>,
     radioStartingIds: Set<String>,
@@ -2229,15 +2246,17 @@ private fun DesktopMixesPanel(
                     onClick = onPlayPersonalMix,
                 )
             }
-            item("popular-mix", contentType = "mix-action") {
-                HomeMixPosterCard(
-                    "popular",
-                    PhoebeIcon.PlaylistPlay,
-                    Res.drawable.mix_popular,
-                    Modifier.width(148.dp),
-                    loading = posterLoading.popularMix,
-                    onClick = onPlayPopularMix,
-                )
+            if (showPopularMix) {
+                item("popular-mix", contentType = "mix-action") {
+                    HomeMixPosterCard(
+                        "popular",
+                        PhoebeIcon.PlaylistPlay,
+                        Res.drawable.mix_popular,
+                        Modifier.width(148.dp),
+                        loading = posterLoading.popularMix,
+                        onClick = onPlayPopularMix,
+                    )
+                }
             }
             item("decade-mix", contentType = "mix-action") {
                 HomeMixPosterCard(
@@ -2284,6 +2303,7 @@ private fun DesktopMixesPanel(
 private fun MobileMixesSection(
     onPlayPersonalMix: () -> Unit,
     onPlayPopularMix: () -> Unit,
+    showPopularMix: Boolean,
     posterLoading: HomePosterLoadingState,
     radioStations: List<PlexRadioStation>,
     radioStartingIds: Set<String>,
@@ -2303,15 +2323,17 @@ private fun MobileMixesSection(
                 onClick = onPlayPersonalMix,
             )
         }
-        item(key = "popular-mix", contentType = "mobile-mix-action") {
-            HomeMixPosterCard(
-                "popular",
-                PhoebeIcon.PlaylistPlay,
-                Res.drawable.mix_popular,
-                Modifier.width(MobileHomePosterCardSize),
-                loading = posterLoading.popularMix,
-                onClick = onPlayPopularMix,
-            )
+        if (showPopularMix) {
+            item(key = "popular-mix", contentType = "mobile-mix-action") {
+                HomeMixPosterCard(
+                    "popular",
+                    PhoebeIcon.PlaylistPlay,
+                    Res.drawable.mix_popular,
+                    Modifier.width(MobileHomePosterCardSize),
+                    loading = posterLoading.popularMix,
+                    onClick = onPlayPopularMix,
+                )
+            }
         }
         item(key = "decade-mix", contentType = "mobile-mix-action") {
             HomeMixPosterCard("Decade Mix", PhoebeIcon.Calendar, Res.drawable.mix_decade, Modifier.width(MobileHomePosterCardSize)) {

--- a/feature/radio/src/commonMain/kotlin/com/phoebe/app/feature/radio/RadioFeature.kt
+++ b/feature/radio/src/commonMain/kotlin/com/phoebe/app/feature/radio/RadioFeature.kt
@@ -54,7 +54,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
@@ -62,10 +64,12 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
@@ -85,6 +89,7 @@ import com.phoebe.app.ui.PhoebeIconView
 import com.phoebe.app.ui.PhoebeUi
 import com.phoebe.app.ui.SectionLabel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.debounce
@@ -1100,6 +1105,13 @@ private fun RadioMapStationSnackbar(
                     overflow = TextOverflow.Ellipsis,
                 )
             }
+            RadioStreamUrlBlock(
+                streamUrl = station.streamUrl,
+                homepageUrl = station.homepageUrl,
+                labelColor = snackbarSecondaryText,
+                valueColor = snackbarPrimaryText,
+                actionColor = PhoebeUi.accentLight,
+            )
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -1143,6 +1155,99 @@ private fun RadioMapStationSnackbar(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun RadioStreamUrlBlock(
+    streamUrl: String,
+    homepageUrl: String?,
+    labelColor: Color,
+    valueColor: Color,
+    actionColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    if (streamUrl.isBlank()) return
+
+    @Suppress("DEPRECATION")
+    val clipboardManager = LocalClipboardManager.current
+    val uriHandler = LocalUriHandler.current
+    var copied by remember(streamUrl) { mutableStateOf(false) }
+    val streamLink = streamUrl.radioExternalUrlOrNull()
+    val displayStreamUrl = remember(streamUrl) { streamUrl.radioUrlBreakText() }
+    val homepageLink = homepageUrl.radioExternalUrlOrNull()
+
+    LaunchedEffect(copied, streamUrl) {
+        if (copied) {
+            delay(1_600L)
+            copied = false
+        }
+    }
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        homepageLink?.let { url ->
+            Text(
+                "Home page",
+                color = labelColor,
+                fontSize = 10.sp,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                url,
+                color = actionColor,
+                fontSize = 11.sp,
+                lineHeight = 14.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                textDecoration = TextDecoration.Underline,
+                modifier = Modifier.clickable { uriHandler.openUri(url) },
+            )
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                "Stream URL",
+                color = labelColor,
+                fontSize = 10.sp,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            TextButton(
+                onClick = {
+                    clipboardManager.setText(AnnotatedString(streamUrl))
+                    copied = true
+                },
+                modifier = Modifier.widthIn(min = 72.dp),
+                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 2.dp),
+                colors = ButtonDefaults.textButtonColors(contentColor = actionColor),
+            ) {
+                Text(
+                    if (copied) "Copied" else "Copy URL",
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+        }
+        Text(
+            displayStreamUrl,
+            color = if (streamLink != null) actionColor else valueColor,
+            fontSize = 11.sp,
+            lineHeight = 14.sp,
+            overflow = TextOverflow.Clip,
+            textDecoration = if (streamLink != null) TextDecoration.Underline else null,
+            modifier = streamLink
+                ?.let { url -> Modifier.clickable { uriHandler.openUri(url) } }
+                ?: Modifier,
+        )
     }
 }
 
@@ -1394,44 +1499,82 @@ private fun RadioMapStationPanel(
     starting: Boolean,
     onPlay: () -> Unit,
 ) {
-    Row(
+    Column(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(8.dp))
             .background(PhoebeUi.elevatedFill)
             .border(BorderStroke(1.dp, PhoebeUi.border), RoundedCornerShape(8.dp))
             .padding(12.dp),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-        verticalAlignment = Alignment.CenterVertically,
+        verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        ArtworkImage(
-            seed = station.name,
-            thumbUrl = station.faviconUrlOrFallback,
-            fallbackThumbUrl = station.fallbackArtworkUrl,
-            modifier = Modifier.size(44.dp),
-            radius = 8.dp,
-            elevated = false,
-        )
-        Column(Modifier.weight(1f)) {
-            Text(station.name, color = PhoebeUi.primaryText, fontSize = 15.sp, fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis)
-            Text(
-                if (approximate) "Approximate: $locationLabel" else locationLabel,
-                color = PhoebeUi.secondaryText,
-                fontSize = 12.sp,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            ArtworkImage(
+                seed = station.name,
+                thumbUrl = station.faviconUrlOrFallback,
+                fallbackThumbUrl = station.fallbackArtworkUrl,
+                modifier = Modifier.size(44.dp),
+                radius = 8.dp,
+                elevated = false,
             )
-            Text(station.displaySubtitle, color = PhoebeUi.mutedText, fontSize = 12.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            Column(Modifier.weight(1f)) {
+                Text(station.name, color = PhoebeUi.primaryText, fontSize = 15.sp, fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text(
+                    if (approximate) "Approximate: $locationLabel" else locationLabel,
+                    color = PhoebeUi.secondaryText,
+                    fontSize = 12.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(station.displaySubtitle, color = PhoebeUi.mutedText, fontSize = 12.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            }
+            FilledTonalButton(onClick = onPlay, enabled = !starting) {
+                if (starting) {
+                    CircularProgressIndicator(modifier = Modifier.size(14.dp), strokeWidth = 2.dp, color = PhoebeUi.accentLight)
+                } else {
+                    Text("Play")
+                }
+            }
         }
-        FilledTonalButton(onClick = onPlay, enabled = !starting) {
-            if (starting) {
-                CircularProgressIndicator(modifier = Modifier.size(14.dp), strokeWidth = 2.dp, color = PhoebeUi.accentLight)
-            } else {
-                Text("Play")
+        RadioStreamUrlBlock(
+            streamUrl = station.streamUrl,
+            homepageUrl = station.homepageUrl,
+            labelColor = PhoebeUi.secondaryText,
+            valueColor = PhoebeUi.primaryText,
+            actionColor = PhoebeUi.accentLight,
+        )
+    }
+}
+
+private fun String.radioUrlBreakText(): String =
+    buildString(length + length / 8) {
+        this@radioUrlBreakText.forEach { char ->
+            append(char)
+            if (
+                char == '/' ||
+                char == '?' ||
+                char == '&' ||
+                char == '=' ||
+                char == '.' ||
+                char == ':' ||
+                char == '-'
+            ) {
+                append('\u200B')
             }
         }
     }
-}
+
+private fun String?.radioExternalUrlOrNull(): String? =
+    this
+        ?.trim()
+        ?.takeIf { url ->
+            url.startsWith("http://", ignoreCase = true) ||
+                url.startsWith("https://", ignoreCase = true)
+        }
 
 @Composable
 private fun RadioCountryRow(

--- a/feature/radio/src/commonMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.kt
+++ b/feature/radio/src/commonMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.kt
@@ -117,7 +117,7 @@ internal fun radioMapHtml(
               max-width: none;
               display: none;
               gap: 8px;
-              padding: 12px;
+              padding: 14px;
               border-radius: 8px;
               border: 1px solid var(--phoebe-map-popup-border);
               background: var(--phoebe-map-popup-bg);
@@ -129,7 +129,22 @@ internal fun radioMapHtml(
             #selectionName { font-size: 14px; font-weight: 800; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
             #selectionMeta { color: var(--phoebe-map-popup-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
             #selectionSub { color: var(--phoebe-map-popup-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-            #selectionActions { display: flex; align-items: center; justify-content: flex-end; gap: 6px; width: 100%; }
+            #selectionLinks { display: flex; flex-direction: column; gap: 6px; margin-top: 8px; }
+            .selectionLinkRow { display: none; align-items: start; column-gap: 8px; row-gap: 4px; min-width: 0; }
+            #selectionHomepageRow { grid-template-columns: 42px minmax(0, 1fr); }
+            #selectionStreamRow { grid-template-columns: 42px minmax(0, 1fr) auto; }
+            .selectionLinkLabel { color: var(--phoebe-map-popup-muted); font-size: 10px; font-weight: 800; line-height: 16px; }
+            #selection a.selectionUrl {
+              display: block;
+              min-width: 0;
+              color: ${markerTintCssHex.escapeJs()};
+              overflow-wrap: anywhere;
+              white-space: normal;
+              word-break: break-word;
+              text-decoration: underline;
+              cursor: pointer;
+            }
+            #selectionActions { display: flex; align-items: center; justify-content: flex-end; gap: 8px; width: 100%; margin-top: 12px; }
             #selection button {
               border: 0;
               border-radius: 999px;
@@ -146,6 +161,11 @@ internal fun radioMapHtml(
             #selection button.secondary {
               color: var(--phoebe-map-popup-secondary);
               background: var(--phoebe-map-popup-secondary-action);
+            }
+            #selection button.selectionInlineAction {
+              align-self: start;
+              padding: 4px 8px;
+              font-size: 11px;
             }
             #selectionPlaySpinner {
               display: none;
@@ -210,6 +230,60 @@ internal fun radioMapHtml(
               const pieces = [station.country, station.language, station.codec].filter((value) => value && String(value).trim().length > 0);
               return pieces.length > 0 ? pieces.join(' · ') : (station.approximate ? 'Approximate country location' : 'Station location');
             };
+            const externalUrl = (value) => {
+              const url = String(value || '').trim();
+              return /^https?:\/\//i.test(url) ? url : '';
+            };
+            const setSelectionLink = (rowId, linkId, rawUrl) => {
+              const row = document.getElementById(rowId);
+              const link = document.getElementById(linkId);
+              if (!row || !link) return;
+              const url = externalUrl(rawUrl);
+              if (!url) {
+                row.style.display = 'none';
+                link.textContent = '';
+                link.removeAttribute('href');
+                delete link.dataset.url;
+                return;
+              }
+              row.style.display = 'grid';
+              link.textContent = url;
+              link.title = url;
+              link.href = url;
+              link.dataset.url = url;
+            };
+            const resetCopyStreamLabel = () => {
+              const copyLabel = document.getElementById('selectionCopyStreamLabel');
+              if (copyLabel) copyLabel.textContent = 'Copy';
+            };
+            const openExternalRadioMapUrl = (rawUrl) => {
+              const url = externalUrl(rawUrl);
+              if (!url) return;
+              if (desktopBridgeBaseUrl) {
+                postDesktopBridge('open-url', null, null, null, url);
+              } else {
+                window.open(url, '_blank', 'noopener,noreferrer');
+              }
+            };
+            window.openRadioMapLink = (anchor) => {
+              openExternalRadioMapUrl(anchor?.dataset?.url || anchor?.href);
+              return false;
+            };
+            window.copySelectedRadioMapStreamUrl = async () => {
+              const url = String(selectedStationForAction?.streamUrl || '').trim();
+              if (!url) return;
+              try {
+                await navigator.clipboard.writeText(url);
+                const copyLabel = document.getElementById('selectionCopyStreamLabel');
+                if (copyLabel) {
+                  copyLabel.textContent = 'Copied';
+                  window.setTimeout(resetCopyStreamLabel, 1600);
+                }
+              } catch (_error) {
+                const copyLabel = document.getElementById('selectionCopyStreamLabel');
+                if (copyLabel) copyLabel.textContent = 'Copy failed';
+              }
+            };
             const setSelectionStarting = (starting) => {
               const playButton = document.getElementById('selectionPlay');
               const playLabel = document.getElementById('selectionPlayLabel');
@@ -238,6 +312,9 @@ internal fun radioMapHtml(
               document.getElementById('selectionName').textContent = station.name || 'Radio station';
               document.getElementById('selectionMeta').textContent = stationMeta(station);
               document.getElementById('selectionSub').textContent = station.subtitle || (station.approximate ? 'Approximate location' : 'Ready to play');
+              setSelectionLink('selectionHomepageRow', 'selectionHomepageLink', station.homepageUrl);
+              setSelectionLink('selectionStreamRow', 'selectionStreamLink', station.streamUrl);
+              resetCopyStreamLabel();
               setSelectionStarting(sourceStartingStationIds.has(String(station.id)));
               selection.style.display = 'block';
             };
@@ -283,10 +360,11 @@ internal fun radioMapHtml(
                 viewport,
               }, '*');
             };
-            const postDesktopBridge = (action, itemId, zoom, viewport) => {
+            const postDesktopBridge = (action, itemId, zoom, viewport, externalUrl) => {
               if (!desktopBridgeBaseUrl) return;
               const params = new URLSearchParams();
               if (itemId) params.set('id', itemId);
+              if (externalUrl) params.set('url', externalUrl);
               if (Number.isFinite(Number(zoom))) params.set('zoom', String(zoom));
               if (viewport) {
                 params.set('north', String(viewport.north));
@@ -370,7 +448,7 @@ internal fun radioMapHtml(
               return icon;
             };
             const markerDataSignature = (items) => items
-              .map((item) => [item.id, item.lat, item.lng, item.count, item.approximate ? 1 : 0, item.isCluster ? 1 : 0].join('@'))
+              .map((item) => [item.id, item.lat, item.lng, item.count, item.streamUrl || '', item.homepageUrl || '', item.approximate ? 1 : 0, item.isCluster ? 1 : 0].join('@'))
               .join('|');
             const indexStation = (station) => {
               if (!station) return;
@@ -563,6 +641,19 @@ internal fun radioMapHtml(
               <div id="selectionName">Radio station</div>
               <div id="selectionMeta">Station location</div>
               <div id="selectionSub">Ready to play</div>
+              <div id="selectionLinks">
+                <div id="selectionHomepageRow" class="selectionLinkRow">
+                  <span class="selectionLinkLabel">Home</span>
+                  <a id="selectionHomepageLink" class="selectionUrl" href="#" target="_blank" rel="noopener noreferrer" onclick="return window.openRadioMapLink(this)"></a>
+                </div>
+                <div id="selectionStreamRow" class="selectionLinkRow">
+                  <span class="selectionLinkLabel">Stream</span>
+                  <a id="selectionStreamLink" class="selectionUrl" href="#" target="_blank" rel="noopener noreferrer" onclick="return window.openRadioMapLink(this)"></a>
+                  <button id="selectionCopyStream" class="secondary selectionInlineAction" type="button" onclick="window.copySelectedRadioMapStreamUrl()">
+                    <span id="selectionCopyStreamLabel">Copy</span>
+                  </button>
+                </div>
+              </div>
             </div>
             <div id="selectionActions">
               <button id="selectionPlay" type="button" onclick="window.playSelectedRadioMapStation()">
@@ -624,6 +715,8 @@ private fun RadioMapItem.radioMapStationInfoJsonLine(): String =
           "language": "${station.language.orEmpty().escapeJs()}",
           "codec": "${station.codec.orEmpty().escapeJs()}",
           "subtitle": "${station.displaySubtitle.escapeJs()}",
+          "streamUrl": "${station.streamUrl.escapeJs()}",
+          "homepageUrl": "${station.homepageUrl.orEmpty().escapeJs()}",
         """.trimIndent()
         is RadioMapItem.Cluster -> ""
     }
@@ -656,6 +749,8 @@ private fun RadioStation.toRadioMapChildMarkerJson(
           "language": "${language.orEmpty().escapeJs()}",
           "codec": "${codec.orEmpty().escapeJs()}",
           "subtitle": "${displaySubtitle.escapeJs()}",
+          "streamUrl": "${streamUrl.escapeJs()}",
+          "homepageUrl": "${homepageUrl.orEmpty().escapeJs()}",
           "children": []
         }
     """.trimIndent()

--- a/feature/radio/src/commonTest/kotlin/com/phoebe/app/feature/radio/RadioMapItemTest.kt
+++ b/feature/radio/src/commonTest/kotlin/com/phoebe/app/feature/radio/RadioMapItemTest.kt
@@ -271,6 +271,7 @@ class RadioMapItemTest {
             id = "kexp-1",
             name = "KEXP's One",
             streamUrl = "https://stream.example/kexp-1",
+            homepageUrl = "https://kexp.example/",
             countryCode = "US",
             geoLat = 47.608,
             geoLong = -122.335,
@@ -324,6 +325,14 @@ class RadioMapItemTest {
         assertTrue(html.contains("playSelectedRadioMapStation"))
         assertTrue(html.contains("postMapMessage('playItem', station.id, null, null)"))
         assertTrue(html.contains("window.updateRadioMapSelection(station.id);"))
+        assertTrue(html.contains("selectionHomepageLink"))
+        assertTrue(html.contains("selectionStreamLink"))
+        assertTrue(html.contains("copySelectedRadioMapStreamUrl"))
+        assertTrue(html.contains("openExternalRadioMapUrl"))
+        assertTrue(html.contains("overflow-wrap: anywhere"))
+        assertTrue(html.contains("row.style.display = 'grid'"))
+        assertTrue(html.contains("\"streamUrl\": \"https://stream.example/kexp-1\""))
+        assertTrue(html.contains("\"homepageUrl\": \"https://kexp.example/\""))
         assertTrue(html.contains("currentViewportPayload"))
         assertFalse(html.contains("userInteractedWithMap"))
         assertFalse(html.contains("id=\"searchArea\""))

--- a/feature/radio/src/desktopMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.desktop.kt
+++ b/feature/radio/src/desktopMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.desktop.kt
@@ -208,6 +208,7 @@ private class DesktopRadioMapBrowserServer(
                 "/", "/radio-map" -> exchange.sendHtml(currentHtml())
                 "/select" -> exchange.handleItemAction(onSelected)
                 "/play" -> exchange.handlePlayAction(onPlay)
+                "/open-url" -> exchange.handleOpenUrl()
                 "/zoom" -> exchange.handleZoom()
                 "/viewport" -> exchange.handleViewport()
                 else -> exchange.sendText("Not found", status = 404)
@@ -236,10 +237,7 @@ private class DesktopRadioMapBrowserServer(
     }
 
     fun openInBrowser() {
-        val desktop = runCatching { if (Desktop.isDesktopSupported()) Desktop.getDesktop() else null }.getOrNull()
-        if (desktop != null && desktop.isSupported(Desktop.Action.BROWSE)) {
-            runCatching { desktop.browse(URI(url)) }
-        }
+        openUrlInBrowser(url)
     }
 
     fun dispose() {
@@ -274,6 +272,14 @@ private class DesktopRadioMapBrowserServer(
         sendText("ok")
     }
 
+    private fun HttpExchange.handleOpenUrl() {
+        val url = queryParameters()["url"].orEmpty().trim()
+        if (url.isRadioMapExternalUrl()) {
+            executor.execute { openUrlInBrowser(url) }
+        }
+        sendText("ok")
+    }
+
     private fun HttpExchange.handleZoom() {
         val zoom = queryParameters()["zoom"]?.toDoubleOrNull()
         if (zoom != null && zoom.isFinite()) {
@@ -296,7 +302,17 @@ private class DesktopRadioMapBrowserServer(
         }
         sendText("ok")
     }
+
+    private fun openUrlInBrowser(url: String) {
+        val desktop = runCatching { if (Desktop.isDesktopSupported()) Desktop.getDesktop() else null }.getOrNull()
+        if (desktop != null && desktop.isSupported(Desktop.Action.BROWSE)) {
+            runCatching { desktop.browse(URI(url)) }
+        }
+    }
 }
+
+private fun String.isRadioMapExternalUrl(): Boolean =
+    startsWith("http://", ignoreCase = true) || startsWith("https://", ignoreCase = true)
 
 private data class DesktopRadioMapSnapshot(
     val url: String,

--- a/feature/radio/src/wasmJsMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.web.kt
+++ b/feature/radio/src/wasmJsMain/kotlin/com/phoebe/app/feature/radio/RadioMapHost.web.kt
@@ -248,11 +248,22 @@ private external fun createRadioMapIframe(
       const bottom = Math.min(window.innerHeight || top, top + requestedHeight);
       const clippedWidth = Math.max(0, right - left);
       const clippedHeight = Math.max(0, bottom - top);
+      iframe.dataset.phoebeMapLeft = String(left);
+      iframe.dataset.phoebeMapTop = String(top);
+      iframe.dataset.phoebeMapWidth = String(clippedWidth);
+      iframe.dataset.phoebeMapHeight = String(clippedHeight);
+      const bridgeHost = typeof window !== "undefined" ? window : globalThis;
+      const bridge = bridgeHost.PhoebeRadioMap || {};
+      bridgeHost.PhoebeRadioMap = bridge;
+      globalThis.PhoebeRadioMap = bridge;
+      const occlusionTop = bridge.occlusionTopPx == null ? null : Math.max(0, Number(bridge.occlusionTopPx) / scale);
+      const occludedBottom = Math.min(bottom, occlusionTop == null ? bottom : occlusionTop);
+      const occludedHeight = Math.max(0, occludedBottom - top);
       iframe.style.left = left + "px";
       iframe.style.top = top + "px";
       iframe.style.width = clippedWidth + "px";
-      iframe.style.height = clippedHeight + "px";
-      iframe.style.display = clippedWidth > 0 && clippedHeight > 0 ? "block" : "none";
+      iframe.style.height = occludedHeight + "px";
+      iframe.style.display = clippedWidth > 0 && occludedHeight > 0 ? "block" : "none";
       if (iframe.contentWindow) {
         iframe.contentWindow.dispatchEvent(new Event("resize"));
       }

--- a/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopSandboxPlayback.kt
+++ b/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopSandboxPlayback.kt
@@ -23,7 +23,6 @@ internal object DesktopSandboxPlayback {
             }
         }
         return DesktopPlaybackStartupPolicy.sampledPlaybackExtensionFromSuffix(extension)
-            ?: desktopMp3ExtensionFromSuffix(extension)
     }
 
     fun streamingSampledExtensionFromSuffix(extension: String): String? {
@@ -34,12 +33,11 @@ internal object DesktopSandboxPlayback {
             }
         }
         return DesktopPlaybackStartupPolicy.streamingSampledExtensionFromSuffix(extension)
-            ?: desktopMp3ExtensionFromSuffix(extension)
     }
 
     /**
-     * Prefer progressive Java Sound decoding for sampled-friendly remote streams. The desktop
-     * player still falls back to fully buffered playback when streaming setup fails.
+     * Prefer progressive Java Sound decoding for sampled-friendly remote streams. MP3 is intentionally
+     * limited to Flatpak where JavaFX media is unavailable; the Java Sound MP3 SPI can produce static.
      */
     fun shouldStreamRemoteSampledPlayback(uri: String): Boolean {
         if (!DesktopPlaybackStartupPolicy.isRemoteUri(uri)) return false
@@ -83,10 +81,5 @@ internal object DesktopSandboxPlayback {
             return track.streamUrl
         }
         return track.flatpakSandboxTranscodeUrl() ?: track.streamUrl
-    }
-
-    private fun desktopMp3ExtensionFromSuffix(extension: String): String? = when (extension.lowercase()) {
-        "mp3", "mpeg", "mpga" -> "mp3"
-        else -> null
     }
 }

--- a/playback/src/desktopTest/kotlin/com/phoebe/app/RealAudioPlaybackDesktopTest.kt
+++ b/playback/src/desktopTest/kotlin/com/phoebe/app/RealAudioPlaybackDesktopTest.kt
@@ -436,7 +436,7 @@ class RealAudioPlaybackDesktopTest {
     }
 
     @Test
-    fun remoteNoExtensionMp3StreamUsesSampledStreamFromContentType() {
+    fun remoteNoExtensionMp3StreamUsesJavaFxInsteadOfSampledPlayback() {
         assumeRealAudioTestsEnabled()
 
         val fixture = fixtureBytes("wikimedia-example.mp3")
@@ -465,17 +465,17 @@ class RealAudioPlaybackDesktopTest {
 
             assertTrue(
                 waitUntil(timeoutMs = 25_000L) {
-                    diagnostics.hasEngine(PlaybackEnginePath.SampledStream) &&
-                        player.state.value.isPlaying &&
-                        diagnostics.hasEnergy(PlaybackEnginePath.SampledStream)
+                    diagnostics.hasEngine(PlaybackEnginePath.JavaFxMediaPlayer) &&
+                        player.state.value.isPlaying
                 },
-                "No-extension remote MP3 should use sampled stream after probing Content-Type; " +
+                "No-extension remote MP3 should use JavaFX instead of Java Sound; " +
                     "engines=${diagnostics.engineEvents()} requests=${requestEvents.toList()} " +
                     "errors=${diagnostics.errorEvents()}",
             )
             assertFalse(
-                diagnostics.hasEngine(PlaybackEnginePath.JavaFxMediaPlayer),
-                "No-extension remote MP3 should not fall through to JavaFX once sampled streaming starts.",
+                diagnostics.hasEngine(PlaybackEnginePath.SampledStream) ||
+                    diagnostics.hasEngine(PlaybackEnginePath.SampledClip),
+                "No-extension remote MP3 must not use Java Sound because MP3 decoding can produce static",
             )
         } finally {
             player.releaseForTests()

--- a/playback/src/desktopTest/kotlin/com/phoebe/app/player/DesktopPlaybackStartupPolicyTest.kt
+++ b/playback/src/desktopTest/kotlin/com/phoebe/app/player/DesktopPlaybackStartupPolicyTest.kt
@@ -183,12 +183,12 @@ class DesktopPlaybackStartupPolicyTest {
     }
 
     @Test
-    fun desktopMp3UsesJavaSoundInsteadOfWaitingOnJavaFx() {
+    fun desktopMp3UsesJavaFxInsteadOfJavaSound() {
         DesktopSandboxPlayback.flatpakSandboxOverride = { false }
         try {
-            assertEquals("mp3", DesktopSandboxPlayback.sampledPlaybackExtensionFromSuffix("mp3"))
-            assertEquals("mp3", DesktopSandboxPlayback.streamingSampledExtensionFromSuffix("mp3"))
-            assertTrue(
+            assertEquals(null, DesktopSandboxPlayback.sampledPlaybackExtensionFromSuffix("mp3"))
+            assertEquals(null, DesktopSandboxPlayback.streamingSampledExtensionFromSuffix("mp3"))
+            assertFalse(
                 DesktopSandboxPlayback.shouldStreamRemoteSampledPlayback(
                     "https://music.example.test/library/track.mp3?token=abc",
                 ),

--- a/web-screenshot-tests/phoebe-e2e.spec.ts
+++ b/web-screenshot-tests/phoebe-e2e.spec.ts
@@ -49,6 +49,43 @@ test('web chromecast mock connects and loads a remote stream', async ({ page }) 
   expect(results.message).toContain('mock Chromecast connected');
 });
 
+test('web chromecast bootstrap tolerates missing chrome.cast namespace', async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', error => pageErrors.push(error.message));
+  await page.route('https://www.gstatic.com/cv/js/sender/**', route => route.abort());
+  await page.route('**/phoebe.js', route => route.abort());
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+  const options = await page.evaluate(() => {
+    let observedOptions: { receiverApplicationId?: string; autoJoinPolicy?: string } | null = null;
+    const testWindow = window as unknown as {
+      __onGCastApiAvailable: (isAvailable: boolean) => void;
+      cast: unknown;
+      chrome: unknown;
+    };
+    testWindow.cast = {
+      framework: {
+        CastContext: {
+          getInstance: () => ({
+            setOptions: (nextOptions: { receiverApplicationId?: string; autoJoinPolicy?: string }) => {
+              observedOptions = nextOptions;
+            },
+          }),
+        },
+      },
+    };
+    testWindow.chrome = {};
+
+    testWindow.__onGCastApiAvailable(true);
+
+    return observedOptions;
+  });
+
+  expect(pageErrors).toEqual([]);
+  expect(options).toEqual({ receiverApplicationId: 'CC1AD845' });
+});
+
 test('web local playback regression starts real browser audio after tap', async ({ page }) => {
   await page.goto('/?e2e=localPlaybackRegression', { waitUntil: 'domcontentloaded' });
   await page.waitForFunction(


### PR DESCRIPTION
## Summary
- add radio station homepage/stream URL display, copy, and external-open flows across Compose and embedded map UI
- add mobile radio-map occlusion handling so the web iframe stays clear of the expanded player sheet
- add manual Sentry envelope telemetry for web and iOS, plus a safer web Chromecast bootstrap and desktop MP3 playback policy update
- hide the Plex-only popular mix action for unsupported providers

## Validation
- `./gradlew :composeApp:desktopTest :feature:radio:desktopTest :composeApp:wasmJsBrowserTest --continue`
- `PHOEBE_WEB_PORT=8107 npx playwright test web-screenshot-tests/phoebe-e2e.spec.ts -g "web chromecast bootstrap tolerates missing chrome.cast namespace"`
- `./gradlew :composeApp:compileKotlinIosSimulatorArm64`
- `./gradlew :playback:desktopTest`

## Notes
- Left local Xcode UI state unstaged: `iosApp/iosApp.xcodeproj/project.xcworkspace/xcuserdata/joeroskopf.xcuserdatad/UserInterfaceState.xcuserstate`.