### PR TITLE
Speed up lyric annotation loading

### DIFF
--- a/backend/lyrics/src/main/kotlin/com/phoebe/app/backend/lyrics/LyricsBackendFeature.kt
+++ b/backend/lyrics/src/main/kotlin/com/phoebe/app/backend/lyrics/LyricsBackendFeature.kt
@@ -4,7 +4,6 @@ import com.phoebe.app.backend.MissingProviderCredentialException
 import com.phoebe.app.backend.BackendSingleFlight
 import com.phoebe.app.backend.PhoebeBackendEnvironment
 import com.phoebe.app.backend.PhoebeBackendFeature
-import com.phoebe.app.backend.ProviderApiException
 import com.phoebe.app.backend.normalizedBackendCacheKey
 import com.phoebe.app.backend.optionalBackendQueryParameter
 import com.phoebe.app.backend.positiveDurationMsQueryParameter
@@ -164,10 +163,9 @@ class GeniusApiAdapter(
         val token = accessToken ?: throw MissingProviderCredentialException("GENIUS_ACCESS_TOKEN is not configured.")
         val songs = search(artist = artist, title = title, token = token)
         val selected = songs.bestMatch(artist = artist, title = title) ?: return GeniusReferentsResponse()
-        val song = runCatching { song(selected.id, token) }.getOrDefault(selected)
         return GeniusReferentsResponse(
-            song = song,
-            referents = referents(song.id, token),
+            song = selected,
+            referents = referents(selected.id, token),
         )
     }
 
@@ -187,13 +185,6 @@ class GeniusApiAdapter(
             }
         }
         return songs.distinctBy { it.id }
-    }
-
-    private suspend fun song(songId: Long, token: String): GeniusSongReference {
-        val response = geniusRequest("$GeniusApiBaseUrl/songs/$songId", token)
-        val body: GeniusSongApiResponse = response.body()
-        return body.response?.song?.toSong()
-            ?: throw ProviderApiException("Genius song response did not include a song.")
     }
 
     private suspend fun referents(songId: Long, token: String): List<GeniusReferent> {
@@ -260,16 +251,6 @@ private data class GeniusSearchPayload(
 @Serializable
 private data class GeniusSearchHit(
     val result: GeniusSongPayload? = null,
-)
-
-@Serializable
-private data class GeniusSongApiResponse(
-    val response: GeniusSongPayloadWrapper? = null,
-)
-
-@Serializable
-private data class GeniusSongPayloadWrapper(
-    val song: GeniusSongPayload? = null,
 )
 
 @Serializable

--- a/composeApp/src/desktopTest/kotlin/com/phoebe/app/LyricsRepositoryDesktopTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/phoebe/app/LyricsRepositoryDesktopTest.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Test
+import java.nio.file.Files
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -299,6 +300,59 @@ class LyricsRepositoryDesktopTest {
     }
 
     @Test
+    fun notFoundRaceDoesNotDowngradeLoadedLyricsCache() = runTest {
+        val (db, sqlDriver) = newInMemoryPhoebeDatabase()
+        driver = sqlDriver
+        val dir = Files.createTempDirectory("phoebe-lyrics-race-test")
+        val audio = dir.resolve("song.mp3")
+        val lrc = dir.resolve("song.lrc")
+        Files.write(audio, byteArrayOf(0))
+        Files.writeString(lrc, "[00:01.00] Sidecar lyric")
+        val lrclibStarted = CompletableDeferred<Unit>()
+        val releaseLrclib = CompletableDeferred<Unit>()
+        val http = testHttpClient(
+            MockEngine { request ->
+                when (request.url.host) {
+                    "lrclib.net" -> {
+                        lrclibStarted.complete(Unit)
+                        releaseLrclib.await()
+                        respond("", HttpStatusCode.NotFound)
+                    }
+                    else -> respond("", HttpStatusCode.NotFound)
+                }
+            },
+        )
+        val repo = lyricsRepository(db, http).repository
+        val remoteOnlyTrack = track(localUri = null)
+        val localSidecarTrack = track(localUri = audio.toUri().toString())
+
+        val notFoundLoad = async { repo.lyricsFor(remoteOnlyTrack, includeRemoteAnnotations = true) }
+        lrclibStarted.await()
+        try {
+            val loadedLoad = async { repo.lyricsFor(localSidecarTrack, includeRemoteAnnotations = false) }
+            val sidecarLoaded = assertIs<LyricsLoadState.Loaded>(
+                withContext(Dispatchers.Default) {
+                    withTimeout(2_000) { loadedLoad.await() }
+                },
+            )
+            assertEquals(listOf("Sidecar lyric"), sidecarLoaded.document.lines.map { it.text })
+        } finally {
+            releaseLrclib.complete(Unit)
+        }
+
+        val racedState = assertIs<LyricsLoadState.Loaded>(
+            withContext(Dispatchers.Default) {
+                withTimeout(2_000) { notFoundLoad.await() }
+            },
+        )
+        assertEquals(listOf("Sidecar lyric"), racedState.document.lines.map { it.text })
+        val cached = assertIs<LyricsLoadState.Loaded>(
+            repo.lyricsFor(remoteOnlyTrack, includeRemoteAnnotations = false),
+        )
+        assertEquals(listOf("Sidecar lyric"), cached.document.lines.map { it.text })
+    }
+
+    @Test
     fun matchesGeniusFragmentsAcrossCurlyAndStraightApostrophes() = runTest {
         val (db, sqlDriver) = newInMemoryPhoebeDatabase()
         driver = sqlDriver
@@ -559,6 +613,7 @@ class LyricsRepositoryDesktopTest {
         artist: String = "Test Artist",
         album: String = "Test Album",
         durationMs: Long = 123_000L,
+        localUri: String? = null,
     ): Track = Track(
         id = id,
         title = title,
@@ -567,6 +622,7 @@ class LyricsRepositoryDesktopTest {
         durationMs = durationMs,
         streamUrl = "",
         downloadUrl = "",
+        localUri = localUri,
     )
 
     private suspend fun lyricsRepository(

--- a/composeApp/src/desktopTest/kotlin/com/phoebe/app/LyricsRepositoryDesktopTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/phoebe/app/LyricsRepositoryDesktopTest.kt
@@ -19,7 +19,12 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.encodedPath
 import io.ktor.http.headersOf
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -143,6 +148,79 @@ class LyricsRepositoryDesktopTest {
         assertEquals(listOf("Hello", "World"), loaded.document.lines.map { it.text })
         assertNull(loaded.document.annotations)
         assertEquals(0, backendCalls)
+    }
+
+    @Test
+    fun unrelatedLyricsLoadsDoNotWaitForSlowRemoteGeniusAnnotations() = runTest {
+        val (db, sqlDriver) = newInMemoryPhoebeDatabase()
+        driver = sqlDriver
+        val firstTrack = track(id = "local:first", title = "First Song")
+        val secondTrack = track(id = "local:second", title = "Second Song")
+        val backendStarted = CompletableDeferred<Unit>()
+        val releaseBackend = CompletableDeferred<Unit>()
+        val lrclibHttp = testHttpClient(
+            MockEngine { request ->
+                when {
+                    request.url.host == "lrclib.net" -> {
+                        val lyric = when (request.url.parameters["track_name"]) {
+                            "Second Song" -> "Second lyric"
+                            else -> "First lyric"
+                        }
+                        respondJson(
+                            """{"id":1,"instrumental":false,"plainLyrics":"$lyric","syncedLyrics":null}""",
+                        )
+                    }
+                    else -> respond("", HttpStatusCode.NotFound)
+                }
+            },
+        )
+        val backendHttp = testHttpClient(
+            MockEngine { request ->
+                when (request.url.host) {
+                    BackendHost -> {
+                        backendStarted.complete(Unit)
+                        releaseBackend.await()
+                        respondJson(geniusBackendReferentsJson(includeUnmatched = false))
+                    }
+                    else -> respond("", HttpStatusCode.NotFound)
+                }
+            },
+        )
+        val settingsRepository = AppSettingsRepository(db)
+        settingsRepository.setEventSettings(
+            EventSettings(
+                backendTarget = EventsBackendTarget.Localhost,
+                localBackendUrl = BackendBaseUrl,
+            ),
+        )
+        val repository = LyricsRepository(
+            database = db,
+            httpClient = lrclibHttp,
+            appSettingsRepository = settingsRepository,
+            geniusBackendClient = GeniusBackendClient(backendHttp),
+        )
+
+        val firstLoad = async { repository.lyricsFor(firstTrack) }
+        backendStarted.await()
+        val secondLoad = async {
+            repository.lyricsFor(secondTrack, includeRemoteAnnotations = false)
+        }
+
+        try {
+            val secondLoaded = assertIs<LyricsLoadState.Loaded>(
+                withContext(Dispatchers.Default) {
+                    withTimeout(2_000) { secondLoad.await() }
+                },
+            )
+            assertEquals(listOf("Second lyric"), secondLoaded.document.lines.map { it.text })
+        } finally {
+            releaseBackend.complete(Unit)
+        }
+        assertIs<LyricsLoadState.Loaded>(
+            withContext(Dispatchers.Default) {
+                withTimeout(2_000) { firstLoad.await() }
+            },
+        )
     }
 
     @Test
@@ -400,12 +478,18 @@ class LyricsRepositoryDesktopTest {
         assertNull(loaded.document.annotations)
     }
 
-    private fun track(): Track = Track(
-        id = "local:test",
-        title = "Test Song",
-        artist = "Test Artist",
-        album = "Test Album",
-        durationMs = 123_000L,
+    private fun track(
+        id: String = "local:test",
+        title: String = "Test Song",
+        artist: String = "Test Artist",
+        album: String = "Test Album",
+        durationMs: Long = 123_000L,
+    ): Track = Track(
+        id = id,
+        title = title,
+        artist = artist,
+        album = album,
+        durationMs = durationMs,
         streamUrl = "",
         downloadUrl = "",
     )

--- a/composeApp/src/desktopTest/kotlin/com/phoebe/app/LyricsRepositoryDesktopTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/phoebe/app/LyricsRepositoryDesktopTest.kt
@@ -22,11 +22,13 @@ import io.ktor.http.headersOf
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
@@ -221,6 +223,79 @@ class LyricsRepositoryDesktopTest {
                 withTimeout(2_000) { firstLoad.await() }
             },
         )
+    }
+
+    @Test
+    fun concurrentSameTrackLyricsLoadsShareInFlightWork() = runTest {
+        val (db, sqlDriver) = newInMemoryPhoebeDatabase()
+        driver = sqlDriver
+        val backendStarted = CompletableDeferred<Unit>()
+        val releaseBackend = CompletableDeferred<Unit>()
+        val lrclibCalls = AtomicInteger()
+        val backendCalls = AtomicInteger()
+        val lrclibHttp = testHttpClient(
+            MockEngine { request ->
+                when {
+                    request.url.host == "lrclib.net" -> {
+                        lrclibCalls.incrementAndGet()
+                        respondJson("""{"id":1,"instrumental":false,"plainLyrics":"Shared lyric","syncedLyrics":null}""")
+                    }
+                    else -> respond("", HttpStatusCode.NotFound)
+                }
+            },
+        )
+        val backendHttp = testHttpClient(
+            MockEngine { request ->
+                when (request.url.host) {
+                    BackendHost -> {
+                        backendCalls.incrementAndGet()
+                        backendStarted.complete(Unit)
+                        releaseBackend.await()
+                        respondJson(geniusBackendReferentsJson(includeUnmatched = false))
+                    }
+                    else -> respond("", HttpStatusCode.NotFound)
+                }
+            },
+        )
+        val settingsRepository = AppSettingsRepository(db)
+        settingsRepository.setEventSettings(
+            EventSettings(
+                backendTarget = EventsBackendTarget.Localhost,
+                localBackendUrl = BackendBaseUrl,
+            ),
+        )
+        val repository = LyricsRepository(
+            database = db,
+            httpClient = lrclibHttp,
+            appSettingsRepository = settingsRepository,
+            geniusBackendClient = GeniusBackendClient(backendHttp),
+        )
+
+        val firstLoad = async { repository.lyricsFor(track()) }
+        backendStarted.await()
+        val secondLoad = async { repository.lyricsFor(track()) }
+
+        try {
+            withContext(Dispatchers.Default) { delay(200) }
+            assertEquals(1, lrclibCalls.get())
+            assertEquals(1, backendCalls.get())
+        } finally {
+            releaseBackend.complete(Unit)
+        }
+        val firstLoaded = assertIs<LyricsLoadState.Loaded>(
+            withContext(Dispatchers.Default) {
+                withTimeout(2_000) { firstLoad.await() }
+            },
+        )
+        val secondLoaded = assertIs<LyricsLoadState.Loaded>(
+            withContext(Dispatchers.Default) {
+                withTimeout(2_000) { secondLoad.await() }
+            },
+        )
+        assertEquals(listOf("Shared lyric"), firstLoaded.document.lines.map { it.text })
+        assertEquals(firstLoaded.document.lines.map { it.text }, secondLoaded.document.lines.map { it.text })
+        assertEquals(1, lrclibCalls.get())
+        assertEquals(1, backendCalls.get())
     }
 
     @Test

--- a/data/lyrics/src/commonMain/kotlin/com/phoebe/app/data/LyricsRepository.kt
+++ b/data/lyrics/src/commonMain/kotlin/com/phoebe/app/data/LyricsRepository.kt
@@ -23,6 +23,7 @@ import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
@@ -43,6 +44,7 @@ class LyricsRepository(
     private val geniusBackendClient: GeniusBackendClient,
 ) {
     private val memoryCache = mutableMapOf<String, LyricsLoadState>()
+    private val activeLoads = mutableMapOf<ActiveLyricsLoadKey, CompletableDeferred<LyricsLoadState>>()
     private val lookupMutex = Mutex()
 
     suspend fun clearMemoryCache() {
@@ -58,12 +60,61 @@ class LyricsRepository(
         forceRemoteAnnotationsRefresh: Boolean = forceRefresh,
     ): LyricsLoadState = withContext(Dispatchers.Default) {
         val fingerprint = track.lyricsFingerprint()
+        val key = ActiveLyricsLoadKey(
+            fingerprint = fingerprint,
+            forceRefresh = forceRefresh,
+            includeRemoteAnnotations = includeRemoteAnnotations,
+            forceRemoteAnnotationsRefresh = forceRemoteAnnotationsRefresh,
+        )
+        val activeLoad = CompletableDeferred<LyricsLoadState>()
+        val existingLoad = lookupMutex.withLock {
+            activeLoads[key]?.let { return@withLock it }
+            activeLoads[key] = activeLoad
+            null
+        }
+        if (existingLoad != null) return@withContext existingLoad.await()
+        try {
+            val loaded = loadLyricsState(
+                track = track,
+                fingerprint = fingerprint,
+                forceRefresh = forceRefresh,
+                includeRemoteAnnotations = includeRemoteAnnotations,
+                forceRemoteAnnotationsRefresh = forceRemoteAnnotationsRefresh,
+            )
+            val state = lookupMutex.withLock {
+                val merged = mergeLyricsMemoryCacheState(
+                    current = memoryCache[fingerprint],
+                    loaded = loaded,
+                    forceRefresh = forceRefresh,
+                )
+                memoryCache[fingerprint] = merged
+                merged
+            }
+            activeLoad.complete(state)
+            state
+        } catch (error: Throwable) {
+            activeLoad.completeExceptionally(error)
+            throw error
+        } finally {
+            lookupMutex.withLock {
+                activeLoads.remove(key, activeLoad)
+            }
+        }
+    }
+
+    private suspend fun loadLyricsState(
+        track: Track,
+        fingerprint: String,
+        forceRefresh: Boolean,
+        includeRemoteAnnotations: Boolean,
+        forceRemoteAnnotationsRefresh: Boolean,
+    ): LyricsLoadState {
         val cached = if (!forceRefresh) {
             lookupMutex.withLock { memoryCache[fingerprint] }
         } else {
             null
         }
-        val loaded = if (cached != null) {
+        return if (cached != null) {
             if (includeRemoteAnnotations) {
                 enrichCachedLyricsState(track, cached, forceRemoteAnnotationsRefresh)
             } else {
@@ -77,15 +128,6 @@ class LyricsRepository(
                 includeRemoteAnnotations = includeRemoteAnnotations,
                 forceRemoteAnnotationsRefresh = forceRemoteAnnotationsRefresh,
             )
-        }
-        lookupMutex.withLock {
-            val state = mergeLyricsMemoryCacheState(
-                current = memoryCache[fingerprint],
-                loaded = loaded,
-                forceRefresh = forceRefresh,
-            )
-            memoryCache[fingerprint] = state
-            state
         }
     }
 
@@ -137,6 +179,13 @@ class LyricsRepository(
         if (loaded.document.annotations != null || current.document.trackFingerprint != loaded.document.trackFingerprint) return loaded
         return loaded.copy(document = loaded.document.copy(annotations = existingAnnotations))
     }
+
+    private data class ActiveLyricsLoadKey(
+        val fingerprint: String,
+        val forceRefresh: Boolean,
+        val includeRemoteAnnotations: Boolean,
+        val forceRemoteAnnotationsRefresh: Boolean,
+    )
 
     private suspend fun loadBaseLyrics(track: Track, fingerprint: String, forceRefresh: Boolean): LyricsDocument? {
         if (!forceRefresh) {

--- a/data/lyrics/src/commonMain/kotlin/com/phoebe/app/data/LyricsRepository.kt
+++ b/data/lyrics/src/commonMain/kotlin/com/phoebe/app/data/LyricsRepository.kt
@@ -97,7 +97,9 @@ class LyricsRepository(
             throw error
         } finally {
             lookupMutex.withLock {
-                activeLoads.remove(key, activeLoad)
+                if (activeLoads[key] === activeLoad) {
+                    activeLoads.remove(key)
+                }
             }
         }
     }

--- a/data/lyrics/src/commonMain/kotlin/com/phoebe/app/data/LyricsRepository.kt
+++ b/data/lyrics/src/commonMain/kotlin/com/phoebe/app/data/LyricsRepository.kt
@@ -58,27 +58,34 @@ class LyricsRepository(
         forceRemoteAnnotationsRefresh: Boolean = forceRefresh,
     ): LyricsLoadState = withContext(Dispatchers.Default) {
         val fingerprint = track.lyricsFingerprint()
-        lookupMutex.withLock {
-            if (!forceRefresh) {
-                memoryCache[fingerprint]?.let { cached ->
-                    val state = if (includeRemoteAnnotations) {
-                        enrichCachedLyricsState(track, cached, forceRemoteAnnotationsRefresh)
-                    } else {
-                        cachedLyricsStateWithFreshCachedAnnotations(cached)
-                    }
-                    memoryCache[fingerprint] = state
-                    return@withLock state
-                }
+        val cached = if (!forceRefresh) {
+            lookupMutex.withLock { memoryCache[fingerprint] }
+        } else {
+            null
+        }
+        val loaded = if (cached != null) {
+            if (includeRemoteAnnotations) {
+                enrichCachedLyricsState(track, cached, forceRemoteAnnotationsRefresh)
+            } else {
+                cachedLyricsStateWithFreshCachedAnnotations(cached)
             }
-            val loaded = loadLyrics(
+        } else {
+            loadLyrics(
                 track = track,
                 fingerprint = fingerprint,
                 forceRefresh = forceRefresh,
                 includeRemoteAnnotations = includeRemoteAnnotations,
                 forceRemoteAnnotationsRefresh = forceRemoteAnnotationsRefresh,
             )
-            memoryCache[fingerprint] = loaded
-            loaded
+        }
+        lookupMutex.withLock {
+            val state = mergeLyricsMemoryCacheState(
+                current = memoryCache[fingerprint],
+                loaded = loaded,
+                forceRefresh = forceRefresh,
+            )
+            memoryCache[fingerprint] = state
+            state
         }
     }
 
@@ -119,6 +126,17 @@ class LyricsRepository(
             )
             else -> state
         }
+
+    private fun mergeLyricsMemoryCacheState(
+        current: LyricsLoadState?,
+        loaded: LyricsLoadState,
+        forceRefresh: Boolean,
+    ): LyricsLoadState {
+        if (forceRefresh || current !is LyricsLoadState.Loaded || loaded !is LyricsLoadState.Loaded) return loaded
+        val existingAnnotations = current.document.annotations ?: return loaded
+        if (loaded.document.annotations != null || current.document.trackFingerprint != loaded.document.trackFingerprint) return loaded
+        return loaded.copy(document = loaded.document.copy(annotations = existingAnnotations))
+    }
 
     private suspend fun loadBaseLyrics(track: Track, fingerprint: String, forceRefresh: Boolean): LyricsDocument? {
         if (!forceRefresh) {

--- a/data/lyrics/src/commonMain/kotlin/com/phoebe/app/data/LyricsRepository.kt
+++ b/data/lyrics/src/commonMain/kotlin/com/phoebe/app/data/LyricsRepository.kt
@@ -174,7 +174,8 @@ class LyricsRepository(
         loaded: LyricsLoadState,
         forceRefresh: Boolean,
     ): LyricsLoadState {
-        if (forceRefresh || current !is LyricsLoadState.Loaded || loaded !is LyricsLoadState.Loaded) return loaded
+        if (forceRefresh || current !is LyricsLoadState.Loaded) return loaded
+        if (loaded !is LyricsLoadState.Loaded) return current
         val existingAnnotations = current.document.annotations ?: return loaded
         if (loaded.document.annotations != null || current.document.trackFingerprint != loaded.document.trackFingerprint) return loaded
         return loaded.copy(document = loaded.document.copy(annotations = existingAnnotations))


### PR DESCRIPTION
## Summary
- avoid holding the lyrics repository memory-cache mutex while LRCLIB or Genius annotation network calls are running
- preserve existing in-memory annotations when a concurrent base lyric load finishes later
- skip the backend Genius /songs/{id} round trip and fetch referents from the selected search result directly
- add a regression test proving unrelated lyric loads are not blocked by a slow remote annotation call

## Root Cause
Lyric annotation enrichment was doing slow remote work while the shared lyrics lookup mutex was held. A slow Genius request could make unrelated lyric loads wait behind it. The backend also performed an extra Genius song lookup before fetching referents, adding another sequential network hop to cold annotation requests.

## Validation
- ./gradlew :composeApp:desktopTest --tests com.phoebe.app.LyricsRepositoryDesktopTest
- ./gradlew :backend:app:test --tests com.phoebe.app.backend.PhoebeBackendApplicationTest