### PR TITLE
[codex] Fix top tracks mix loading

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
@@ -117,6 +117,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 
 data class PendingDuplicatePlaylistAdd(
     val playlist: Playlist,
@@ -1637,17 +1638,17 @@ class AppState(
 
     fun playPopularMix() = scope.launch {
         val popularPool = runCatching {
-            withTimeout(MixProviderLoadTimeoutMs) {
+            withTimeoutOrNull(MixProviderLoadTimeoutMs) {
                 dependencies.catalogRepository.popularSongsForLibrary(
                     session = session.value,
                     limit = PopularMixTrackLimit,
                 )
             }
         }.getOrElse { error ->
-            if (error is CancellationException && error !is TimeoutCancellationException) throw error
+            if (error is CancellationException) throw error
             PhoebeLog.d("AppState") { "popular mix provider load failed: ${error.message}" }
-            emptyList()
-        }
+            null
+        }.orEmpty()
         if (popularPool.isEmpty()) {
             mutableMessage.value = "No popular songs found yet."
             return@launch
@@ -1668,17 +1669,17 @@ class AppState(
         val cachedPool = dependencies.catalogRepository.cachedPopularTracksForLibrary(currentSession)
         val topTracksPool = cachedPool.takeIf { it.isNotEmpty() }
             ?: runCatching {
-                withTimeout(MixProviderLoadTimeoutMs) {
+                withTimeoutOrNull(MixProviderLoadTimeoutMs) {
                     dependencies.catalogRepository.popularSongsForLibrary(
                         session = currentSession,
                         limit = PopularMixTrackLimit,
                     )
                 }
             }.getOrElse { error ->
-                if (error is CancellationException && error !is TimeoutCancellationException) throw error
+                if (error is CancellationException) throw error
                 PhoebeLog.d("AppState") { "top tracks mix quick provider load failed: ${error.message}" }
-                emptyList()
-            }
+                null
+            }.orEmpty()
         if (topTracksPool.isEmpty()) {
             mutableMessage.value = "No top tracks found yet."
             return@launch

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
@@ -1581,13 +1581,15 @@ class AppState(
 
     fun warmTopTracksMixTracks() {
         val currentSession = session.value
-        if (!currentSession.isPlex()) return
+        val plexSession = currentSession?.takeIf { it.isPlex() } ?: return
         val signature = currentSession.topTracksMixSessionSignature() ?: return
         if (signature == topTracksMixWarmSignature) return
         topTracksMixWarmSignature = signature
         scope.launch {
             runCatching {
                 val tracks = dependencies.catalogRepository.cachedPopularTracksForLibrary(currentSession)
+                    .takeIf { it.isNotEmpty() }
+                    ?: startTopTracksMixBuild(plexSession, signature).await()
                 if (tracks.isEmpty()) {
                     topTracksMixWarmSignature = null
                 }
@@ -1635,12 +1637,14 @@ class AppState(
 
     fun playPopularMix() = scope.launch {
         val popularPool = runCatching {
-            dependencies.catalogRepository.popularSongsForLibrary(
-                session = session.value,
-                limit = PopularMixTrackLimit,
-            )
+            withTimeout(MixProviderLoadTimeoutMs) {
+                dependencies.catalogRepository.popularSongsForLibrary(
+                    session = session.value,
+                    limit = PopularMixTrackLimit,
+                )
+            }
         }.getOrElse { error ->
-            if (error is CancellationException) throw error
+            if (error is CancellationException && error !is TimeoutCancellationException) throw error
             PhoebeLog.d("AppState") { "popular mix provider load failed: ${error.message}" }
             emptyList()
         }
@@ -1662,21 +1666,18 @@ class AppState(
     fun playTopTracksMix() = scope.launch {
         val currentSession = session.value
         val cachedPool = dependencies.catalogRepository.cachedPopularTracksForLibrary(currentSession)
-        val signature = currentSession.topTracksMixSessionSignature()
         val topTracksPool = cachedPool.takeIf { it.isNotEmpty() }
-            ?: run {
-                val plexSession = currentSession?.takeIf { it.isPlex() } ?: return@run emptyList()
-                val buildSignature = signature ?: return@run emptyList()
-                val build = startTopTracksMixBuild(plexSession, buildSignature)
-                runCatching {
-                    build.await()
-                }.getOrElse { error ->
-                    if (error is CancellationException) throw error
-                    PhoebeLog.d("AppState") { "top tracks mix provider load failed: ${error.message}" }
-                    emptyList()
-                }.also { tracks ->
-                    if (tracks.isNotEmpty()) topTracksMixWarmSignature = buildSignature
+            ?: runCatching {
+                withTimeout(MixProviderLoadTimeoutMs) {
+                    dependencies.catalogRepository.popularSongsForLibrary(
+                        session = currentSession,
+                        limit = PopularMixTrackLimit,
+                    )
                 }
+            }.getOrElse { error ->
+                if (error is CancellationException && error !is TimeoutCancellationException) throw error
+                PhoebeLog.d("AppState") { "top tracks mix quick provider load failed: ${error.message}" }
+                emptyList()
             }
         if (topTracksPool.isEmpty()) {
             mutableMessage.value = "No top tracks found yet."
@@ -3115,6 +3116,7 @@ private const val PlaybackHistoryDedupeWindowMs = 30_000L
 
 private const val PopularMixTrackLimit = 500
 private const val PopularMixShuffleChunkSize = 50
+private const val MixProviderLoadTimeoutMs = 20_000L
 
 private const val PlayHistoryCatalogResolveTimeoutMs = 1_500L
 


### PR DESCRIPTION
## Summary

Fixes the mobile web fresh-sync path where tapping the Top Tracks / popular tracks mix could keep the poster action in a loading state while the app synchronously built the full per-artist popular-track cache.

The tap path now uses cached aggregate tracks when available, otherwise it starts playback from the bounded library-wide popular-tracks query. The fuller per-artist Top Tracks cache warms in the background and no longer blocks the user-initiated action. Popular mix loading also has a bounded provider timeout so a hung provider request cannot pin the loading state indefinitely.

## Validation

- `./gradlew :composeApp:compileKotlinDesktop`
- `./gradlew :composeApp:compileKotlinWasmJs`
- `./gradlew :composeApp:desktopTest --tests 'com.phoebe.app.CatalogRepositoryRefreshDesktopTest.popularTracksForLibraryAggregatesTopFivePerArtistAndPersistsCache' --tests 'com.phoebe.app.CatalogRepositoryRefreshDesktopTest.popularSongsForLibraryQueriesFiveHundredPlexTracks' --tests 'com.phoebe.app.CatalogRepositoryRefreshDesktopTest.refreshAggregatedDoesNotWarmPopularMixArtistTracks'`
