### PR TITLE
Improve Android playback buffering on weak networks

### DIFF
--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidPlaybackDiagnostics.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidPlaybackDiagnostics.kt
@@ -108,11 +108,14 @@ internal object PhoebeLoadControlConfig {
                 profile.minBufferMs,
                 profile.maxBufferMs,
                 BufferForPlaybackMs,
-                BufferForPlaybackAfterRebufferMs,
+                bufferForPlaybackAfterRebufferMs(profile),
             )
             .setTargetBufferBytes(profile.targetBufferBytes)
             .setPrioritizeTimeOverSizeThresholds(false)
             .build()
+
+    internal fun bufferForPlaybackAfterRebufferMs(profile: PhoebeLoadControlProfile): Int =
+        minOf(BufferForPlaybackAfterRebufferMs, profile.minBufferMs)
 }
 
 internal data class PhoebeLoadControlProfile(

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidPlaybackDiagnostics.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidPlaybackDiagnostics.kt
@@ -59,16 +59,16 @@ internal object PhoebeLoadControlConfig {
     const val RelaxedMainMinBufferMs = 15_000
     const val RelaxedMainMaxBufferMs = 75_000
     const val RelaxedMainTargetBufferBytes = 6 * 1024 * 1024
-    const val MainMinBufferMs = 12_000
-    const val MainMaxBufferMs = 45_000
-    const val MainTargetBufferBytes = 4 * 1024 * 1024
-    const val ConstrainedMainMaxBufferMs = 30_000
-    const val ConstrainedMainTargetBufferBytes = 2 * 1024 * 1024
+    // A metered network is often also the least reliable one. Keeping a modestly larger
+    // runway here avoids a cycle of short re-buffers when reception briefly drops.
+    const val ConstrainedMainMinBufferMs = 20_000
+    const val ConstrainedMainMaxBufferMs = 90_000
+    const val ConstrainedMainTargetBufferBytes = 4 * 1024 * 1024
     const val CrossfadeMinBufferMs = 2_000
     const val CrossfadeMaxBufferMs = 12_000
     const val CrossfadeTargetBufferBytes = 1 * 1024 * 1024
     const val BufferForPlaybackMs = 750
-    const val BufferForPlaybackAfterRebufferMs = 2_000
+    const val BufferForPlaybackAfterRebufferMs = 5_000
 
     fun create(
         engine: PlaybackEnginePath,
@@ -90,7 +90,7 @@ internal object PhoebeLoadControlConfig {
             )
         } else if (!uiVisible || constrainedNetwork) {
             PhoebeLoadControlProfile(
-                minBufferMs = MainMinBufferMs,
+                minBufferMs = ConstrainedMainMinBufferMs,
                 maxBufferMs = ConstrainedMainMaxBufferMs,
                 targetBufferBytes = ConstrainedMainTargetBufferBytes,
             )

--- a/playback/src/androidUnitTest/kotlin/com/phoebe/app/player/AndroidPlaybackDiagnosticsTest.kt
+++ b/playback/src/androidUnitTest/kotlin/com/phoebe/app/player/AndroidPlaybackDiagnosticsTest.kt
@@ -88,9 +88,20 @@ class AndroidPlaybackDiagnosticsTest {
         )
 
         profiles.forEach { profile ->
-            assertTrue(profile.minBufferMs >= PhoebeLoadControlConfig.BufferForPlaybackAfterRebufferMs)
+            assertTrue(
+                PhoebeLoadControlConfig.bufferForPlaybackAfterRebufferMs(profile) <= profile.minBufferMs,
+            )
             assertTrue(profile.maxBufferMs >= profile.minBufferMs)
             assertTrue(profile.targetBufferBytes > 0)
         }
+
+        assertEquals(
+            PhoebeLoadControlConfig.BufferForPlaybackAfterRebufferMs,
+            PhoebeLoadControlConfig.bufferForPlaybackAfterRebufferMs(profiles.first()),
+        )
+        assertEquals(
+            PhoebeLoadControlConfig.CrossfadeMinBufferMs,
+            PhoebeLoadControlConfig.bufferForPlaybackAfterRebufferMs(profiles.last()),
+        )
     }
 }

--- a/playback/src/androidUnitTest/kotlin/com/phoebe/app/player/AndroidPlaybackDiagnosticsTest.kt
+++ b/playback/src/androidUnitTest/kotlin/com/phoebe/app/player/AndroidPlaybackDiagnosticsTest.kt
@@ -19,7 +19,7 @@ class AndroidPlaybackDiagnosticsTest {
     }
 
     @Test
-    fun media3LoadControlTightensBuffersOnConstrainedNetwork() {
+    fun media3LoadControlBuildsMoreRunwayOnConstrainedNetwork() {
         val wifi = PhoebeLoadControlConfig.profileFor(
             engine = PlaybackEnginePath.Media3,
             constrainedNetwork = false,
@@ -31,14 +31,16 @@ class AndroidPlaybackDiagnosticsTest {
             uiVisible = true,
         )
 
-        assertTrue(cellular.maxBufferMs < wifi.maxBufferMs)
+        assertTrue(cellular.minBufferMs > wifi.minBufferMs)
+        assertTrue(cellular.maxBufferMs > wifi.maxBufferMs)
         assertTrue(cellular.targetBufferBytes < wifi.targetBufferBytes)
+        assertEquals(PhoebeLoadControlConfig.ConstrainedMainMinBufferMs, cellular.minBufferMs)
         assertEquals(PhoebeLoadControlConfig.ConstrainedMainMaxBufferMs, cellular.maxBufferMs)
         assertEquals(PhoebeLoadControlConfig.ConstrainedMainTargetBufferBytes, cellular.targetBufferBytes)
     }
 
     @Test
-    fun media3LoadControlTightensBuffersWhenUiIsHidden() {
+    fun media3LoadControlUsesResilientBufferWhenUiIsHidden() {
         val foreground = PhoebeLoadControlConfig.profileFor(
             engine = PlaybackEnginePath.Media3,
             constrainedNetwork = false,
@@ -50,8 +52,10 @@ class AndroidPlaybackDiagnosticsTest {
             uiVisible = false,
         )
 
-        assertTrue(background.maxBufferMs < foreground.maxBufferMs)
+        assertTrue(background.minBufferMs > foreground.minBufferMs)
+        assertTrue(background.maxBufferMs > foreground.maxBufferMs)
         assertTrue(background.targetBufferBytes < foreground.targetBufferBytes)
+        assertEquals(PhoebeLoadControlConfig.ConstrainedMainMinBufferMs, background.minBufferMs)
         assertEquals(PhoebeLoadControlConfig.ConstrainedMainMaxBufferMs, background.maxBufferMs)
         assertEquals(PhoebeLoadControlConfig.ConstrainedMainTargetBufferBytes, background.targetBufferBytes)
     }


### PR DESCRIPTION
## Summary
- give metered and background Android playback a longer 20–90 second buffering runway
- cap that profile's buffer target at 4 MiB
- require five seconds of playable audio after a rebuffer before resuming

## Why
The previous constrained-network profile optimized memory by restricting playback to a 12–30 second / 2 MiB buffer. On spotty mobile connections that made repeated stalls more likely.

## Validation
- `./gradlew :playback:testAndroidHostTest`
- `git diff --check`