### PR TITLE
Cap Genius referents pagination to avoid backend timeouts

### DIFF
--- a/backend/lyrics/src/main/kotlin/com/phoebe/app/backend/lyrics/LyricsBackendFeature.kt
+++ b/backend/lyrics/src/main/kotlin/com/phoebe/app/backend/lyrics/LyricsBackendFeature.kt
@@ -190,13 +190,15 @@ class GeniusApiAdapter(
     private suspend fun referents(songId: Long, token: String): List<GeniusReferent> {
         val referents = mutableListOf<GeniusReferent>()
         var page = 1
-        while (true) {
+        var pagesFetched = 0
+        while (pagesFetched < MaxReferentsPages) {
             val response = geniusRequestOrNullOnNotFound("$GeniusApiBaseUrl/referents", token) {
                 parameter("song_id", songId)
                 parameter("text_format", "plain")
                 parameter("per_page", GeniusReferentsPerPage)
                 parameter("page", page)
             } ?: break
+            pagesFetched++
             val body: GeniusReferentsApiResponse = response.body()
             referents += body.response?.referents.orEmpty().mapNotNull { it.toReferent() }
             val nextPage = body.response?.nextPage ?: break
@@ -426,6 +428,7 @@ private fun String.looksLikePlaylistPage(): Boolean =
 private const val GeniusApiBaseUrl = "https://api.genius.com"
 private const val GeniusSearchPerPage = 10
 private const val GeniusReferentsPerPage = 50
+private const val MaxReferentsPages = 10
 private const val StrongMatchScore = 100
 private val FeaturingSegmentPattern = Regex(
     pattern = """(?i)[\[(][^\])]*(?:feat\.?|ft\.?|featuring|with)\s+[^)\]]*[\])]""",


### PR DESCRIPTION
## Summary
- The production deploy's smoke test failed on run [30385886228](https://github.com/j-roskopf/Phoebe/actions/runs/30385886228): `curl: (22) The requested URL returned error: 500` on `/v1/genius/referents?artist=Taylor Swift&title=Anti-Hero`, ~300s after the request started — matching Vercel's function execution timeout.
- Root cause: `GeniusApiAdapter.referents()` paginated a song's Genius annotations with an unbounded `while (true)` loop. Heavily-annotated songs can have far more pages than expected, and fetching them sequentially can exceed the platform's execution timeout, causing the handler to be killed and return a 500.
- Fix: cap pagination at `MaxReferentsPages = 10` (500 referents at 50/page), bounding worst-case latency.

## Test plan
- [ ] CI build/tests
- [ ] Re-run the release smoke test (or manually hit `/v1/genius/referents?artist=Taylor Swift&title=Anti-Hero` against a deploy) to confirm it now returns within the timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvjxvmnTtqaxodjVX5kv14