### PR TITLE
Harden GitHub Pages release deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -884,10 +884,11 @@ jobs:
             composeApp/build/dist/wasmJs/productionExecutable/404.html
 
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: composeApp/build/dist/wasmJs/productionExecutable
+          include-hidden-files: true
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- update the release workflow to use `actions/upload-pages-artifact@v5`
- include hidden files in the Pages artifact so `.nojekyll` is preserved
- update the release workflow to use `actions/deploy-pages@v5`

## Validation
- `git diff --check`
- `actionlint -ignore SC2129 .github/workflows/release.yml`

Note: plain `actionlint .github/workflows/release.yml` still reports the existing unrelated `SC2129` shellcheck style warning in the iOS signing script.
