### PR TITLE
Run release backend deploy in parallel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,7 +165,6 @@ jobs:
     name: Android release
     needs:
       - version
-      - events-backend
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
@@ -250,7 +249,6 @@ jobs:
     name: Linux release
     needs:
       - version
-      - events-backend
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
@@ -344,7 +342,6 @@ jobs:
     name: Windows release
     needs:
       - version
-      - events-backend
     runs-on: windows-latest
     timeout-minutes: 90
     environment: release
@@ -462,7 +459,6 @@ jobs:
     name: macOS release
     needs:
       - version
-      - events-backend
     runs-on: macos-latest
     timeout-minutes: 90
     env:
@@ -700,7 +696,6 @@ jobs:
     name: iOS release
     needs:
       - version
-      - events-backend
     runs-on: macos-26
     timeout-minutes: 90
     env:
@@ -944,21 +939,14 @@ jobs:
           tag_name: ${{ needs.version.outputs.tag_name }}
           files: release-artifacts/**/*.ipa
 
-  web-pages-deploy:
-    name: Deploy web to GitHub Pages
+  web:
+    name: Web release
     needs:
       - version
-      - events-backend
-    if: needs.version.result == 'success' && needs.events-backend.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    environment:
-      name: github-pages
-      url: ${{ steps.pages_url.outputs.page_url }}
     permissions:
       contents: read
-      id-token: write
-      pages: write
     env:
       PHOEBE_GOOGLE_MAPS_WEB_API_KEY: ${{ secrets.PHOEBE_GOOGLE_MAPS_WEB_API_KEY }}
 
@@ -1011,6 +999,23 @@ jobs:
           path: composeApp/build/dist/wasmJs/productionExecutable
           include-hidden-files: true
 
+  web-pages-deploy:
+    name: Deploy web to GitHub Pages
+    needs:
+      - events-backend
+      - web
+    if: always() && needs.events-backend.result == 'success' && needs.web.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.pages_url.outputs.page_url }}
+    permissions:
+      contents: read
+      id-token: write
+      pages: write
+
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ For release CI, add these GitHub Actions repository secrets:
 - `VERCEL_ORG_ID`: from `.vercel/project.json`
 - `VERCEL_PROJECT_ID_EVENTS_PROD`: from `.vercel/project.json`
 
-The release workflow runs on every push to `main`, so merging to `main` triggers a release. Its `events-backend` job deploys the production backend with `scripts/deploy-events-backend-vercel.sh --prod --yes`, checks `/health`, and runs a Ticketmaster smoke lookup before app packaging jobs continue.
+The release workflow runs on every push to `main`, so merging to `main` triggers a release. Its `events-backend` job deploys the production backend with `scripts/deploy-events-backend-vercel.sh --prod --yes`, checks `/health`, and runs a Ticketmaster smoke lookup in parallel with the client packaging jobs. The GitHub release and final web Pages deploy still wait for the backend smoke test to pass.
 
 **iOS debug build:**
 
@@ -283,7 +283,7 @@ xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp -configuration Debug 
 
 ## Releases
 
-Every push to `main` runs the release workflow. It bumps `gradle.properties`, tags `release/x.y.z`, deploys the events backend to Vercel, then builds signed Android APK/AAB, Linux DEB and Flatpak, Windows MSI, macOS DMG, web, and iOS artifacts as draft GitHub releases. Signing secrets and setup are documented in [docs/github-actions.md](docs/github-actions.md) and `docs/release-signing-setup.md`.
+Every push to `main` runs the release workflow. It bumps `gradle.properties`, tags `release/x.y.z`, then deploys the events backend to Vercel in parallel with signed Android APK/AAB, Linux DEB and Flatpak, Windows MSI, macOS DMG, web, and iOS artifact generation. Signing secrets and setup are documented in [docs/github-actions.md](docs/github-actions.md) and `docs/release-signing-setup.md`.
 
 ## Debug logging
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -45,21 +45,16 @@ input or timeout.
 
 ## Releases
 
-Create a tag named `release/x.x.x`, for example:
+Release CI runs on pushes to `main`, so merging a PR starts the release. You can also start it manually from the Actions tab with an optional custom version such as `1.2.3`; otherwise CI uses an auto-incremented version code and UTC timestamp version name.
 
-```sh
-git tag release/1.2.3
-git push origin release/1.2.3
-```
-
-The release version comes from `gradle.properties`:
+The version job updates `gradle.properties`:
 
 ```properties
 phoebe.versionName=1.2.3
 phoebe.versionCode=1002003
 ```
 
-The release workflow requires the pushed tag to match `phoebe.versionName`, so `phoebe.versionName=1.2.3` must be released with tag `release/1.2.3`. It validates that the version is plain semver, then starts the production events backend deploy and the Android, Linux, Windows, macOS, iOS, and web build jobs in parallel. Native package jobs use `phoebe.versionCode` for Android, rename the generated binaries to include `phoebe.versionName`, then create a draft GitHub release with the generated APK, AAB, DEB, Flatpak bundle, MSI, and DMG assets attached after those jobs and the backend smoke test finish successfully. The iOS IPA is built on its own macOS runner and is uploaded to the same release afterward, so a slow iOS build no longer blocks publishing the other platform artifacts.
+The release workflow validates that the version is plain semver, commits the version bump back to `main`, creates the matching `release/x.y.z` tag, then starts the production events backend deploy and the Android, Linux, Windows, macOS, iOS, and web build jobs in parallel. Native package jobs use `phoebe.versionCode` for Android, rename the generated binaries to include `phoebe.versionName`, then create a draft GitHub release with the generated APK, AAB, DEB, Flatpak bundle, MSI, and DMG assets attached after those jobs and the backend smoke test finish successfully. The iOS IPA is built on its own macOS runner and is uploaded to the same release afterward, so a slow iOS build no longer blocks publishing the other platform artifacts.
 
 The web build job prepares the Wasm distribution independently of the draft GitHub release. The final GitHub Pages deploy waits for both the web build and the backend smoke test to finish successfully.
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -59,9 +59,9 @@ phoebe.versionName=1.2.3
 phoebe.versionCode=1002003
 ```
 
-The release workflow requires the pushed tag to match `phoebe.versionName`, so `phoebe.versionName=1.2.3` must be released with tag `release/1.2.3`. It validates that the version is plain semver, deploys the production events backend to Vercel, then starts the Android, Linux, Windows, macOS, iOS, and web deploy jobs. Native package jobs use `phoebe.versionCode` for Android, rename the generated binaries to include `phoebe.versionName`, then create a draft GitHub release with the generated APK, AAB, DEB, Flatpak bundle, MSI, and DMG assets attached as soon as those jobs finish. The iOS IPA is built on its own macOS runner and is uploaded to the same release afterward, so a slow iOS build no longer blocks publishing the other platform artifacts.
+The release workflow requires the pushed tag to match `phoebe.versionName`, so `phoebe.versionName=1.2.3` must be released with tag `release/1.2.3`. It validates that the version is plain semver, then starts the production events backend deploy and the Android, Linux, Windows, macOS, iOS, and web build jobs in parallel. Native package jobs use `phoebe.versionCode` for Android, rename the generated binaries to include `phoebe.versionName`, then create a draft GitHub release with the generated APK, AAB, DEB, Flatpak bundle, MSI, and DMG assets attached after those jobs and the backend smoke test finish successfully. The iOS IPA is built on its own macOS runner and is uploaded to the same release afterward, so a slow iOS build no longer blocks publishing the other platform artifacts.
 
-The web deploy job builds the Wasm distribution and deploys it to this repository's GitHub Pages site independently of the draft GitHub release.
+The web build job prepares the Wasm distribution independently of the draft GitHub release. The final GitHub Pages deploy waits for both the web build and the backend smoke test to finish successfully.
 
 ## GitHub Pages
 


### PR DESCRIPTION
## Summary
- start the release backend deployment in parallel with Android, Linux, Windows, macOS, iOS, and web client build jobs
- split web release generation from the final GitHub Pages deploy so client generation can run early while Pages deploy still waits for backend smoke success
- update release docs to describe the new dependency graph

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml YAML parses"'\n- git diff --check -- .github/workflows/release.yml README.md docs/github-actions.md\n\n## Notes\n- Existing staged playback/sidebar changes were left out of this PR.