### PR TITLE
[codex] Stop recent queue scan early

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/QueueContinuationPlanner.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/QueueContinuationPlanner.kt
@@ -349,9 +349,12 @@ private class ExcludedTracks private constructor(
             ids += recentTrackIds
             val identities = currentQueue.mapTo(mutableSetOf()) { it.playHistoryIdentityKey() }
             if (recentTrackIds.isNotEmpty()) {
-                catalogTracks.forEach { track ->
-                    if (track.id in recentTrackIds) {
+                val remainingRecentTrackIds = recentTrackIds.toMutableSet()
+                for (track in catalogTracks) {
+                    if (track.id in remainingRecentTrackIds) {
                         identities += track.playHistoryIdentityKey()
+                        remainingRecentTrackIds.remove(track.id)
+                        if (remainingRecentTrackIds.isEmpty()) break
                     }
                 }
             }

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/QueueContinuationPlanner.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/QueueContinuationPlanner.kt
@@ -346,10 +346,11 @@ private class ExcludedTracks private constructor(
     companion object {
         fun from(currentQueue: List<Track>, catalogTracks: List<Track>, recentTrackIds: Set<String>): ExcludedTracks {
             val ids = currentQueue.mapTo(mutableSetOf()) { it.id }
+            val remainingRecentTrackIds = recentTrackIds.toMutableSet()
+            remainingRecentTrackIds.removeAll(ids)
             ids += recentTrackIds
             val identities = currentQueue.mapTo(mutableSetOf()) { it.playHistoryIdentityKey() }
-            if (recentTrackIds.isNotEmpty()) {
-                val remainingRecentTrackIds = recentTrackIds.toMutableSet()
+            if (remainingRecentTrackIds.isNotEmpty()) {
                 for (track in catalogTracks) {
                     if (track.id in remainingRecentTrackIds) {
                         identities += track.playHistoryIdentityKey()


### PR DESCRIPTION
## Summary
- stop scanning catalog tracks once all recent queue IDs have been found
- follow-up to Gemini feedback on #130

## Validation
- `./gradlew :composeApp:desktopTest :composeApp:compileAndroidMain`
