### PR TITLE
Polish mobile artwork presentation

### DIFF
--- a/feature/details/src/commonMain/kotlin/com/phoebe/app/feature/details/PhoebeDetailPanels.kt
+++ b/feature/details/src/commonMain/kotlin/com/phoebe/app/feature/details/PhoebeDetailPanels.kt
@@ -2708,7 +2708,6 @@ private fun ArtworkGalleryDialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
-        PlatformBackHandler(enabled = true, onBack = onDismiss)
         Box(
             Modifier
                 .fillMaxSize()

--- a/feature/details/src/commonMain/kotlin/com/phoebe/app/feature/details/PhoebeDetailPanels.kt
+++ b/feature/details/src/commonMain/kotlin/com/phoebe/app/feature/details/PhoebeDetailPanels.kt
@@ -2708,15 +2708,16 @@ private fun ArtworkGalleryDialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
+        PlatformBackHandler(enabled = true, onBack = onDismiss)
         Box(
             Modifier
                 .fillMaxSize()
-                .background(Color.Black.copy(alpha = 0.94f))
-                .windowInsetsPadding(WindowInsets.safeDrawing),
+                .background(Color.Black.copy(alpha = 0.94f)),
         ) {
             Column(
                 Modifier
                     .fillMaxSize()
+                    .windowInsetsPadding(WindowInsets.safeDrawing)
                     .padding(start = 18.dp, top = topPadding, end = 18.dp, bottom = 14.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {

--- a/feature/playback/src/commonMain/kotlin/com/phoebe/app/feature/playback/MobilePlayer.kt
+++ b/feature/playback/src/commonMain/kotlin/com/phoebe/app/feature/playback/MobilePlayer.kt
@@ -468,15 +468,34 @@ fun MobilePlayer(
         val fullArtworkHeight = fullArtworkWidth - artworkHeightTrim
 
         val collapsedArtworkSize = 44.dp
-        val currentArtworkWidth = lerp(collapsedArtworkSize, fullArtworkWidth, clampedExpansionFraction)
-        val currentArtworkHeight = lerp(collapsedArtworkSize, fullArtworkHeight, clampedExpansionFraction)
-        val artworkLayerScaleX = (currentArtworkWidth.value / fullArtworkWidth.value.coerceAtLeast(1f))
+        val artworkIsImage = visualizerPreset == NowPlayingVisualizerPreset.Artwork
+        val artworkInset = if (artworkIsImage) {
+            (fullArtworkWidth - fullArtworkHeight).coerceAtLeast(0.dp)
+        } else {
+            0.dp
+        }
+        val fullArtworkDisplayWidth = if (artworkIsImage) {
+            (fullArtworkWidth - artworkInset * 2f)
+                .coerceAtLeast(collapsedArtworkSize)
+                .coerceAtMost(fullArtworkWidth)
+        } else {
+            fullArtworkWidth
+        }
+        val fullArtworkDisplayHeight = if (artworkIsImage) {
+            fullArtworkDisplayWidth
+        } else {
+            fullArtworkHeight
+        }
+        val currentArtworkWidth = lerp(collapsedArtworkSize, fullArtworkDisplayWidth, clampedExpansionFraction)
+        val currentArtworkHeight = lerp(collapsedArtworkSize, fullArtworkDisplayHeight, clampedExpansionFraction)
+        val artworkLayerScaleX = (currentArtworkWidth.value / fullArtworkDisplayWidth.value.coerceAtLeast(1f))
             .coerceIn(0.01f, 1f)
-        val artworkLayerScaleY = (currentArtworkHeight.value / fullArtworkHeight.value.coerceAtLeast(1f))
+        val artworkLayerScaleY = (currentArtworkHeight.value / fullArtworkDisplayHeight.value.coerceAtLeast(1f))
             .coerceIn(0.01f, 1f)
-        val targetArtworkX = 0.dp
+        val targetArtworkX = artworkInset
+        val targetArtworkY = artworkInset
         val currentArtworkX = lerp(12.dp, targetArtworkX, clampedExpansionFraction)
-        val currentArtworkY = lerp(14.dp, 0.dp, clampedExpansionFraction)
+        val currentArtworkY = lerp(14.dp, targetArtworkY, clampedExpansionFraction)
 
         val miniPlayerAlpha = collapsedChromeAlpha
         val fullPlayerAlpha = ((clampedExpansionFraction - 0.2f) * 1.25f).coerceIn(0f, 1f)
@@ -729,8 +748,8 @@ fun MobilePlayer(
         if (track != null) {
             Box(
                 modifier = Modifier
-                    .width(fullArtworkWidth)
-                    .height(fullArtworkHeight)
+                    .width(fullArtworkDisplayWidth)
+                    .height(fullArtworkDisplayHeight)
                     .graphicsLayer {
                         translationX = currentArtworkX.toPx()
                         translationY = currentArtworkY.toPx()

--- a/feature/playback/src/commonMain/kotlin/com/phoebe/app/feature/playback/MobilePlayer.kt
+++ b/feature/playback/src/commonMain/kotlin/com/phoebe/app/feature/playback/MobilePlayer.kt
@@ -469,15 +469,13 @@ fun MobilePlayer(
 
         val collapsedArtworkSize = 44.dp
         val artworkIsImage = visualizerPreset == NowPlayingVisualizerPreset.Artwork
-        val artworkInset = if (artworkIsImage) {
-            (fullArtworkWidth - fullArtworkHeight).coerceAtLeast(0.dp)
+        val artworkHorizontalInset = if (artworkIsImage) {
+            ((fullArtworkWidth - fullArtworkHeight) / 2f).coerceAtLeast(0.dp)
         } else {
             0.dp
         }
         val fullArtworkDisplayWidth = if (artworkIsImage) {
-            (fullArtworkWidth - artworkInset * 2f)
-                .coerceAtLeast(collapsedArtworkSize)
-                .coerceAtMost(fullArtworkWidth)
+            fullArtworkHeight.coerceAtLeast(collapsedArtworkSize)
         } else {
             fullArtworkWidth
         }
@@ -492,8 +490,8 @@ fun MobilePlayer(
             .coerceIn(0.01f, 1f)
         val artworkLayerScaleY = (currentArtworkHeight.value / fullArtworkDisplayHeight.value.coerceAtLeast(1f))
             .coerceIn(0.01f, 1f)
-        val targetArtworkX = artworkInset
-        val targetArtworkY = artworkInset
+        val targetArtworkX = artworkHorizontalInset
+        val targetArtworkY = 0.dp
         val currentArtworkX = lerp(12.dp, targetArtworkX, clampedExpansionFraction)
         val currentArtworkY = lerp(14.dp, targetArtworkY, clampedExpansionFraction)
 


### PR DESCRIPTION
## Summary
- keep mobile artwork square when showing album art in the expanded player while preserving visualizer sizing
- align expanded artwork positioning with the inset display area
- make the artwork gallery dialog handle platform back and keep safe-area padding on the dialog content

## Tests
- ./gradlew :feature:details:compileKotlinDesktop :feature:playback:compileKotlinDesktop --no-daemon