### PR TITLE
[codex] Fix macOS release smoke fixture

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -533,7 +533,7 @@ jobs:
             echo "::error::Could not find macOS DMG artifact"
             exit 1
           fi
-          fixture="${PWD}/composeApp/src/commonTest/resources/test-audio/wikimedia-example.mp3"
+          fixture="${PWD}/composeApp/src/commonTest/resources/test-audio/wikimedia-example.wav"
           if [[ ! -f "${fixture}" ]]; then
             echo "::error::Missing playback smoke fixture: ${fixture}"
             exit 1


### PR DESCRIPTION
## Summary

- Switch the macOS notarized DMG playback smoke fixture from `wikimedia-example.mp3` to `wikimedia-example.wav`.
- Keeps the release job verifying the signed/notarized app launches from the DMG and reports playback, while avoiding the JavaFX-only MP3 path that stalled on the hosted macOS runner.

## Root cause

The failed release job selected `JavaFxMediaPlayer` for the MP3 fixture and timed out without an error:

- run: https://github.com/j-roskopf/Phoebe/actions/runs/28527261069/job/84567010343
- failure: `PHOEBE_PLAYBACK_SMOKE_FAILED reason=timeout timeoutMs=20000 engines=JavaFxMediaPlayer errors=none buffering=false playing=false`

A recent desktop playback policy change intentionally routes non-Flatpak MP3 playback through JavaFX to avoid Java Sound MP3 static. The macOS release smoke was still using an MP3 fixture, so the packaged smoke became coupled to JavaFX MP3 startup behavior on the hosted macOS runner.

## Validation

- `git diff --check`
- `test -f composeApp/src/commonTest/resources/test-audio/wikimedia-example.wav`
- `./gradlew :composeApp:run --args="--phoebe-playback-smoke=$(pwd)/composeApp/src/commonTest/resources/test-audio/wikimedia-example.wav --phoebe-playback-smoke-timeout-ms=20000"`
  - observed `PHOEBE_PLAYBACK_SMOKE_OK firstAudioMs=230 engines=SampledClip errors=none`