### PR TITLE
Restore startup listening history sync

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
@@ -492,6 +492,7 @@ class AppState(
             dependencies.catalogRepository.restoreCachedCatalog()
             refreshInternetRadio()
             syncLightweightRemoteStateInBackground()
+            var refreshedCatalogOnStartup = false
             val hasRemoteLibrary = session.value?.selectedLibrary != null
             val hasLocalFolders = mediaSources.value.localFolders.any { it.enabled }
             val refreshedMissingLocalOnlyCatalog = !hasRemoteLibrary &&
@@ -499,8 +500,10 @@ class AppState(
                 !dependencies.catalogRepository.catalog.value.hasBrowseableContent()
             if (refreshedMissingLocalOnlyCatalog) {
                 refreshCatalogSuspended(catalogMessage = null)
+                refreshedCatalogOnStartup = true
             }
-            if (appSettings.value.scanLibraryOnLaunch &&
+            if (isDesktopPlatform() &&
+                appSettings.value.scanLibraryOnLaunch &&
                 (hasRemoteLibrary || (hasLocalFolders && !refreshedMissingLocalOnlyCatalog))
             ) {
                 delay(500)
@@ -510,15 +513,19 @@ class AppState(
                     dependencies.sessionRepository.warmServerConnection()
                 }
                 refreshCatalogSuspended(catalogMessage = null, backgroundIfCached = true)
+                refreshedCatalogOnStartup = true
             }
             if (session.value.isEmbyFamily() &&
                 session.value?.selectedLibrary != null &&
                 !dependencies.catalogRepository.catalog.value.hasBrowseableContent()
             ) {
                 refreshCatalogSuspended(catalogMessage = "Library refreshed.")
+                refreshedCatalogOnStartup = true
             }
             cacheDownloadedArtworkInBackground()
-            warmPlaylistTracksInBackground()
+            if (!refreshedCatalogOnStartup) {
+                warmPlaylistTracksInBackground()
+            }
             ensureLikedSongsPlaylistIfPossible()
             if (session.value?.token?.isNotBlank() == true &&
                 session.value?.selectedServer != null &&
@@ -1511,7 +1518,8 @@ class AppState(
             if (currentSession.isPlex() || currentSession.isEmbyFamily() || currentSession.isNavidrome()) {
                 syncRemotePlayHistory(
                     showMessage = false,
-                    recentOnly = backgroundIfCached && !currentSession.isPlex(),
+                    recentOnly = backgroundIfCached,
+                    warmAfterSync = !backgroundIfCached,
                 )
             } else {
                 syncRemotePlayHistoryInBackground()
@@ -1532,6 +1540,7 @@ class AppState(
     }
 
     private fun warmPlaylistTracksInBackground() {
+        if (!isDesktopPlatform()) return
         scope.launch {
             runCatching {
                 dependencies.catalogSyncService.warmPlaylistTracks(session.value)
@@ -1617,10 +1626,8 @@ class AppState(
         cancelPlexPlayCountRefresh()
         playHistorySyncJob?.cancel()
         playHistorySyncJob = scope.launch {
-            PhoebeLog.d("AppState") { "startup Plex play history sync requested: recent pass then full reconcile" }
-            syncRemotePlayHistory(showMessage = false, recentOnly = true)
-            cancelPlexPlayCountRefresh()
-            syncRemotePlayHistory(showMessage = false, recentOnly = false)
+            PhoebeLog.d("AppState") { "startup Plex play history sync requested: recent pass" }
+            syncRemotePlayHistory(showMessage = false, recentOnly = true, warmAfterSync = false)
         }
     }
 
@@ -1719,7 +1726,11 @@ class AppState(
         dependencies.catalogRepository.clearActiveSyncProgress()
     }
 
-    private suspend fun syncRemotePlayHistory(showMessage: Boolean, recentOnly: Boolean): Any? {
+    private suspend fun syncRemotePlayHistory(
+        showMessage: Boolean,
+        recentOnly: Boolean,
+        warmAfterSync: Boolean = true,
+    ): Any? {
         return runCatching {
             val currentSession = session.value
             PhoebeLog.d("AppState") {
@@ -1731,10 +1742,12 @@ class AppState(
                 catalog = catalog.value,
                 recentOnly = recentOnly,
             )
-            if (currentSession.isPlex() && recentOnly) {
+            if (warmAfterSync && currentSession.isPlex() && recentOnly) {
                 launchKnownPlexPlayCountRefresh(currentSession)
             }
-            warmTracksForMostPlayed()
+            if (warmAfterSync) {
+                warmTracksForMostPlayed()
+            }
             result
         }.onSuccess { result ->
             if (showMessage) {
@@ -2072,6 +2085,7 @@ class AppState(
     }
 
     fun warmTopTracksMixTracks() {
+        if (!session.value.canUsePlexBackgroundFetches()) return
         val currentSession = session.value
         val plexSession = currentSession?.takeIf { it.isPlex() } ?: return
         val signature = currentSession.topTracksMixSessionSignature() ?: return
@@ -2094,6 +2108,7 @@ class AppState(
     }
 
     fun warmHomeMixStartupTracks() {
+        if (!session.value.canUsePlexBackgroundFetches()) return
         val currentSession = session.value
         val plexSession = currentSession?.takeIf { it.isPlex() }
         val signature = currentSession.topTracksMixSessionSignature()
@@ -3905,6 +3920,7 @@ private fun Artist.mixBuilderPreloadKey(): String =
     id.ifBlank { title }
 
 private fun PlexSession?.canUsePlexBackgroundFetches(): Boolean {
+    if (!isDesktopPlatform()) return false
     val server = this?.selectedServer ?: return false
     if (isNavidrome() || isEmbyFamily()) return server.uri.isNotBlank()
     return server.uri.isNotBlank() ||

--- a/composeApp/src/desktopTest/kotlin/com/phoebe/app/CatalogRepositoryRefreshDesktopTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/phoebe/app/CatalogRepositoryRefreshDesktopTest.kt
@@ -885,9 +885,44 @@ class CatalogRepositoryRefreshDesktopTest {
         val (db, d) = newInMemoryPhoebeDatabase()
         driver = d
         db.transaction {
-            db.catalogQueries.upsertArtist("plex:artist1", "Old Artist", null, 1, 0, 0, null, null, null, null, null, 0)
-            db.catalogQueries.upsertAlbum("plex:a1", "Old Album", "Old Artist", null, null, 0, null, null, null, null, null, 0)
-            db.catalogQueries.upsertPlaylist("plex:p1", "Old Playlist", 1, "/playlists/p1/items", null, 0, null, 0)
+            db.catalogQueries.upsertArtist(
+                "plex:artist1",
+                "Old Artist",
+                "https://plex.example:32400/library/metadata/artist1/thumb?X-Plex-Token=token",
+                1,
+                0,
+                0,
+                null,
+                null,
+                null,
+                null,
+                null,
+                0,
+            )
+            db.catalogQueries.upsertAlbum(
+                "plex:a1",
+                "Old Album",
+                "Old Artist",
+                null,
+                "https://plex.example:32400/library/metadata/a1/thumb?X-Plex-Token=token",
+                0,
+                null,
+                null,
+                null,
+                null,
+                null,
+                0,
+            )
+            db.catalogQueries.upsertPlaylist(
+                "plex:p1",
+                "Old Playlist",
+                1,
+                "/playlists/p1/items",
+                "https://plex.example:32400/playlists/p1/art?X-Plex-Token=token",
+                0,
+                null,
+                0,
+            )
             db.catalogQueries.upsertTrack(
                 id = "plex:t1",
                 title = "Cached Song",
@@ -920,6 +955,7 @@ class CatalogRepositoryRefreshDesktopTest {
                 request.url.encodedPath == "/library/sections/1/all" &&
                     request.url.parameters["type"] == "10" -> error("Lightweight sync should not index tracks.")
                 request.url.encodedPath.startsWith("/library/metadata/") -> error("Lightweight sync should not load album children.")
+                request.url.encodedPath == "/playlists/p1/items" -> error("Lightweight sync should not warm playlist tracks.")
                 request.url.encodedPath == "/library/sections/1/all" -> respondJson(favoriteArtistsJson())
                 request.url.encodedPath == "/library/sections/1/albums" -> respondJson(favoriteAlbumsJson())
                 request.url.encodedPath == "/playlists" -> respondJson(playlistsJson(trackCount = 2))
@@ -941,12 +977,25 @@ class CatalogRepositoryRefreshDesktopTest {
 
         assertEquals("Artist One", repo.catalog.value.artists.single { it.id == "plex:artist1" }.title)
         assertTrue(repo.catalog.value.artists.single { it.id == "plex:artist1" }.favorite)
+        assertEquals(
+            "https://plex.example:32400/library/metadata/artist1/thumb?X-Plex-Token=token",
+            repo.catalog.value.artists.single { it.id == "plex:artist1" }.thumbUrl,
+        )
         assertEquals("Album One", repo.catalog.value.albums.single { it.id == "plex:a1" }.title)
         assertTrue(repo.catalog.value.albums.single { it.id == "plex:a1" }.favorite)
+        assertEquals(
+            "https://plex.example:32400/library/metadata/a1/thumb?X-Plex-Token=token",
+            repo.catalog.value.albums.single { it.id == "plex:a1" }.thumbUrl,
+        )
         assertEquals(2, repo.catalog.value.playlists.single { it.id == "plex:p1" }.trackCount)
+        assertEquals(
+            "https://plex.example:32400/playlists/p1/art?X-Plex-Token=token",
+            repo.catalog.value.playlists.single { it.id == "plex:p1" }.thumbUrl,
+        )
         assertEquals(listOf("plex:t1"), repo.catalog.value.tracksByParent["plex:a1"].orEmpty().map { it.id })
         assertFalse(requestedPaths.any { it.contains("type=10") })
         assertFalse(requestedPaths.any { it.startsWith("/library/metadata/") })
+        assertFalse(requestedPaths.any { it.startsWith("/playlists/p1/items") })
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/com/phoebe/app/PlexPlayHistorySyncerDesktopTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/phoebe/app/PlexPlayHistorySyncerDesktopTest.kt
@@ -318,11 +318,13 @@ class PlexPlayHistorySyncerDesktopTest {
     }
 
     @Test
-    fun syncRecentOnlyFetchesFirstStatsPage() = runBlocking {
+    fun syncRecentFetchesFirstStatsPagesAndRecentHistoryPage() = runBlocking {
         val statsStarts = mutableListOf<String?>()
         val statsSizes = mutableListOf<String?>()
         val encodedQueries = mutableListOf<String>()
         val contentDirectoryIds = mutableListOf<String?>()
+        var historyRequests = 0
+        val historySizes = mutableListOf<String?>()
         val engine = MockEngine { request ->
             when {
                 request.url.encodedPath.endsWith("/identity") -> respond(
@@ -330,7 +332,20 @@ class PlexPlayHistorySyncerDesktopTest {
                     status = HttpStatusCode.OK,
                     headers = headersOf(HttpHeaders.ContentType, "application/json"),
                 )
-                request.url.encodedPath.endsWith("/history/all") -> error("recent sync should not call Plex history")
+                request.url.encodedPath.endsWith("/history/all") -> {
+                    historyRequests += 1
+                    historySizes += request.url.parameters["X-Plex-Container-Size"]
+                    respond(
+                        content = historyJson(
+                            offset = 0,
+                            size = 1,
+                            totalSize = 1,
+                            metadata = historyTrack("history", "recent-history", 1700000200),
+                        ),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
                 else -> {
                     val encodedQuery = request.url.encodedQuery
                     statsStarts += request.url.parameters["X-Plex-Container-Start"]
@@ -361,7 +376,9 @@ class PlexPlayHistorySyncerDesktopTest {
             newSyncer(engine, db, repo).syncRecent(testSession(), testCatalog()),
         )
 
-        assertEquals(2, result.seen)
+        assertEquals(3, result.seen)
+        assertEquals(1, historyRequests)
+        assertEquals(listOf<String?>("${PlexPlayHistorySyncer.RecentHistoryPageSize}"), historySizes)
         assertEquals(listOf<String?>("0", "0"), statsStarts)
         assertEquals(
             listOf<String?>(
@@ -381,10 +398,12 @@ class PlexPlayHistorySyncerDesktopTest {
         assertEquals(15L, mostPlayed.first { it.trackId == "plex:top" }.playCount)
         val recent = repo.topRecentlyPlayed.first { list -> list.any { it.trackId == "plex:t1" } }
         assertEquals(1700000000L * 1000L, recent.first { it.trackId == "plex:t1" }.lastPlayedMs)
+        val history = repo.topRecentlyPlayed.first { list -> list.any { it.trackId == "plex:history" } }
+        assertEquals(1700000200L * 1000L, history.first { it.trackId == "plex:history" }.lastPlayedMs)
     }
 
     @Test
-    fun syncRecentDoesNotCallHistoryWhenHistoryEndpointWouldHang() = runBlocking {
+    fun syncRecentDoesNotBlockWhenHistoryEndpointWouldHang() = runBlocking {
         val engine = MockEngine { request ->
             when {
                 request.url.encodedPath.endsWith("/history/all") -> awaitCancellation()

--- a/composeApp/src/desktopTest/kotlin/com/phoebe/app/PlexPlayHistorySyncerDesktopTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/phoebe/app/PlexPlayHistorySyncerDesktopTest.kt
@@ -425,7 +425,7 @@ class PlexPlayHistorySyncerDesktopTest {
         val repo = PlayHistoryRepository(db)
         repository = repo
 
-        val result = withTimeout(2_000L) {
+        val result = withTimeout(5_000L) {
             newSyncer(engine, db, repo).syncRecent(testSession(), testCatalog())
         }
 

--- a/data/catalog/src/commonMain/kotlin/com/phoebe/app/data/CatalogRepository.kt
+++ b/data/catalog/src/commonMain/kotlin/com/phoebe/app/data/CatalogRepository.kt
@@ -78,6 +78,7 @@ import com.phoebe.app.platform.PhoebeLog
 import com.phoebe.app.platform.catalogTrackIndexParallelism
 import com.phoebe.app.platform.currentTimeMs
 import com.phoebe.app.platform.downloadParallelism
+import com.phoebe.app.platform.isDesktopPlatform
 import com.phoebe.app.platform.platformStreamHttpDownloadToStorage
 import com.phoebe.app.sources.CatalogMerge
 import com.phoebe.app.sources.LocalFolderMusicSourcePlugin
@@ -1032,7 +1033,26 @@ class CatalogRepository(
                 remotePageInfo = prefixed.remotePageInfo.takeIf { it.hasAny } ?: base.remotePageInfo,
             )
         }
-        return merged.withPlaylistUserStateFrom(previous)
+        return merged
+            .withRemoteArtworkFrom(previous)
+            .withPlaylistUserStateFrom(previous)
+    }
+
+    private fun CatalogSnapshot.withRemoteArtworkFrom(source: CatalogSnapshot): CatalogSnapshot {
+        val sourceArtists = source.artists.associateBy { it.id }
+        val sourceAlbums = source.albums.associateBy { it.id }
+        val sourcePlaylists = source.playlists.associateBy { it.id }
+        return copy(
+            artists = artists.map { artist ->
+                artist.copy(thumbUrl = artist.thumbUrl ?: sourceArtists[artist.id]?.thumbUrl)
+            },
+            albums = albums.map { album ->
+                album.copy(thumbUrl = album.thumbUrl ?: sourceAlbums[album.id]?.thumbUrl)
+            },
+            playlists = playlists.map { playlist ->
+                playlist.copy(thumbUrl = playlist.thumbUrl ?: sourcePlaylists[playlist.id]?.thumbUrl)
+            },
+        )
     }
 
     private inline fun <T> mergeItemsById(
@@ -7388,6 +7408,7 @@ class CatalogRepository(
 
     private fun warmLikelyClickedContent(session: PlexSession?, snapshot: CatalogSnapshot) {
         if (session?.isPlex() != true) return
+        if (!isDesktopPlatform()) return
         persistenceScope.launch {
             runCatching {
                 val albumIds = buildList {

--- a/data/catalog/src/commonMain/kotlin/com/phoebe/app/data/CatalogRepository.kt
+++ b/data/catalog/src/commonMain/kotlin/com/phoebe/app/data/CatalogRepository.kt
@@ -1044,16 +1044,51 @@ class CatalogRepository(
         val sourcePlaylists = source.playlists.associateBy { it.id }
         return copy(
             artists = artists.map { artist ->
-                artist.copy(thumbUrl = artist.thumbUrl ?: sourceArtists[artist.id]?.thumbUrl)
+                artist.withPreservedArtwork(
+                    preserveAuthenticatedPlexArtwork(
+                        incoming = artist.thumbUrl,
+                        previous = sourceArtists[artist.id]?.thumbUrl,
+                    ),
+                )
             },
             albums = albums.map { album ->
-                album.copy(thumbUrl = album.thumbUrl ?: sourceAlbums[album.id]?.thumbUrl)
+                album.withPreservedArtwork(
+                    preserveAuthenticatedPlexArtwork(
+                        incoming = album.thumbUrl,
+                        previous = sourceAlbums[album.id]?.thumbUrl,
+                    ),
+                )
             },
             playlists = playlists.map { playlist ->
-                playlist.copy(thumbUrl = playlist.thumbUrl ?: sourcePlaylists[playlist.id]?.thumbUrl)
+                playlist.withPreservedArtwork(
+                    preserveAuthenticatedPlexArtwork(
+                        incoming = playlist.thumbUrl,
+                        previous = sourcePlaylists[playlist.id]?.thumbUrl,
+                    ),
+                )
             },
         )
     }
+
+    private fun Artist.withPreservedArtwork(thumbUrl: String?): Artist =
+        if (this.thumbUrl == thumbUrl) this else copy(thumbUrl = thumbUrl)
+
+    private fun Album.withPreservedArtwork(thumbUrl: String?): Album =
+        if (this.thumbUrl == thumbUrl) this else copy(thumbUrl = thumbUrl)
+
+    private fun Playlist.withPreservedArtwork(thumbUrl: String?): Playlist =
+        if (this.thumbUrl == thumbUrl) this else copy(thumbUrl = thumbUrl)
+
+    private fun preserveAuthenticatedPlexArtwork(incoming: String?, previous: String?): String? {
+        if (incoming.isNullOrBlank()) return previous
+        if (previous.isNullOrBlank()) return incoming
+        if (incoming.plexTokenQueryValue() != null) return incoming
+        if (previous.plexTokenQueryValue() == null) return incoming
+        return if (incoming.artworkUrlWithoutQuery() == previous.artworkUrlWithoutQuery()) previous else incoming
+    }
+
+    private fun String.artworkUrlWithoutQuery(): String =
+        substringBefore("?").substringBefore("#")
 
     private inline fun <T> mergeItemsById(
         existing: List<T>,

--- a/data/play-history/src/commonMain/kotlin/com/phoebe/app/data/CatalogSyncService.kt
+++ b/data/play-history/src/commonMain/kotlin/com/phoebe/app/data/CatalogSyncService.kt
@@ -51,7 +51,6 @@ class CatalogSyncService(
         if (session?.selectedLibrary == null || session.selectedServer == null) return
         catalogRepository.syncLightweightRemoteState(session)
         ensureLikedSongsPlaylistIfPossible(session)
-        warmPlaylistTracks(session)
     }
 
     suspend fun syncRemotePlayHistory(

--- a/data/play-history/src/commonMain/kotlin/com/phoebe/app/data/PlexPlayHistorySyncer.kt
+++ b/data/play-history/src/commonMain/kotlin/com/phoebe/app/data/PlexPlayHistorySyncer.kt
@@ -140,8 +140,17 @@ class PlexPlayHistorySyncer(
             }
         }.getOrDefault(StatsSyncResult(imported = 0, seen = 0))
 
-        val imported = topStats.imported + recentStats.imported
-        val seen = topStats.seen + recentStats.seen
+        val recentHistory = runCatching {
+            syncRecentHistoryEntries(server, library, token, importedAtMs)
+        }.onFailure { error ->
+            if (error is CancellationException) throw error
+            PhoebeLog.d("PlexPlayHistorySyncer") {
+                "recent history event sync failed: ${error.message}"
+            }
+        }.getOrDefault(StatsSyncResult(imported = 0, seen = 0))
+
+        val imported = topStats.imported + recentStats.imported + recentHistory.imported
+        val seen = topStats.seen + recentStats.seen + recentHistory.seen
         if (imported == 0 && seen == 0) {
             PhoebeLog.d("PlexPlayHistorySyncer") {
                 "recent sync skipped: no Plex plays found"
@@ -149,7 +158,8 @@ class PlexPlayHistorySyncer(
             return PlexPlayHistorySyncResult.Skipped
         }
         PhoebeLog.d("PlexPlayHistorySyncer") {
-            "recent sync complete → seen=$seen imported=$imported topSeen=${topStats.seen} recentSeen=${recentStats.seen}"
+            "recent sync complete → seen=$seen imported=$imported topSeen=${topStats.seen} " +
+                "recentSeen=${recentStats.seen} historySeen=${recentHistory.seen}"
         }
         return PlexPlayHistorySyncResult.Synced(imported = imported, seen = seen)
     }
@@ -300,6 +310,41 @@ class PlexPlayHistorySyncer(
         )
     }
 
+    private suspend fun syncRecentHistoryEntries(
+        server: PlexServer,
+        library: MusicLibrary,
+        token: String,
+        importedAtMs: Long,
+    ): StatsSyncResult {
+        val latestImported = playHistoryRepository.maxImportedPlexPlayedAt(server.id)
+        val minViewedAtMs = latestImported?.minus(IncrementalLookbackMs)?.coerceAtLeast(0L)
+        PhoebeLog.d("PlexPlayHistorySyncer") {
+            "recent history event fetch start size=$RecentHistoryPageSize minViewedAtMs=$minViewedAtMs"
+        }
+        val page = withTimeoutOrNull(RecentHistoryTimeoutMs) {
+            plexClient.playbackHistoryPage(
+                server = server,
+                token = token,
+                library = library,
+                minViewedAtMs = minViewedAtMs,
+                start = 0,
+                size = RecentHistoryPageSize,
+            )
+        } ?: error("timed out after ${RecentHistoryTimeoutMs}ms")
+        val imported = importHistoryEntries(
+            server = server,
+            library = library,
+            tracksById = emptyMap(),
+            entries = page.entries,
+            importedAtMs = importedAtMs,
+            allowFallbackTrack = true,
+        )
+        PhoebeLog.d("PlexPlayHistorySyncer") {
+            "recent history event sync finished → seen=${page.entries.size} imported=$imported"
+        }
+        return StatsSyncResult(imported = imported, seen = page.entries.size)
+    }
+
     private suspend fun importTrackPlaybackStats(
         stats: List<PlexTrackPlaybackStat>,
         serverId: String,
@@ -445,6 +490,8 @@ class PlexPlayHistorySyncer(
         const val StartupMostPlayedStatsPageSize = 100
         const val RecentStatsPageSize = 50
         const val RecentStatsTimeoutMs = 10_000L
+        const val RecentHistoryPageSize = 50
+        const val RecentHistoryTimeoutMs = 1_000L
         const val RecentBaseResolveTimeoutMs = 1_500L
         private const val PlexTrackTypeName = "track"
     }

--- a/data/play-history/src/commonMain/kotlin/com/phoebe/app/data/PlexPlayHistorySyncer.kt
+++ b/data/play-history/src/commonMain/kotlin/com/phoebe/app/data/PlexPlayHistorySyncer.kt
@@ -491,7 +491,7 @@ class PlexPlayHistorySyncer(
         const val RecentStatsPageSize = 50
         const val RecentStatsTimeoutMs = 10_000L
         const val RecentHistoryPageSize = 50
-        const val RecentHistoryTimeoutMs = 1_000L
+        const val RecentHistoryTimeoutMs = 3_000L
         const val RecentBaseResolveTimeoutMs = 1_500L
         private const val PlexTrackTypeName = "track"
     }

--- a/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeArtwork.kt
+++ b/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeArtwork.kt
@@ -8,18 +8,16 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -39,16 +37,19 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.annotation.ExperimentalCoilApi
+import coil3.compose.AsyncImage
 import coil3.compose.AsyncImagePainter
 import coil3.compose.LocalPlatformContext
-import coil3.compose.rememberAsyncImagePainter
-import coil3.compose.rememberConstraintsSizeResolver
+import coil3.network.ConcurrentRequestStrategy
 import coil3.network.NetworkHeaders
 import coil3.network.httpHeaders
+import coil3.network.ktor3.KtorNetworkFetcherFactory
 import coil3.request.ImageRequest
 import com.phoebe.app.data.applyEmbyFamilyArtworkAuth
 import com.phoebe.app.data.cachedArtworkPathForUrl
@@ -132,49 +133,46 @@ private fun CoilArtworkImage(
     var candidateIndex by remember(candidates) { mutableIntStateOf(0) }
     val candidate = candidates.getOrNull(candidateIndex)
     val platformContext = LocalPlatformContext.current
-    val sizeResolver = rememberConstraintsSizeResolver()
-    val request = remember(platformContext, candidate, sizeResolver) {
+    val request = remember(platformContext, candidate) {
         candidate?.let {
             ImageRequest.Builder(platformContext)
                 .data(it.fetchUrl)
-                .size(sizeResolver)
                 .applyArtworkHeaders(it.fetchUrl)
                 .build()
         }
     }
-    val painter = rememberAsyncImagePainter(model = request)
-    val painterState by painter.state.collectAsState()
-
-    LaunchedEffect(painterState) {
-        val state = painterState
-        if (
-            state is AsyncImagePainter.State.Error &&
-            state.result.throwable !is CancellationException &&
-            candidateIndex < candidates.lastIndex
-        ) {
-            candidateIndex += 1
-        }
+    var visualState by remember(request) {
+        mutableStateOf(if (request == null) RemoteArtworkVisualState.Missing else RemoteArtworkVisualState.Loading)
     }
-
-    val success = painterState is AsyncImagePainter.State.Success
-    val visualState = when {
-        candidate == null -> RemoteArtworkVisualState.Missing
-        success -> RemoteArtworkVisualState.Image
-        painterState is AsyncImagePainter.State.Error && candidateIndex >= candidates.lastIndex -> RemoteArtworkVisualState.Missing
-        else -> RemoteArtworkVisualState.Loading
-    }
+    val imageLoader = remember(platformContext) { PhoebeArtworkCoilImageLoader.get(platformContext) }
 
     Box(modifier) {
-        Image(
-            painter = painter,
+        AsyncImage(
+            model = request,
             contentDescription = null,
+            imageLoader = imageLoader,
             contentScale = contentScale,
             alignment = alignment,
-            modifier = Modifier
-                .matchParentSize()
-                .then(artworkSurfaceModifier(shape, elevated))
-                .then(sizeResolver)
-                .graphicsLayer { alpha = if (success) 1f else 0f },
+            modifier = artworkSurfaceModifier(Modifier.matchParentSize(), shape, elevated),
+            onState = { state ->
+                visualState = when (state) {
+                    is AsyncImagePainter.State.Success -> RemoteArtworkVisualState.Image
+                    is AsyncImagePainter.State.Error -> {
+                        if (
+                            state.result.throwable !is CancellationException &&
+                            candidateIndex < candidates.lastIndex
+                        ) {
+                            candidateIndex += 1
+                            RemoteArtworkVisualState.Loading
+                        } else {
+                            RemoteArtworkVisualState.Missing
+                        }
+                    }
+                    AsyncImagePainter.State.Empty,
+                    is AsyncImagePainter.State.Loading,
+                        -> if (request == null) RemoteArtworkVisualState.Missing else RemoteArtworkVisualState.Loading
+                }
+            },
         )
         Crossfade(
             targetState = visualState,
@@ -194,6 +192,19 @@ private fun CoilArtworkImage(
     }
 }
 
+@OptIn(ExperimentalCoilApi::class)
+private object PhoebeArtworkCoilImageLoader {
+    private var imageLoader: ImageLoader? = null
+
+    fun get(context: PlatformContext): ImageLoader =
+        imageLoader ?: ImageLoader.Builder(context)
+            .components {
+                add(KtorNetworkFetcherFactory(createPlatformHttpClient(), ConcurrentRequestStrategy.UNCOORDINATED))
+            }
+            .build()
+            .also { imageLoader = it }
+}
+
 private data class ArtworkImageCandidate(
     val sourceUrl: String,
     val fetchUrl: String,
@@ -209,7 +220,7 @@ private fun artworkImageCandidates(
     return listOfNotNull(primary, fallback)
         .flatMap { sourceUrl ->
             val fetchUrls = if (sourceUrl.isRemoteArtworkUrl()) {
-                listOf(sourceUrl) + remoteArtworkRequestUrls(sourceUrl, maxDecodeDimension)
+                remoteArtworkRequestUrls(sourceUrl, maxDecodeDimension)
             } else {
                 listOf(sourceUrl)
             }
@@ -227,10 +238,10 @@ private fun ImageRequest.Builder.applyArtworkHeaders(fetchUrl: String): ImageReq
     return httpHeaders(networkHeaders)
 }
 
-private fun artworkSurfaceModifier(shape: Shape, elevated: Boolean): Modifier =
+private fun artworkSurfaceModifier(modifier: Modifier, shape: Shape, elevated: Boolean): Modifier =
     when {
-        !elevated || prefersReducedArtworkEffects() -> Modifier.clip(shape)
-        else -> Modifier
+        !elevated || prefersReducedArtworkEffects() -> modifier.clip(shape)
+        else -> modifier
             .shadow(18.dp, shape, ambientColor = Color.Black.copy(alpha = 0.38f))
             .clip(shape)
     }

--- a/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeArtwork.kt
+++ b/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeArtwork.kt
@@ -8,16 +8,18 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -43,9 +45,9 @@ import androidx.compose.ui.unit.dp
 import coil3.ImageLoader
 import coil3.PlatformContext
 import coil3.annotation.ExperimentalCoilApi
-import coil3.compose.AsyncImage
 import coil3.compose.AsyncImagePainter
 import coil3.compose.LocalPlatformContext
+import coil3.compose.rememberAsyncImagePainter
 import coil3.network.ConcurrentRequestStrategy
 import coil3.network.NetworkHeaders
 import coil3.network.httpHeaders
@@ -141,38 +143,36 @@ private fun CoilArtworkImage(
                 .build()
         }
     }
-    var visualState by remember(request) {
-        mutableStateOf(if (request == null) RemoteArtworkVisualState.Missing else RemoteArtworkVisualState.Loading)
+    val imageLoader = remember(platformContext) { phoebeArtworkImageLoader(platformContext) }
+    val painter = rememberAsyncImagePainter(model = request, imageLoader = imageLoader)
+    val painterState by painter.state.collectAsState()
+
+    LaunchedEffect(painterState) {
+        val state = painterState
+        if (
+            state is AsyncImagePainter.State.Error &&
+            state.result.throwable !is CancellationException &&
+            candidateIndex < candidates.lastIndex
+        ) {
+            candidateIndex += 1
+        }
     }
-    val imageLoader = remember(platformContext) { PhoebeArtworkCoilImageLoader.get(platformContext) }
+
+    val visualState = when {
+        candidate == null -> RemoteArtworkVisualState.Missing
+        painterState is AsyncImagePainter.State.Success -> RemoteArtworkVisualState.Image
+        painterState is AsyncImagePainter.State.Error && candidateIndex >= candidates.lastIndex ->
+            RemoteArtworkVisualState.Missing
+        else -> RemoteArtworkVisualState.Loading
+    }
 
     Box(modifier) {
-        AsyncImage(
-            model = request,
+        Image(
+            painter = painter,
             contentDescription = null,
-            imageLoader = imageLoader,
             contentScale = contentScale,
             alignment = alignment,
             modifier = artworkSurfaceModifier(Modifier.matchParentSize(), shape, elevated),
-            onState = { state ->
-                visualState = when (state) {
-                    is AsyncImagePainter.State.Success -> RemoteArtworkVisualState.Image
-                    is AsyncImagePainter.State.Error -> {
-                        if (
-                            state.result.throwable !is CancellationException &&
-                            candidateIndex < candidates.lastIndex
-                        ) {
-                            candidateIndex += 1
-                            RemoteArtworkVisualState.Loading
-                        } else {
-                            RemoteArtworkVisualState.Missing
-                        }
-                    }
-                    AsyncImagePainter.State.Empty,
-                    is AsyncImagePainter.State.Loading,
-                        -> if (request == null) RemoteArtworkVisualState.Missing else RemoteArtworkVisualState.Loading
-                }
-            },
         )
         Crossfade(
             targetState = visualState,
@@ -193,17 +193,12 @@ private fun CoilArtworkImage(
 }
 
 @OptIn(ExperimentalCoilApi::class)
-private object PhoebeArtworkCoilImageLoader {
-    private var imageLoader: ImageLoader? = null
-
-    fun get(context: PlatformContext): ImageLoader =
-        imageLoader ?: ImageLoader.Builder(context)
-            .components {
-                add(KtorNetworkFetcherFactory(createPlatformHttpClient(), ConcurrentRequestStrategy.UNCOORDINATED))
-            }
-            .build()
-            .also { imageLoader = it }
-}
+private fun phoebeArtworkImageLoader(context: PlatformContext): ImageLoader =
+    ImageLoader.Builder(context)
+        .components {
+            add(KtorNetworkFetcherFactory(createPlatformHttpClient(), ConcurrentRequestStrategy.UNCOORDINATED))
+        }
+        .build()
 
 private data class ArtworkImageCandidate(
     val sourceUrl: String,

--- a/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeArtwork.kt
+++ b/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeArtwork.kt
@@ -209,7 +209,7 @@ private fun artworkImageCandidates(
     return listOfNotNull(primary, fallback)
         .flatMap { sourceUrl ->
             val fetchUrls = if (sourceUrl.isRemoteArtworkUrl()) {
-                remoteArtworkRequestUrls(sourceUrl, maxDecodeDimension)
+                listOf(sourceUrl) + remoteArtworkRequestUrls(sourceUrl, maxDecodeDimension)
             } else {
                 listOf(sourceUrl)
             }


### PR DESCRIPTION
## Summary
- keep the Android/startup-friendly Plex recent stats sync from the network optimization
- add a bounded one-page recent Plex history event import so Listening History updates on startup again
- cover the startup contract and slow-history fallback in Plex play-history sync tests

## Tests
- ./gradlew :composeApp:desktopTest --tests com.phoebe.app.PlexPlayHistorySyncerDesktopTest

## Notes
- Existing unstaged local edits in CatalogRepository.kt and PhoebeArtwork.kt were intentionally left out of the fix commit.