### PR TITLE
Fix voice search hang for "song by artist" Assistant queries

### DIFF
--- a/composeApp/src/desktopTest/kotlin/com/phoebe/app/CatalogBrowseTreeSearchTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/phoebe/app/CatalogBrowseTreeSearchTest.kt
@@ -60,6 +60,16 @@ class CatalogBrowseTreeSearchTest {
     }
 
     @Test
+    fun searchTracksReturnsOnlyMatchingSongForTitleAndArtistRequest() = runTest {
+        val db = populatedDatabase()
+        val tree = CatalogBrowseTree(db)
+
+        val results = tree.searchTracks(query = "moon song by signal garden", title = "Moon Song", artist = "Signal Garden")
+
+        assertEquals(listOf("track-moon"), results.map { it.id })
+    }
+
+    @Test
     fun searchTracksReturnsPlaylistQueueInOrderForPlaylistRequest() = runTest {
         val db = populatedDatabase()
         val tree = CatalogBrowseTree(db)

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/CatalogBrowseTree.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/CatalogBrowseTree.kt
@@ -157,6 +157,16 @@ class CatalogBrowseTree(
         }.orEmpty()
         if (albumTracks.isNotEmpty()) return albumTracks.distinctBy { it.id }
 
+        val titleAndArtistTracks = if (!title.isNullOrBlank() && !artist.isNullOrBlank()) {
+            hydrate(
+                index.filter { it.title.matchesVoiceQuery(title) && it.artist.matchesVoiceQuery(artist) }
+                    .map { it.id },
+            )
+        } else {
+            emptyList()
+        }
+        if (titleAndArtistTracks.isNotEmpty()) return titleAndArtistTracks.distinctBy { it.id }
+
         val artistTracks = artist?.takeIf { it.isNotBlank() }?.let { artistQuery ->
             hydrate(index.filter { it.artist.matchesVoiceQuery(artistQuery) }.map { it.id })
         }.orEmpty()
@@ -394,9 +404,9 @@ class CatalogBrowseTree(
 
     private fun String.normalizedForVoiceSearch(): String =
         lowercase()
-            .replace(Regex("[^a-z0-9]+"), " ")
+            .replace(NonAlphanumericRegex, " ")
             .trim()
-            .replace(Regex("\\s+"), " ")
+            .replace(WhitespaceRegex, " ")
 
     private data class VoiceSearchField(val value: String, val weight: Int)
 
@@ -405,5 +415,7 @@ class CatalogBrowseTree(
         private const val FieldWeightArtist = 30
         private const val FieldWeightAlbum = 20
         private const val FieldWeightGenre = 10
+        private val NonAlphanumericRegex = Regex("[^a-z0-9]+")
+        private val WhitespaceRegex = Regex("\\s+")
     }
 }


### PR DESCRIPTION
## Summary
- Saying "play X on Phoebe" (artist-only) worked, but "play X by Y on Phoebe" (song + artist) would hang for 5-10s and then show a generic Assistant error.
- Root cause: `CatalogBrowseTree.searchTracks` had no fast path for queries carrying both a title and artist. It fell through a cheap artist-only filter into one or two full-catalog fuzzy-ranking passes (title, then freeform), each re-normalizing every field with `Regex` objects recompiled on every call. On a real synced library this was slow enough to exceed Assistant's command timeout, surfacing as the generic error. It could also silently return the artist's *entire* catalog instead of the requested song if the artist filter matched first.
- Fix: added a combined title+artist filter ahead of the artist-only fallback, so these queries resolve via one cheap pass instead of the expensive ranked scan across the whole catalog. Also cached the two normalization regexes as constants instead of recompiling them per field per row.

## Test plan
- [x] Added `CatalogBrowseTreeSearchTest.searchTracksReturnsOnlyMatchingSongForTitleAndArtistRequest`, which fails before the fix (returns the artist's whole catalog instead of the requested track) and passes after.
- [x] `./gradlew :composeApp:desktopTest --tests "com.phoebe.app.CatalogBrowseTreeSearchTest" --tests "com.phoebe.app.VoiceSearchBenchmark"` — all green.

https://claude.ai/code/session_012gZASeQbh6sndmuk1jraS3