### PR TITLE
[codex] Fix Plex refresh stall on mobile web

### DIFF
--- a/composeApp/src/desktopTest/kotlin/com/phoebe/app/CatalogRepositoryRefreshDesktopTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/phoebe/app/CatalogRepositoryRefreshDesktopTest.kt
@@ -478,10 +478,11 @@ class CatalogRepositoryRefreshDesktopTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun refreshCompletesWhenPlexTrackPageHangs() = runTest {
+    fun refreshFallsBackToAlbumTracksWhenPlexTrackPageHangs() = runTest {
         val (db, d) = newInMemoryPhoebeDatabase()
         driver = d
         val hungTrackPageStarted = CompletableDeferred<Unit>()
+        var albumTrackFallbackRequested = false
         val engine = MockEngine { request ->
             when (request.url.encodedPath) {
                 "/library/sections/1/all" -> if (request.url.parameters["type"] == "10") {
@@ -497,6 +498,10 @@ class CatalogRepositoryRefreshDesktopTest {
                     respondJson(artistsJson())
                 }
                 "/library/sections/1/albums" -> respondJson(albumsJson())
+                "/library/metadata/a1/children" -> {
+                    albumTrackFallbackRequested = true
+                    respondJson(albumTracksJson())
+                }
                 "/playlists" -> respondJson(playlistsJson(trackCount = 0))
                 else -> respond("", HttpStatusCode.NotFound)
             }
@@ -525,6 +530,7 @@ class CatalogRepositoryRefreshDesktopTest {
 
         assertFalse(repo.catalogRefreshing.value)
         assertEquals(CatalogSyncPhase.Complete, repo.catalogSyncState.value.phase)
+        assertTrue(albumTrackFallbackRequested)
         assertEquals(listOf("plex:t1"), repo.catalog.value.tracksByParent["plex:a1"].orEmpty().map { it.id })
     }
 

--- a/core/platform/src/wasmJsMain/kotlin/com/phoebe/app/platform/WebPlatform.kt
+++ b/core/platform/src/wasmJsMain/kotlin/com/phoebe/app/platform/WebPlatform.kt
@@ -180,7 +180,7 @@ actual fun remoteArtworkCacheMaxEstimatedBytes(): Long = 10L * 1024L * 1024L
 
 actual fun remoteArtworkLoadParallelism(): Int = 8
 
-actual fun catalogTrackIndexParallelism(): Int = 4
+actual fun catalogTrackIndexParallelism(): Int = 1
 
 actual fun downloadParallelism(): Int = 3
 

--- a/data/catalog/src/commonMain/kotlin/com/phoebe/app/data/CatalogRepository.kt
+++ b/data/catalog/src/commonMain/kotlin/com/phoebe/app/data/CatalogRepository.kt
@@ -2827,7 +2827,9 @@ class CatalogRepository(
         val pendingBatch = mutableListOf<Track>()
         val batchMutex = Mutex()
         val progressMutex = Mutex()
+        val incompleteMutex = Mutex()
         var loadedTrackEstimate = firstPage.tracks.size
+        var incomplete = false
 
         suspend fun flushBatch(publishToMemory: Boolean) {
             val batch = batchMutex.withLock {
@@ -2846,6 +2848,13 @@ class CatalogRepository(
                 pendingBatch.size >= TrackIndexPageSize
             }
             if (shouldFlush) flushBatch(publishToMemory = false)
+        }
+
+        suspend fun markIncomplete(start: Int, reason: String) {
+            incompleteMutex.withLock { incomplete = true }
+            PhoebeLog.d("CatalogRepository") {
+                "Plex track index incomplete at start=$start: $reason"
+            }
         }
 
         enqueueTracks(firstPage.tracks)
@@ -2893,8 +2902,16 @@ class CatalogRepository(
                         token = token,
                         start = offset,
                         size = pageSize,
-                    ) ?: continue
+                    )
+                    if (page == null) {
+                        markIncomplete(offset, "page unavailable")
+                        pageQueue.cancel()
+                        break
+                    }
                     if (page.tracks.isEmpty()) {
+                        if (totalTracks != null && offset < maxOffset) {
+                            markIncomplete(offset, "empty page before expected total")
+                        }
                         pageQueue.cancel()
                         break
                     }
@@ -2912,7 +2929,7 @@ class CatalogRepository(
         trace?.disk("hydrateInMemoryTracksFromDatabase") {
             hydrateInMemoryTracksFromDatabase(preserveFrom = preserveTracksFrom)
         } ?: hydrateInMemoryTracksFromDatabase(preserveFrom = preserveTracksFrom)
-        true
+        !incompleteMutex.withLock { incomplete }
     }
 
     private suspend fun plexTrackIndexPageOrNull(
@@ -2932,6 +2949,7 @@ class CatalogRepository(
                         token = token,
                         start = start,
                         size = size,
+                        timeoutMs = timeoutMs,
                     )
                 }.onFailure { error ->
                     if (error is CancellationException) throw error

--- a/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexClient.kt
+++ b/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexClient.kt
@@ -16,6 +16,7 @@ import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.plugins.timeout
 import io.ktor.client.request.get
 import io.ktor.client.request.delete
 import io.ktor.client.request.header
@@ -889,9 +890,11 @@ class PlexClient(
         token: String,
         start: Int,
         size: Int,
+        timeoutMs: Long? = null,
     ): PlexTrackPage {
         val response: PlexMediaContainerResponse = withReachableBase(server) { base ->
             val response = httpClient.get("$base/library/sections/${library.key}/all") {
+                timeoutMs?.let { timeout { requestTimeoutMillis = it } }
                 plexServerAuth(token)
                 header(HttpHeaders.Accept, "application/json")
                 header("X-Plex-Container-Start", start.toString())

--- a/test-support/network/kotlin/com/phoebe/app/testing/TestHttpClient.kt
+++ b/test-support/network/kotlin/com/phoebe/app/testing/TestHttpClient.kt
@@ -3,11 +3,15 @@ package com.phoebe.app.testing
 import com.phoebe.app.data.PhoebeDataJson
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 
 fun testHttpClient(engine: MockEngine): HttpClient =
     HttpClient(engine) {
+        install(HttpTimeout) {
+            requestTimeoutMillis = 60_000
+        }
         install(ContentNegotiation) {
             json(PhoebeDataJson)
         }


### PR DESCRIPTION
## Summary
- Treat incomplete Plex paged track indexing as a failed fast path so refresh falls back to album-track indexing instead of stopping at the first 500-song page.
- Pass the Plex track page timeout into the underlying Ktor request so hung mobile-web requests are cancelled at the HTTP layer.
- Reduce web catalog track indexing parallelism to one request at a time to avoid mobile browser fetch throttling on large libraries.

## Root Cause
On Plex, the paged track index uses 500-song pages. If page 2 or a later page timed out on mobile web, the indexer could continue and report success after only the first page, leaving refresh apparently stuck around `500 / 16k` instead of falling back to the slower album-track path.

## Validation
- `./gradlew :composeApp:desktopTest --tests com.phoebe.app.CatalogRepositoryRefreshDesktopTest :data:providers:plex:compileKotlinWasmJs :data:catalog:compileKotlinWasmJs`
