### PR TITLE
Speed up Android playback skips

### DIFF
--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAudioPlayer.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAudioPlayer.kt
@@ -95,6 +95,11 @@ private data class CrossfadeOutgoingSetup(
     val incoming: ExoPlayer,
 )
 
+internal const val AndroidPlatformQueueWindowSize = 24
+
+internal fun platformQueueWindowEndExclusive(startIndex: Int, queueSize: Int): Int =
+    (startIndex + AndroidPlatformQueueWindowSize).coerceAtMost(queueSize)
+
 class AndroidAudioPlayer(
     private val diagnostics: PlaybackDiagnostics = AndroidPlaybackDiagnostics.diagnostics,
 ) : SimpleAudioPlayer() {
@@ -1024,7 +1029,11 @@ class AndroidAudioPlayer(
         shouldPlay: Boolean = playWhenReady,
     ) {
         val windowStartIndex = targetIndex
-        val windowTracks = queue.subList(windowStartIndex, (windowStartIndex + 1).coerceAtMost(queue.size))
+        // Keep a bounded forward window in Media3. A queue selection still starts at the
+        // requested track, but subsequent skips can seek to an already-installed item
+        // instead of stopping the decoder and setting up a fresh stream request.
+        val windowEndExclusive = platformQueueWindowEndExclusive(windowStartIndex, queue.size)
+        val windowTracks = queue.subList(windowStartIndex, windowEndExclusive)
         expectControllerTarget(queueIds, platformIndex = 0, generation)
         releasePlatformDecoderBeforeLoad(player)
         player.volume = effectiveOutputVolume()
@@ -1549,7 +1558,6 @@ class AndroidAudioPlayer(
         const val NormalPositionSyncIntervalMs = 1_000L
         const val FinePositionSyncIntervalMs = 250L
         const val FinePositionSyncWindowMs = 12_000L
-        const val MaxPlatformQueueItems = 24
         const val CrossfadeSteps = 24
         const val CrossfadePrepareTimeoutMs = 5_000L
         const val CrossfadeMinimumFadeMs = 500L

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAudioPlayer.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAudioPlayer.kt
@@ -97,8 +97,14 @@ private data class CrossfadeOutgoingSetup(
 
 internal const val AndroidPlatformQueueWindowSize = 24
 
-internal fun platformQueueWindowEndExclusive(startIndex: Int, queueSize: Int): Int =
-    (startIndex + AndroidPlatformQueueWindowSize).coerceAtMost(queueSize)
+internal fun platformQueueWindowEndExclusive(
+    startIndex: Int,
+    queueSize: Int,
+    repeatMode: RepeatMode,
+): Int {
+    val windowSize = if (repeatMode == RepeatMode.One) 1 else AndroidPlatformQueueWindowSize
+    return (startIndex + windowSize).coerceAtMost(queueSize)
+}
 
 class AndroidAudioPlayer(
     private val diagnostics: PlaybackDiagnostics = AndroidPlaybackDiagnostics.diagnostics,
@@ -1031,8 +1037,13 @@ class AndroidAudioPlayer(
         val windowStartIndex = targetIndex
         // Keep a bounded forward window in Media3. A queue selection still starts at the
         // requested track, but subsequent skips can seek to an already-installed item
-        // instead of stopping the decoder and setting up a fresh stream request.
-        val windowEndExclusive = platformQueueWindowEndExclusive(windowStartIndex, queue.size)
+        // instead of stopping the decoder and setting up a fresh stream request. Repeat
+        // One must stay single-item so Media3 cannot advance before the app restarts it.
+        val windowEndExclusive = platformQueueWindowEndExclusive(
+            startIndex = windowStartIndex,
+            queueSize = queue.size,
+            repeatMode = state.value.repeat,
+        )
         val windowTracks = queue.subList(windowStartIndex, windowEndExclusive)
         expectControllerTarget(queueIds, platformIndex = 0, generation)
         releasePlatformDecoderBeforeLoad(player)

--- a/playback/src/androidUnitTest/kotlin/com/phoebe/app/player/AndroidPlaybackDiagnosticsTest.kt
+++ b/playback/src/androidUnitTest/kotlin/com/phoebe/app/player/AndroidPlaybackDiagnosticsTest.kt
@@ -6,6 +6,13 @@ import kotlin.test.assertTrue
 
 class AndroidPlaybackDiagnosticsTest {
     @Test
+    fun platformQueueWindowKeepsUpcomingSkipsOnTheExistingMedia3Player() {
+        assertEquals(24, AndroidPlatformQueueWindowSize)
+        assertEquals(24, platformQueueWindowEndExclusive(startIndex = 0, queueSize = 50))
+        assertEquals(50, platformQueueWindowEndExclusive(startIndex = 42, queueSize = 50))
+    }
+
+    @Test
     fun media3LoadControlUsesRelaxedProfileForForegroundUnmeteredPlayback() {
         val profile = PhoebeLoadControlConfig.profileFor(
             engine = PlaybackEnginePath.Media3,

--- a/playback/src/androidUnitTest/kotlin/com/phoebe/app/player/AndroidPlaybackDiagnosticsTest.kt
+++ b/playback/src/androidUnitTest/kotlin/com/phoebe/app/player/AndroidPlaybackDiagnosticsTest.kt
@@ -1,5 +1,6 @@
 package com.phoebe.app.player
 
+import com.phoebe.app.domain.RepeatMode
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -8,8 +9,13 @@ class AndroidPlaybackDiagnosticsTest {
     @Test
     fun platformQueueWindowKeepsUpcomingSkipsOnTheExistingMedia3Player() {
         assertEquals(24, AndroidPlatformQueueWindowSize)
-        assertEquals(24, platformQueueWindowEndExclusive(startIndex = 0, queueSize = 50))
-        assertEquals(50, platformQueueWindowEndExclusive(startIndex = 42, queueSize = 50))
+        assertEquals(24, platformQueueWindowEndExclusive(0, 50, RepeatMode.Off))
+        assertEquals(50, platformQueueWindowEndExclusive(42, 50, RepeatMode.All))
+    }
+
+    @Test
+    fun platformQueueWindowKeepsRepeatOneOnTheCurrentTrack() {
+        assertEquals(43, platformQueueWindowEndExclusive(42, 50, RepeatMode.One))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- keep a bounded 24-track forward window in the Android Media3 timeline
- seek within that window on repeated skips instead of resetting the decoder and stream
- retain existing cellular buffering and rebuffer-resilience settings

## Verification
- ./gradlew :playback:testAndroidHostTest
- git diff --check