### PR TITLE
[codex] Address queue and artwork review feedback

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/QueueContinuationPlanner.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/QueueContinuationPlanner.kt
@@ -347,9 +347,14 @@ private class ExcludedTracks private constructor(
         fun from(currentQueue: List<Track>, catalogTracks: List<Track>, recentTrackIds: Set<String>): ExcludedTracks {
             val ids = currentQueue.mapTo(mutableSetOf()) { it.id }
             ids += recentTrackIds
-            val byId = catalogTracks.associateBy { it.id }
             val identities = currentQueue.mapTo(mutableSetOf()) { it.playHistoryIdentityKey() }
-            recentTrackIds.mapNotNullTo(identities) { byId[it]?.playHistoryIdentityKey() }
+            if (recentTrackIds.isNotEmpty()) {
+                catalogTracks.forEach { track ->
+                    if (track.id in recentTrackIds) {
+                        identities += track.playHistoryIdentityKey()
+                    }
+                }
+            }
             return ExcludedTracks(ids, identities)
         }
     }
@@ -367,7 +372,7 @@ private fun PlaybackQueueOrigin?.keepPlayingSourceLabel(): String =
     }
 
 private val RelationWhitespaceRegex = Regex("""\s+""")
-private val NonAlphanumericRelationRegex = Regex("""[^a-z0-9]+""")
+private val NonAlphanumericRelationRegex = Regex("""[^\p{L}\p{N}]+""")
 private val BroadRelationTags = setOf(
     "alternative",
     "dance",

--- a/data/local-media/src/androidMain/kotlin/com/phoebe/app/sources/LocalLibrary.android.kt
+++ b/data/local-media/src/androidMain/kotlin/com/phoebe/app/sources/LocalLibrary.android.kt
@@ -14,10 +14,12 @@ import com.phoebe.app.platform.PlatformStorage
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.util.concurrent.atomic.AtomicReference
 
 private val audioExt = setOf("mp3", "m4a", "flac", "wav", "aac", "ogg", "opus")
 private val artworkExt = setOf("jpg", "jpeg", "png", "webp")
 private val sidecarArtworkNames = listOf("cover", "folder", "front", "album", "artwork")
+private val lastSidecarParentCache = AtomicReference<Pair<File, Map<String, File>>?>()
 private const val MaxEmbeddedArtworkBytes = 12 * 1024 * 1024
 
 actual object LocalLibraryIO {
@@ -158,10 +160,16 @@ private suspend fun embeddedArtworkUri(sourceUri: String, bytes: ByteArray?): St
 
 private fun sidecarArtworkUri(file: File): String? {
     val parent = file.parentFile ?: return null
-    val filesByName = parent.listFiles()
-        ?.filter { it.isFile }
-        ?.associateBy { it.name.lowercase() }
-        .orEmpty()
+    val cached = lastSidecarParentCache.get()
+    val filesByName = if (cached != null && cached.first == parent) {
+        cached.second
+    } else {
+        parent.listFiles()
+            ?.filter { it.isFile }
+            ?.associateBy { it.name.lowercase() }
+            .orEmpty()
+            .also { lastSidecarParentCache.set(parent to it) }
+    }
     for (name in sidecarArtworkNames) {
         for (extension in artworkExt) {
             filesByName["$name.$extension"]?.let { return it.toURI().toString() }

--- a/data/local-media/src/desktopMain/kotlin/com/phoebe/app/sources/LocalLibrary.desktop.kt
+++ b/data/local-media/src/desktopMain/kotlin/com/phoebe/app/sources/LocalLibrary.desktop.kt
@@ -18,10 +18,12 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
+import java.util.concurrent.atomic.AtomicReference
 
 private val audioExt = setOf("mp3", "m4a", "flac", "wav", "aac", "ogg", "opus")
 private val artworkExt = setOf("jpg", "jpeg", "png", "webp")
 private val sidecarArtworkNames = listOf("cover", "folder", "front", "album", "artwork")
+private val lastSidecarParentCache = AtomicReference<Pair<Path, Map<String, Path>>?>()
 private const val MaxEmbeddedArtworkBytes = 12 * 1024 * 1024
 
 actual object LocalLibraryIO {
@@ -161,14 +163,20 @@ private suspend fun embeddedArtworkUri(sourceUri: String, artwork: Artwork?): St
 
 private fun sidecarArtworkUri(path: Path): String? {
     val parent = path.parent ?: return null
-    val filesByName = runCatching {
-        Files.list(parent).use { stream ->
-            stream
-                .filter { Files.isRegularFile(it) }
-                .toList()
-                .associateBy { it.fileName.toString().lowercase() }
-        }
-    }.getOrDefault(emptyMap())
+    val cached = lastSidecarParentCache.get()
+    val filesByName = if (cached != null && cached.first == parent) {
+        cached.second
+    } else {
+        runCatching {
+            Files.list(parent).use { stream ->
+                stream
+                    .filter { Files.isRegularFile(it) }
+                    .toList()
+                    .associateBy { it.fileName.toString().lowercase() }
+            }
+        }.getOrDefault(emptyMap())
+            .also { files -> lastSidecarParentCache.set(parent to files) }
+    }
     for (name in sidecarArtworkNames) {
         for (extension in artworkExt) {
             filesByName["$name.$extension"]?.let { return it.toUri().toString() }

--- a/feature/home/src/commonMain/kotlin/com/phoebe/app/feature/home/MixBuilderRoutes.kt
+++ b/feature/home/src/commonMain/kotlin/com/phoebe/app/feature/home/MixBuilderRoutes.kt
@@ -915,10 +915,14 @@ private fun albumMixBuilderQueue(
 ): List<Track> {
     val leading = mutableListOf<Track>()
     val rest = mutableListOf<Track>()
+    val artistsByTitle = mutableMapOf<String, Artist>()
+    catalog.artists.forEach { artist ->
+        artistsByTitle.getOrPut(artist.title.lowercase()) { artist }
+    }
     albums.forEach { album ->
         val albumTracks = albumTrackIndex.tracksForAlbum(album)
         if (albumTracks.isEmpty()) return@forEach
-        val artist = catalog.artists.firstOrNull { it.title.equals(album.artist, ignoreCase = true) }
+        val artist = artistsByTitle[album.artist.lowercase()]
         val popular = artist
             ?.let { catalog.popularTracksByArtist[it.id].orEmpty() }
             .orEmpty()


### PR DESCRIPTION
## Summary
- avoid building a full catalog ID map while excluding recent Keep Playing tracks
- cache sidecar artwork directory listings on Android and desktop local scans
- pre-index mix builder artists by title while preserving first-match behavior
- preserve Unicode letters and numbers when simplifying relation text

## Review Follow-up
Addresses Gemini feedback left on #129 after it merged.

## Validation
- `./gradlew :composeApp:desktopTest :composeApp:compileAndroidMain`
