### PR TITLE
Fix Android playback queue ANR

### DIFF
--- a/feature/playback/src/commonMain/kotlin/com/phoebe/app/feature/playback/PhoebeQueue.kt
+++ b/feature/playback/src/commonMain/kotlin/com/phoebe/app/feature/playback/PhoebeQueue.kt
@@ -21,7 +21,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
@@ -263,15 +263,41 @@ fun UpNextList(
                 )
             }
         }
-        itemsIndexed(
-            items = upNext,
-            key = { _, track -> track.id },
-            contentType = { _, _ -> "up-next" },
-        ) { index, track ->
-            Column(verticalArrangement = Arrangement.spacedBy(rowSpacing)) {
-                if (dividerUpNextIndex == index && upNextDivider != null) {
-                    KeepPlayingDivider(upNextDivider.label)
+        val dividerItemIndex = dividerUpNextIndex ?: -1
+        val dividerMarker = upNextDivider
+        val hasDivider = dividerItemIndex in 0 until upNext.size && dividerMarker != null
+        val totalCount = upNext.size + if (hasDivider) 1 else 0
+        items(
+            count = totalCount,
+            key = { itemIndex ->
+                if (hasDivider) {
+                    when {
+                        itemIndex < dividerItemIndex -> upNext[itemIndex].id
+                        itemIndex == dividerItemIndex ->
+                            "keep-playing-divider-${requireNotNull(dividerMarker).beforeQueueIndex}"
+                        else -> upNext[itemIndex - 1].id
+                    }
+                } else {
+                    upNext[itemIndex].id
                 }
+            },
+            contentType = { itemIndex ->
+                if (hasDivider && itemIndex == dividerItemIndex) {
+                    "keep-playing-divider"
+                } else {
+                    "up-next"
+                }
+            },
+        ) { itemIndex ->
+            if (hasDivider && itemIndex == dividerItemIndex) {
+                KeepPlayingDivider(requireNotNull(dividerMarker).label)
+            } else {
+                val index = if (hasDivider && itemIndex > dividerItemIndex) {
+                    itemIndex - 1
+                } else {
+                    itemIndex
+                }
+                val track = upNext[index]
                 val isDragging = draggingTrackId == track.id
                 val draggingId = draggingTrackId
                 val startIndex = dragStartIndex

--- a/feature/playback/src/commonMain/kotlin/com/phoebe/app/feature/playback/PhoebeQueue.kt
+++ b/feature/playback/src/commonMain/kotlin/com/phoebe/app/feature/playback/PhoebeQueue.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
@@ -262,16 +263,15 @@ fun UpNextList(
                 )
             }
         }
-        upNext.forEachIndexed { index, track ->
-            if (dividerUpNextIndex == index && upNextDivider != null) {
-                item(
-                    key = "keep-playing-divider-${upNextDivider.beforeQueueIndex}",
-                    contentType = "keep-playing-divider",
-                ) {
+        itemsIndexed(
+            items = upNext,
+            key = { _, track -> track.id },
+            contentType = { _, _ -> "up-next" },
+        ) { index, track ->
+            Column(verticalArrangement = Arrangement.spacedBy(rowSpacing)) {
+                if (dividerUpNextIndex == index && upNextDivider != null) {
                     KeepPlayingDivider(upNextDivider.label)
                 }
-            }
-            item(key = track.id, contentType = "up-next") {
                 val isDragging = draggingTrackId == track.id
                 val draggingId = draggingTrackId
                 val startIndex = dragStartIndex


### PR DESCRIPTION
## Summary

- keep the Up Next queue truly lazy when Popular Mix appends hundreds of tracks
- preserve queue item keys, drag behavior, divider spacing, and playback actions

## Root cause

Popular Mix starts with a 50-track seed and can append up to 500 tracks. The Up Next Compose list used `forEachIndexed` inside `LazyColumn`, registering every queue item on each playback-position recomposition. During startup this saturated the main thread, causing the timeline to stop updating and the Android UI to become unresponsive.

## Validation

- `./gradlew :composeApp:desktopTest --tests com.phoebe.app.ui.PlaybackClickTargetDesktopTest.upNextRowInvokesQueuePlaybackRequestForTappedUpcomingTrack`
- `./gradlew :composeApp:compileAndroidMain`
- `git diff --check`