### PR TITLE
Fix macOS Chromecast permissions and app icon

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -397,8 +397,13 @@ sentry {
 }
 
 private val macosLocalNetworkInfoPlistKeys = """
+    <key>NSBonjourServices</key>
+    <array>
+        <string>_googlecast._tcp</string>
+        <string>_CC1AD845._googlecast._tcp</string>
+    </array>
     <key>NSLocalNetworkUsageDescription</key>
-    <string>Phoebe connects to Jellyfin, Plex, Emby, and other media servers on your home network.</string>
+    <string>Phoebe uses the local network to discover and control Chromecast devices and connect to media servers on your home network.</string>
 """.trimIndent()
 
 val macMediaKeysAppResources = layout.buildDirectory.dir("generated/appResources")

--- a/composeApp/src/desktopMain/kotlin/com/phoebe/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/phoebe/app/Main.kt
@@ -169,11 +169,12 @@ private fun configureDesktopApplicationIcon(debug: Boolean) {
     if (!isMacOs()) return
     val resourceName = if (debug) "icon-macos-debug.png" else "icon-macos.png"
     val iconFile = runCatching {
+        val stream = Thread.currentThread().contextClassLoader.getResourceAsStream(resourceName)
+            ?: return@runCatching null
         val tempFile = Files.createTempFile("phoebe-app-icon-", ".png")
-        Thread.currentThread().contextClassLoader.getResourceAsStream(resourceName)?.use { stream ->
-            Files.copy(stream, tempFile, StandardCopyOption.REPLACE_EXISTING)
-        } ?: return
-        tempFile.toFile().apply { deleteOnExit() }
+        val file = tempFile.toFile().apply { deleteOnExit() }
+        stream.use { Files.copy(it, tempFile, StandardCopyOption.REPLACE_EXISTING) }
+        file
     }.onFailure { error ->
         PhoebeLog.d("Phoebe") { "macOS application icon setup failed: ${error.message}" }
     }.getOrNull() ?: return

--- a/composeApp/src/desktopMain/kotlin/com/phoebe/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/phoebe/app/Main.kt
@@ -36,6 +36,8 @@ import java.awt.event.HierarchyEvent
 import java.awt.event.HierarchyListener
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import javax.imageio.ImageIO
@@ -48,6 +50,7 @@ private val desktopShutdownStarted = AtomicBoolean(false)
 
 fun main(args: Array<String>) {
     configureDesktopApplicationName()
+    configureDesktopApplicationIcon(isDebugBuild())
     configureWindowsDesktopRendering()
     configureSandboxedNativeLibraries()
     if (runDesktopPlaybackSmokeIfRequested(args)) return
@@ -160,6 +163,22 @@ private fun configureDesktopApplicationName() {
     val displayName = appDisplayName()
     System.setProperty("apple.awt.application.name", displayName)
     System.setProperty("com.apple.mrj.application.apple.menu.about.name", displayName)
+}
+
+private fun configureDesktopApplicationIcon(debug: Boolean) {
+    if (!isMacOs()) return
+    val resourceName = if (debug) "icon-macos-debug.png" else "icon-macos.png"
+    val iconFile = runCatching {
+        val tempFile = Files.createTempFile("phoebe-app-icon-", ".png")
+        Thread.currentThread().contextClassLoader.getResourceAsStream(resourceName)?.use { stream ->
+            Files.copy(stream, tempFile, StandardCopyOption.REPLACE_EXISTING)
+        } ?: return
+        tempFile.toFile().apply { deleteOnExit() }
+    }.onFailure { error ->
+        PhoebeLog.d("Phoebe") { "macOS application icon setup failed: ${error.message}" }
+    }.getOrNull() ?: return
+
+    System.setProperty("apple.awt.application.icon", iconFile.absolutePath)
 }
 
 private fun loadDesktopResourceImage(resourcePath: String) =


### PR DESCRIPTION
## Summary
- add Chromecast Bonjour service declarations to the macOS Info.plist metadata
- clarify the local network permission prompt for Chromecast control and media server access
- set the macOS desktop app icon from the bundled release/debug icon resource at startup

## Tests
- ./gradlew :composeApp:compileKotlinDesktop