### PR TITLE
Improve Android voice search playback

### DIFF
--- a/androidApp/src/debug/res/xml/shortcuts.xml
+++ b/androidApp/src/debug/res/xml/shortcuts.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- The Assistant preview must target the debug application ID installed on the test phone. -->
+    <capability android:name="actions.intent.GET_THING">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="com.phoebe.app.debug"
+            android:targetClass="com.phoebe.app.MainActivity">
+            <parameter
+                android:name="thing.name"
+                android:key="phoebe.assistant.SEARCH_QUERY" />
+        </intent>
+    </capability>
+</shortcuts>

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
         <meta-data
+            android:name="android.app.shortcuts"
+            android:resource="@xml/shortcuts" />
+        <meta-data
             android:name="com.google.android.geo.API_KEY"
             android:value="${phoebeGoogleMapsAndroidApiKey}" />
     </application>

--- a/androidApp/src/main/res/xml/shortcuts.xml
+++ b/androidApp/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <!--
+        App Actions uses this capability for queries such as "Search Kind of Blue on Phoebe".
+        The debug build overrides targetPackage because it has an application-id suffix.
+    -->
+    <capability android:name="actions.intent.GET_THING">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="com.phoebe.app"
+            android:targetClass="com.phoebe.app.MainActivity">
+            <parameter
+                android:name="thing.name"
+                android:key="phoebe.assistant.SEARCH_QUERY" />
+        </intent>
+    </capability>
+</shortcuts>

--- a/composeApp/src/androidMain/kotlin/com/phoebe/app/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/phoebe/app/MainActivity.kt
@@ -1,7 +1,8 @@
 package com.phoebe.app
 
-import android.annotation.SuppressLint
 import android.Manifest
+import android.annotation.SuppressLint
+import android.app.SearchManager
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
@@ -15,7 +16,6 @@ import android.widget.FrameLayout
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 import androidx.mediarouter.app.MediaRouteButton
 import com.google.android.gms.cast.framework.CastButtonFactory
@@ -33,12 +33,14 @@ class MainActivity : FragmentActivity(), AndroidCastRoutePickerHost {
         setContent { App() }
         installCastRouteButton()
         handlePlayFromSearchIntent(intent)
+        handleAssistantSearchIntent(intent)
     }
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
         handlePlayFromSearchIntent(intent)
+        handleAssistantSearchIntent(intent)
     }
 
     override fun onStart() {
@@ -96,13 +98,34 @@ class MainActivity : FragmentActivity(), AndroidCastRoutePickerHost {
 
     private fun handlePlayFromSearchIntent(intent: Intent?) {
         if (intent?.action != MediaStore.INTENT_ACTION_MEDIA_PLAY_FROM_SEARCH) return
+        startPlaybackFromSearch(
+            query = intent.getStringExtra(SearchManager.QUERY).orEmpty(),
+            extras = intent.extras,
+        )
+    }
+
+    /** Handles the query passed by the Assistant App Actions GET_THING capability. */
+    private fun handleAssistantSearchIntent(intent: Intent?) {
+        if (intent?.action != Intent.ACTION_VIEW) return
+        val query = intent.getStringExtra(AssistantSearchQueryExtra)?.trim().orEmpty()
+        if (query.isBlank()) return
+        startPlaybackFromSearch(query = query, extras = null)
+    }
+
+    private fun startPlaybackFromSearch(query: String, extras: Bundle?) {
         val serviceIntent = Intent(this, com.phoebe.app.player.PlaybackService::class.java)
             .setAction(MediaStore.INTENT_ACTION_MEDIA_PLAY_FROM_SEARCH)
-            .putExtras(intent)
-        ContextCompat.startForegroundService(this, serviceIntent)
+            .putExtra(SearchManager.QUERY, query)
+            .apply { extras?.let(::putExtras) }
+        // Deliberately not startForegroundService: the service only calls startForeground once
+        // playback actually begins, and a search that matches nothing would otherwise trip
+        // ForegroundServiceDidNotStartInTimeException. The activity is foreground here, so a
+        // plain start is allowed, and media3 promotes the service when the player starts.
+        startService(serviceIntent)
     }
 
     private companion object {
         private const val REQUEST_POST_NOTIFICATIONS = 1001
+        private const val AssistantSearchQueryExtra = "phoebe.assistant.SEARCH_QUERY"
     }
 }

--- a/composeApp/src/desktopTest/kotlin/com/phoebe/app/CatalogBrowseTreeSearchTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/phoebe/app/CatalogBrowseTreeSearchTest.kt
@@ -50,6 +50,47 @@ class CatalogBrowseTreeSearchTest {
     }
 
     @Test
+    fun searchTracksReturnsWholeArtistCatalogForArtistRequest() = runTest {
+        val db = populatedDatabase()
+        val tree = CatalogBrowseTree(db)
+
+        val results = tree.searchTracks(query = "signal garden", artist = "Signal Garden")
+
+        assertEquals(setOf("track-moon", "track-river"), results.map { it.id }.toSet())
+    }
+
+    @Test
+    fun searchTracksReturnsPlaylistQueueInOrderForPlaylistRequest() = runTest {
+        val db = populatedDatabase()
+        val tree = CatalogBrowseTree(db)
+
+        val results = tree.searchTracks(query = "night drive", playlist = "Night Drive")
+
+        assertEquals(listOf("track-river", "track-moon"), results.map { it.id })
+    }
+
+    @Test
+    fun searchTracksReturnsEmptyWhenNothingMatches() = runTest {
+        val db = populatedDatabase()
+        val tree = CatalogBrowseTree(db)
+
+        val results = tree.searchTracks(query = "noah kahan", artist = "Noah Kahan")
+
+        assertEquals(emptyList(), results.map { it.id })
+    }
+
+    @Test
+    fun searchTracksHydratesFullTrackRowsNotJustIndexFields() = runTest {
+        val db = populatedDatabase()
+        val tree = CatalogBrowseTree(db)
+
+        val track = tree.searchTracks(query = "moon").first()
+
+        assertEquals("https://example.test/track-moon.mp3", track.streamUrl)
+        assertEquals(180_000, track.durationMs)
+    }
+
+    @Test
     fun playlistChildrenIncludeShuffleThenContextualTrackIds() = runTest {
         val db = populatedDatabase()
         val tree = CatalogBrowseTree(db)

--- a/composeApp/src/desktopTest/kotlin/com/phoebe/app/VoiceSearchBenchmark.kt
+++ b/composeApp/src/desktopTest/kotlin/com/phoebe/app/VoiceSearchBenchmark.kt
@@ -1,0 +1,57 @@
+package com.phoebe.app
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.phoebe.app.data.db.phoebeDatabaseFromDriver
+import com.phoebe.app.player.CatalogBrowseTree
+import kotlinx.coroutines.test.runTest
+import java.io.File
+import java.util.Properties
+import kotlin.test.Test
+import kotlin.time.measureTime
+
+/**
+ * Times voice search against a real device catalog. Skips unless PHOEBE_BENCH_DB points at a
+ * pulled phoebe .db file, so it is inert in CI.
+ */
+class VoiceSearchBenchmark {
+
+    @Test
+    fun timeVoiceSearchAgainstRealCatalog() = runTest {
+        val path = System.getenv("PHOEBE_BENCH_DB") ?: return@runTest
+        val file = File(path)
+        if (!file.exists()) return@runTest
+
+        val driver = JdbcSqliteDriver("jdbc:sqlite:${file.absolutePath}", Properties())
+        val db = phoebeDatabaseFromDriver(driver)
+        val tree = CatalogBrowseTree(db)
+
+        val trackCount = db.catalogQueries.selectAllTrackIds().executeAsList().size
+        println("catalog tracks=$trackCount")
+
+        // Warm the JIT and page cache so we time steady-state work, not first-touch I/O.
+        repeat(3) { tree.searchTracks(query = "warmup") }
+
+        listOf(
+            Triple("artist request", "noah kahan", mapOf("artist" to "Noah Kahan")),
+            Triple("title request", "stick season", mapOf("title" to "Stick Season")),
+            Triple("freeform request", "love", emptyMap()),
+            Triple("no match", "zzzzqqq", mapOf("artist" to "zzzzqqq")),
+        ).forEach { (label, query, extras) ->
+            val elapsed = measureTime {
+                tree.searchTracks(
+                    query = query,
+                    title = extras["title"],
+                    artist = extras["artist"],
+                )
+            }
+            val hits = tree.searchTracks(
+                query = query,
+                title = extras["title"],
+                artist = extras["artist"],
+            ).size
+            println("$label \"$query\" -> ${elapsed.inWholeMilliseconds}ms, $hits tracks")
+        }
+
+        driver.close()
+    }
+}

--- a/data/database/src/commonMain/sqldelight/com/phoebe/app/db/Catalog.sq
+++ b/data/database/src/commonMain/sqldelight/com/phoebe/app/db/Catalog.sq
@@ -191,6 +191,12 @@ SELECT * FROM TrackRow;
 selectTrackById:
 SELECT * FROM TrackRow WHERE id = ? LIMIT 1;
 
+-- Narrow projection for voice/browse search ranking. Reading all 40 TrackRow columns
+-- for every candidate is what made Assistant queries time out; only matched ids are
+-- hydrated afterwards via selectTracksByIds.
+selectTrackSearchIndex:
+SELECT id, title, artist, album, genre, dateAddedMs FROM TrackRow;
+
 selectTracksByIds:
 SELECT * FROM TrackRow WHERE id IN :ids;
 

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/PlaybackService.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/PlaybackService.kt
@@ -229,6 +229,18 @@ class PlaybackService : MediaLibraryService() {
                 PhoebeLog.d(TAG) {
                     "onSetMediaItems package=${controller.packageName} count=${mediaItems.size} item=${mediaItems.firstOrNull()?.debugSummary()}"
                 }
+                // Voice requests carry a search query and no resolvable media id, so try the
+                // search path first: expanding them only burns a lookup that cannot succeed.
+                if (mediaItems.isVoiceSearchRequest()) {
+                    return@listenableFuture resolveSearchMediaItems(
+                        source,
+                        mediaItems,
+                        startIndex,
+                        startPositionMs,
+                    ) ?: throw UnsupportedOperationException(
+                        "No results for voice search \"${mediaItems.first().requestMetadata.searchQuery}\".",
+                    )
+                }
                 val expanded = expandMediaItems(source, mediaItems, startIndex)
                 if (expanded != null) {
                     val tracks = expanded.tracks
@@ -241,10 +253,6 @@ class PlaybackService : MediaLibraryService() {
                     }
                     MediaItemsWithStartPosition(expanded.items, expanded.startIndex, startPositionMs)
                 } else {
-                    val searched = resolveSearchMediaItems(source, mediaItems, startIndex, startPositionMs)
-                    if (searched != null) {
-                        return@listenableFuture searched
-                    }
                     val tracks = source.resolveTracks(mediaItems)
                     if (tracks.isEmpty()) {
                         throw UnsupportedOperationException("No playable media items resolved for request.")
@@ -406,6 +414,12 @@ class PlaybackService : MediaLibraryService() {
 
     private fun List<MediaItem>.isInAppPlaybackQueue(): Boolean =
         isNotEmpty() && all { it.requestMetadata.extras?.getBoolean(InAppPlaybackExtra, false) == true }
+
+    /** True for Assistant/Android Auto voice requests, which arrive as a lone query-bearing item. */
+    private fun List<MediaItem>.isVoiceSearchRequest(): Boolean {
+        val request = singleOrNull()?.requestMetadata ?: return false
+        return isSearchRequest(request.searchQuery?.trim().orEmpty(), request.extras)
+    }
 
     private fun MediaItem.debugSummary(): String {
         val extras = requestMetadata.extras

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/CatalogBrowseTree.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/CatalogBrowseTree.kt
@@ -1,6 +1,7 @@
 package com.phoebe.app.player
 
 import com.phoebe.app.db.PhoebeDatabase
+import com.phoebe.app.db.SelectTrackSearchIndex
 import com.phoebe.app.domain.Album
 import com.phoebe.app.domain.Artist
 import com.phoebe.app.domain.Playlist
@@ -81,7 +82,8 @@ class CatalogBrowseTree(
 
     fun trackById(trackId: String): Track? {
         val resolvedId = BrowseMediaIds.parseTrackId(trackId)?.trackId ?: trackId
-        val row = database.catalogQueries.selectAllTracks().executeAsList().find { it.id == resolvedId }
+        if (resolvedId.isBlank()) return null
+        val row = database.catalogQueries.selectTrackById(resolvedId).executeAsOneOrNull()
             ?: return null
         return row.toTrack()
     }
@@ -133,6 +135,11 @@ class CatalogBrowseTree(
         }.orEmpty()
         if (playlistTracks.isNotEmpty()) return playlistTracks.distinctBy { it.id }
 
+        // Rank over the narrow projection, then hydrate only the ids that matched. Reading
+        // every TrackRow column per branch is what pushed voice searches past the Assistant's
+        // timeout on large libraries.
+        val index by lazy { database.catalogQueries.selectTrackSearchIndex().executeAsList() }
+
         val albumTracks = album?.takeIf { it.isNotBlank() }?.let { albumQuery ->
             val matchedAlbums = albums()
                 .filter { candidate ->
@@ -140,59 +147,77 @@ class CatalogBrowseTree(
                         artist?.takeIf { it.isNotBlank() }?.let { candidate.artist.matchesVoiceQuery(it) } != false
                 }
             matchedAlbums.flatMap { tracksForParent(it.id) }.ifEmpty {
-                allTracks().filter { track ->
-                    track.album.matchesVoiceQuery(albumQuery) &&
-                        artist?.takeIf { it.isNotBlank() }?.let { track.artist.matchesVoiceQuery(it) } != false
-                }
+                hydrate(
+                    index.filter { row ->
+                        row.album.matchesVoiceQuery(albumQuery) &&
+                            artist?.takeIf { it.isNotBlank() }?.let { row.artist.matchesVoiceQuery(it) } != false
+                    }.map { it.id },
+                )
             }
         }.orEmpty()
         if (albumTracks.isNotEmpty()) return albumTracks.distinctBy { it.id }
 
         val artistTracks = artist?.takeIf { it.isNotBlank() }?.let { artistQuery ->
-            allTracks().filter { it.artist.matchesVoiceQuery(artistQuery) }
+            hydrate(index.filter { it.artist.matchesVoiceQuery(artistQuery) }.map { it.id })
         }.orEmpty()
         if (artistTracks.isNotEmpty()) return artistTracks.distinctBy { it.id }
 
         val titleTracks = title?.takeIf { it.isNotBlank() }?.let { titleQuery ->
-            allTracks().rankedByVoiceQuery(titleQuery) {
-                listOf(
-                    VoiceSearchField(it.title, FieldWeightTitle),
-                    VoiceSearchField(it.artist, FieldWeightArtist),
-                    VoiceSearchField(it.album, FieldWeightAlbum),
-                )
-            }
+            hydrate(
+                index.rankedByVoiceQuery(titleQuery) {
+                    listOf(
+                        VoiceSearchField(it.title, FieldWeightTitle),
+                        VoiceSearchField(it.artist, FieldWeightArtist),
+                        VoiceSearchField(it.album, FieldWeightAlbum),
+                    )
+                },
+            )
         }.orEmpty()
         if (titleTracks.isNotEmpty()) return titleTracks
 
         val genreTracks = genre?.takeIf { it.isNotBlank() }?.let { genreQuery ->
-            allTracks().filter { it.genre?.matchesVoiceQuery(genreQuery) == true }
+            hydrate(index.filter { it.genre?.matchesVoiceQuery(genreQuery) == true }.map { it.id })
         }.orEmpty()
         if (genreTracks.isNotEmpty()) return genreTracks.distinctBy { it.id }
 
         val freeformQuery = query.trim()
         return if (freeformQuery.isBlank()) {
-            allTracks()
-                .sortedWith(compareByDescending<Track> { it.dateAddedMs ?: Long.MIN_VALUE }.thenBy { it.title.lowercase() })
-                .take(25)
+            hydrate(
+                index
+                    .sortedWith(
+                        compareByDescending<SelectTrackSearchIndex> { it.dateAddedMs ?: Long.MIN_VALUE }
+                            .thenBy { it.title.lowercase() },
+                    )
+                    .take(25)
+                    .map { it.id },
+            )
         } else {
-            allTracks().rankedByVoiceQuery(freeformQuery) {
-                listOf(
-                    VoiceSearchField(it.title, FieldWeightTitle),
-                    VoiceSearchField(it.artist, FieldWeightArtist),
-                    VoiceSearchField(it.album, FieldWeightAlbum),
-                    VoiceSearchField(it.genre.orEmpty(), FieldWeightGenre),
-                )
-            }
+            hydrate(
+                index.rankedByVoiceQuery(freeformQuery) {
+                    listOf(
+                        VoiceSearchField(it.title, FieldWeightTitle),
+                        VoiceSearchField(it.artist, FieldWeightArtist),
+                        VoiceSearchField(it.album, FieldWeightAlbum),
+                        VoiceSearchField(it.genre.orEmpty(), FieldWeightGenre),
+                    )
+                },
+            )
         }
+    }
+
+    /** Loads full rows for [ids], preserving the ranked order they were matched in. */
+    private fun hydrate(ids: List<String>): List<Track> {
+        if (ids.isEmpty()) return emptyList()
+        val tracksById = database.catalogQueries.selectTracksByIds(ids)
+            .executeAsList()
+            .associate { it.id to it.toTrack() }
+        return ids.mapNotNull { tracksById[it] }
     }
 
     private fun hasCachedCatalog(): Boolean =
         database.catalogQueries.selectArtists().executeAsList().isNotEmpty() ||
             database.catalogQueries.selectAlbums().executeAsList().isNotEmpty() ||
             database.catalogQueries.selectPlaylists().executeAsList().isNotEmpty()
-
-    private fun allTracks(): List<Track> =
-        database.catalogQueries.selectAllTracks().executeAsList().map { it.toTrack() }
 
     private fun artists(): List<Artist> =
         database.catalogQueries.selectArtists().executeAsList().map {
@@ -230,12 +255,8 @@ class CatalogBrowseTree(
     private fun albumsForArtist(artistTitle: String): List<Album> =
         albums().filter { it.artist.equals(artistTitle, ignoreCase = true) }
 
-    private fun tracksForParent(parentId: String): List<Track> {
-        val trackRows = database.catalogQueries.selectAllTracks().executeAsList()
-        val tracksById = trackRows.associate { it.id to it.toTrack() }
-        return database.catalogQueries.selectTracksForParent(parentId).executeAsList()
-            .mapNotNull { tracksById[it.id] }
-    }
+    private fun tracksForParent(parentId: String): List<Track> =
+        database.catalogQueries.selectTracksForParent(parentId).executeAsList().map { it.toTrack() }
 
     private fun com.phoebe.app.db.TrackRow.toTrack(): Track =
         Track(
@@ -339,10 +360,11 @@ class CatalogBrowseTree(
         return target.isNotBlank() && (value == target || value.contains(target))
     }
 
-    private fun List<Track>.rankedByVoiceQuery(
+    /** Returns matching track ids, best match first. */
+    private fun List<SelectTrackSearchIndex>.rankedByVoiceQuery(
         query: String,
-        fields: (Track) -> List<VoiceSearchField>,
-    ): List<Track> {
+        fields: (SelectTrackSearchIndex) -> List<VoiceSearchField>,
+    ): List<String> {
         val normalizedQuery = query.normalizedForVoiceSearch()
         val tokens = normalizedQuery.split(' ').filter { it.isNotBlank() }
         if (normalizedQuery.isBlank()) return emptyList()
@@ -361,12 +383,12 @@ class CatalogBrowseTree(
                 if (score > 0) track to score else null
             }
             .sortedWith(
-                compareByDescending<Pair<Track, Int>> { it.second }
+                compareByDescending<Pair<SelectTrackSearchIndex, Int>> { it.second }
                     .thenBy { it.first.title.lowercase() }
                     .thenBy { it.first.artist.lowercase() },
             )
-            .map { it.first }
-            .distinctBy { it.id }
+            .map { it.first.id }
+            .distinct()
             .toList()
     }
 


### PR DESCRIPTION
## Summary
- add Android App Actions and Assistant deep-link handling for voice playback
- resolve voice searches from a narrow catalog index, then hydrate playable tracks in ranked order
- avoid foreground-service startup timeout when a voice query has no matches
- add catalog search coverage and an opt-in real-catalog benchmark

## Tests
- ./gradlew :composeApp:desktopTest --tests '*CatalogBrowseTreeSearchTest'
- ./gradlew compileKotlinDesktop (completed during the focused gate)

## Notes
- Local .andy/, .claude/, .codex/hooks.json, and Xcode user-state files remain uncommitted.