### PR TITLE
[codex] Use Ogg for macOS playback smoke

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -95,12 +95,17 @@ jobs:
           smoke_dir="${HOME}/Downloads/phoebe-smoke"
           mkdir -p "${smoke_dir}"
           cp composeApp/src/commonTest/resources/test-audio/wikimedia-example.mp3 "${smoke_dir}/wikimedia-example.mp3"
+          cp composeApp/src/commonTest/resources/test-audio/wikimedia-example.ogg "${smoke_dir}/wikimedia-example.ogg"
           if [[ -f composeApp/src/commonTest/resources/test-audio/wikimedia-example.wav ]]; then
             cp composeApp/src/commonTest/resources/test-audio/wikimedia-example.wav "${smoke_dir}/wikimedia-example.wav"
           fi
+          smoke_fixture="${smoke_dir}/wikimedia-example.mp3"
+          if [[ "${RUNNER_OS}" == "macOS" ]]; then
+            smoke_fixture="${smoke_dir}/wikimedia-example.ogg"
+          fi
           {
             echo "PHOEBE_SMOKE_DIR=${smoke_dir}"
-            echo "PHOEBE_SMOKE_FIXTURE=${smoke_dir}/wikimedia-example.mp3"
+            echo "PHOEBE_SMOKE_FIXTURE=${smoke_fixture}"
             echo "PHOEBE_FLATPAK_SMOKE_FIXTURE=${smoke_dir}/wikimedia-example.wav"
           } >> "${GITHUB_ENV}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -533,7 +533,7 @@ jobs:
             echo "::error::Could not find macOS DMG artifact"
             exit 1
           fi
-          fixture="${PWD}/composeApp/src/commonTest/resources/test-audio/wikimedia-example.wav"
+          fixture="${PWD}/composeApp/src/commonTest/resources/test-audio/wikimedia-example.ogg"
           if [[ ! -f "${fixture}" ]]; then
             echo "::error::Missing playback smoke fixture: ${fixture}"
             exit 1


### PR DESCRIPTION
## Summary

- Use the downloaded `wikimedia-example.ogg` fixture for macOS playback smoke in both Release and Package Smoke workflows.
- Keep Linux and Windows package smoke on their existing MP3 fixture.
- Copy the Ogg fixture into the Unix package smoke directory and select it only when `RUNNER_OS` is `macOS`.

## Root cause

The first macOS Release fix switched the DMG smoke to WAV, but macOS GitHub runners do not have `ffmpeg`, so `fetch-test-audio.sh` skips derived WAV/FLAC/M4A fixtures there.

The fresh main run after PR #122 showed both adjacent problems:

- Release macOS failed before playback with `Missing playback smoke fixture: .../wikimedia-example.wav`.
- Package Smoke macOS still used MP3 and timed out with `PHOEBE_PLAYBACK_SMOKE_FAILED reason=timeout ... engines=JavaFxMediaPlayer errors=none ... wikimedia-example.mp3`.

Ogg is downloaded directly from Wikimedia by the fetch script and routes through the sampled desktop playback path covered by existing desktop tests.

## Validation

- `git diff --check`
- `test -f composeApp/src/commonTest/resources/test-audio/wikimedia-example.ogg`
- `./gradlew :composeApp:run --args="--phoebe-playback-smoke=$(pwd)/composeApp/src/commonTest/resources/test-audio/wikimedia-example.ogg --phoebe-playback-smoke-timeout-ms=20000"`
  - observed `PHOEBE_PLAYBACK_SMOKE_OK firstAudioMs=2068 engines=SampledClip errors=none`