### PR TITLE
Improve desktop playback performance

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -427,7 +427,9 @@ compose.desktop {
             "-XX:MinHeapFreeRatio=5",
             "-XX:MaxHeapFreeRatio=20",
             "-XX:+UseStringDeduplication",
-            "-Dskiko.gpu.resourceCacheLimit=64M",
+            // Skia's GPU resource cache limit is sized at runtime from the display
+            // (see configureSkiaGpuResourceCache in Main.kt) because a fixed budget
+            // that fits a 1080p screen thrashes on a large or HiDPI one.
         ) + aarch64C1OsrWorkaroundJvmArgs + windowsSkikoJvmArgs()
         if (System.getProperty("os.name").lowercase().contains("mac")) {
             val mediaKeysDylibPath =

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeRoot.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeRoot.kt
@@ -2225,7 +2225,18 @@ private fun PhoebeRootStateHolder(
                 }
                 }
             } else {
-                val audioAnalysis by state.audioAnalysis.collectAsState()
+                // Analysis frames arrive ~20x/sec and rebuild PlaybackUiState on every
+                // one, so only collect them while the visualizer route is actually
+                // showing a visualizer. Mirrors the mobile gate in PhoebePlayerOverlay.
+                val collectAudioAnalysis = screen == AppScreen.Player &&
+                    appSettings.nowPlayingVisualizerPreset != NowPlayingVisualizerPreset.Artwork
+                val audioAnalysis by produceState(AudioAnalysisFrame.Empty, collectAudioAnalysis) {
+                    if (collectAudioAnalysis) {
+                        state.audioAnalysis.collect { value = it }
+                    } else {
+                        value = AudioAnalysisFrame.Empty
+                    }
+                }
                 DesktopPlayer(
                     playerFlow = state.player,
                     shellState = DesktopShellState(

--- a/composeApp/src/desktopMain/kotlin/com/phoebe/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/phoebe/app/Main.kt
@@ -31,6 +31,7 @@ import com.sun.jna.Pointer
 import java.awt.Component
 import java.awt.Desktop
 import java.awt.EventQueue
+import java.awt.GraphicsEnvironment
 import java.awt.Image
 import java.awt.event.HierarchyEvent
 import java.awt.event.HierarchyListener
@@ -52,6 +53,7 @@ private val desktopProcessExitScheduled = AtomicBoolean(false)
 fun main(args: Array<String>) {
     configureDesktopApplicationName()
     configureDesktopApplicationIcon(isDebugBuild())
+    configureSkiaGpuResourceCache()
     configureWindowsDesktopRendering()
     configureSandboxedNativeLibraries()
     if (runDesktopPlaybackSmokeIfRequested(args)) return
@@ -173,6 +175,45 @@ private fun configureDesktopApplicationName() {
     System.setProperty("apple.awt.application.name", displayName)
     System.setProperty("com.apple.mrj.application.apple.menu.about.name", displayName)
 }
+
+/**
+ * Sizes Skia's GPU resource cache from the largest attached display.
+ *
+ * The cache holds every texture and offscreen layer surface the renderer touches
+ * in a frame. Compose nests a layer per `graphicsLayer`/clip, and each one is a
+ * full-window RGBA8 surface — roughly 20 MB on a 3440x1440 screen. When the
+ * budget can't hold one frame's working set, Skia evicts and re-uploads album art
+ * on every frame, which pins a core or more during playback.
+ *
+ * Budgeting ~[SkiaGpuCacheFullScreenLayers] full-screen layers keeps a realistic
+ * frame resident. Respects an explicit `-Dskiko.gpu.resourceCacheLimit` override.
+ */
+private fun configureSkiaGpuResourceCache() {
+    if (System.getProperty("skiko.gpu.resourceCacheLimit") != null) return
+    val limitBytes = runCatching {
+        val screenBytes = GraphicsEnvironment.getLocalGraphicsEnvironment()
+            .screenDevices
+            .maxOf { device ->
+                val config = device.defaultConfiguration
+                val bounds = config.bounds
+                val transform = config.defaultTransform
+                val widthPx = bounds.width * transform.scaleX
+                val heightPx = bounds.height * transform.scaleY
+                widthPx * heightPx * BytesPerPixel
+            }
+        (screenBytes * SkiaGpuCacheFullScreenLayers).toLong()
+    }.getOrDefault(SkiaGpuCacheMinBytes)
+        .coerceIn(SkiaGpuCacheMinBytes, SkiaGpuCacheMaxBytes)
+
+    val limitMb = (limitBytes / (1024L * 1024L)).coerceAtLeast(1L)
+    System.setProperty("skiko.gpu.resourceCacheLimit", "${limitMb}M")
+    PhoebeLog.d("Phoebe") { "skia gpu resource cache limit: ${limitMb}M" }
+}
+
+private const val BytesPerPixel = 4.0
+private const val SkiaGpuCacheFullScreenLayers = 16.0
+private const val SkiaGpuCacheMinBytes = 128L * 1024L * 1024L
+private const val SkiaGpuCacheMaxBytes = 512L * 1024L * 1024L
 
 private fun configureDesktopApplicationIcon(debug: Boolean) {
     if (!isMacOs()) return

--- a/domain/src/commonMain/kotlin/com/phoebe/app/domain/AudioAnalysis.kt
+++ b/domain/src/commonMain/kotlin/com/phoebe/app/domain/AudioAnalysis.kt
@@ -53,8 +53,13 @@ data class AudioAnalysisFrame(
     val source: AudioAnalysisSource = AudioAnalysisSource.None,
 ) {
     fun normalized(maxBands: Int = MaxBands): AudioAnalysisFrame {
+        val bandLimit = maxBands.coerceAtLeast(1)
+        // Frames are normalized on publish and again where they are consumed, and
+        // at ~20 frames a second the redundant pass allocated two 128-element band
+        // lists each time. Already-normalized frames now cost a scan and no copy.
+        if (isNormalized(bandLimit)) return this
         val normalizedBands = bands
-            .take(maxBands.coerceAtLeast(1))
+            .take(bandLimit)
             .map { it.coerceIn(0f, 1f) }
         return copy(
             amplitude = amplitude.coerceIn(0f, 1f),
@@ -62,6 +67,12 @@ data class AudioAnalysisFrame(
             timestampMs = timestampMs.coerceAtLeast(0L),
         )
     }
+
+    private fun isNormalized(bandLimit: Int): Boolean =
+        amplitude in 0f..1f &&
+            timestampMs >= 0L &&
+            bands.size <= bandLimit &&
+            bands.all { it in 0f..1f }
 
     companion object {
         const val MaxBands = 128

--- a/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopSystemVolumeController.kt
+++ b/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopSystemVolumeController.kt
@@ -21,17 +21,32 @@ actual fun createSystemVolumeController(): SystemVolumeController {
 }
 
 /**
- * macOS system volume bridge. Uses `osascript` for both reads and writes:
+ * macOS system volume bridge, backed by CoreAudio:
  *
  *  - reads run every 400 ms so hardware volume keys propagate to the UI
  *  - writes go straight through; subsequent polls reconcile any drift
  *
+ * Reads and writes go through [MacCoreAudioVolume], which is a direct framework
+ * call. `osascript` remains only as a fallback for devices CoreAudio won't report
+ * a software volume for; because that path forks a process, it polls far less
+ * often (see [FALLBACK_POLL_MS]) — hardware key changes just take longer to show.
+ *
  * After a UI-driven write we ignore inbound polls for a short window so a slow
- * AppleScript response can't snap the slider back to a stale value.
+ * response can't snap the slider back to a stale value.
  */
 private class MacSystemVolumeController : SystemVolumeController {
     override val isSupported: Boolean = true
     override val controlsPlayerOutput: Boolean = false
+
+    /**
+     * True when CoreAudio owns volume for this machine, so polling never forks.
+     *
+     * Note this is not "CoreAudio returned a volume". Devices with no software
+     * volume read null through CoreAudio *and* through AppleScript, so falling
+     * back on a null read would fork a process every poll to learn nothing.
+     */
+    private val useCoreAudio: Boolean = MacCoreAudioVolume.isAvailable
+
     private val _volume = MutableStateFlow(readSystemVolume() ?: 0.7f)
     override val volume: StateFlow<Float> = _volume
     private var pollJob: Job? = null
@@ -41,9 +56,10 @@ private class MacSystemVolumeController : SystemVolumeController {
 
     override fun start(scope: CoroutineScope) {
         if (pollJob != null) return
+        val pollIntervalMs = if (useCoreAudio) POLL_MS else FALLBACK_POLL_MS
         pollJob = scope.launch(Dispatchers.IO) {
             while (isActive) {
-                delay(POLL_MS)
+                delay(pollIntervalMs)
                 if (System.currentTimeMillis() - lastWriteAt.get() < IGNORE_POLL_MS) continue
                 val current = readSystemVolume() ?: continue
                 if (kotlin.math.abs(current - _volume.value) > 0.005f) {
@@ -57,6 +73,7 @@ private class MacSystemVolumeController : SystemVolumeController {
         val clamped = value.coerceIn(0f, 1f)
         _volume.value = clamped
         lastWriteAt.set(System.currentTimeMillis())
+        if (MacCoreAudioVolume.writeVolume(clamped)) return
         runCatching {
             val percent = (clamped * 100f).toInt().coerceIn(0, 100)
             ProcessBuilder("osascript", "-e", "set volume output volume $percent")
@@ -66,7 +83,10 @@ private class MacSystemVolumeController : SystemVolumeController {
         }
     }
 
-    private fun readSystemVolume(): Float? = runCatching {
+    private fun readSystemVolume(): Float? =
+        if (useCoreAudio) MacCoreAudioVolume.readVolume() else readSystemVolumeViaAppleScript()
+
+    private fun readSystemVolumeViaAppleScript(): Float? = runCatching {
         val process = ProcessBuilder("osascript", "-e", "output volume of (get volume settings)")
             .redirectErrorStream(true)
             .start()
@@ -77,6 +97,7 @@ private class MacSystemVolumeController : SystemVolumeController {
 
     companion object {
         const val POLL_MS = 400L
+        const val FALLBACK_POLL_MS = 2_000L
         const val IGNORE_POLL_MS = 600L
     }
 }

--- a/playback/src/desktopMain/kotlin/com/phoebe/app/player/MacCoreAudioVolume.kt
+++ b/playback/src/desktopMain/kotlin/com/phoebe/app/player/MacCoreAudioVolume.kt
@@ -1,0 +1,150 @@
+package com.phoebe.app.player
+
+import com.phoebe.app.platform.PhoebeLog
+import com.sun.jna.Library
+import com.sun.jna.Native
+import com.sun.jna.Pointer
+import com.sun.jna.Structure
+import com.sun.jna.ptr.FloatByReference
+import com.sun.jna.ptr.IntByReference
+
+/**
+ * Reads and writes the macOS default output device volume through CoreAudio.
+ *
+ * The previous implementation shelled out to `osascript` for every read. At a
+ * 400 ms poll that forked a process ~2.5 times a second for the life of the app,
+ * costing roughly 15% of a core even while idle. These calls are plain C
+ * function calls into an already-loaded system framework instead.
+ *
+ * Returns null from every operation when CoreAudio is unavailable or the default
+ * device exposes no software volume control (common for HDMI and some USB DACs),
+ * so callers can fall back.
+ */
+internal object MacCoreAudioVolume {
+
+    /**
+     * True when CoreAudio can resolve a default output device, meaning it is the
+     * authoritative source for volume on this machine.
+     *
+     * Deliberately not "a volume was readable": a device that exposes no software
+     * volume (HDMI, many USB DACs, aggregates) has none for AppleScript to read
+     * either, so falling back to `osascript` there would fork a process per poll
+     * to learn nothing. Callers should treat false — not a null read — as the
+     * signal to try another mechanism.
+     */
+    val isAvailable: Boolean
+        get() = library?.let { defaultOutputDeviceId(it) != null } == true
+
+    /**
+     * Current output volume in 0..1, or null when the default output device has
+     * no software volume control.
+     */
+    fun readVolume(): Float? {
+        val lib = library ?: return null
+        val deviceId = defaultOutputDeviceId(lib) ?: return null
+        for (element in VolumeElements) {
+            val address = propertyAddress(PropertyVolumeScalar, ScopeOutput, element)
+            if (lib.AudioObjectHasProperty(deviceId, address) == FalseByte) continue
+            val value = FloatByReference()
+            val size = IntByReference(FloatBytes)
+            val status = lib.AudioObjectGetPropertyData(deviceId, address, 0, Pointer.NULL, size, value.pointer)
+            if (status == NoError) return value.value.coerceIn(0f, 1f)
+        }
+        return null
+    }
+
+    /** Sets the output volume. Returns false if CoreAudio could not apply it. */
+    fun writeVolume(value: Float): Boolean {
+        val lib = library ?: return false
+        val deviceId = defaultOutputDeviceId(lib) ?: return false
+        val clamped = value.coerceIn(0f, 1f)
+        var applied = false
+        for (element in VolumeElements) {
+            val address = propertyAddress(PropertyVolumeScalar, ScopeOutput, element)
+            if (lib.AudioObjectHasProperty(deviceId, address) == FalseByte) continue
+            val payload = FloatByReference(clamped)
+            val status = lib.AudioObjectSetPropertyData(deviceId, address, 0, Pointer.NULL, FloatBytes, payload.pointer)
+            if (status == NoError) {
+                applied = true
+                // The main element covers the whole device; per-channel elements
+                // only exist when it does not, so stop once one takes effect.
+                if (element == ElementMain) return true
+            }
+        }
+        return applied
+    }
+
+    private fun defaultOutputDeviceId(lib: CoreAudioLibrary): Int? {
+        val address = propertyAddress(PropertyDefaultOutputDevice, ScopeGlobal, ElementMain)
+        val deviceId = IntByReference()
+        val size = IntByReference(IntBytes)
+        val status = lib.AudioObjectGetPropertyData(SystemObject, address, 0, Pointer.NULL, size, deviceId.pointer)
+        if (status != NoError || deviceId.value == UnknownDevice) return null
+        return deviceId.value
+    }
+
+    private fun propertyAddress(selector: Int, scope: Int, element: Int) =
+        AudioObjectPropertyAddress().apply {
+            mSelector = selector
+            mScope = scope
+            mElement = element
+            write()
+        }
+
+    private val library: CoreAudioLibrary? by lazy {
+        runCatching {
+            Native.load("CoreAudio", CoreAudioLibrary::class.java)
+        }.onFailure { error ->
+            PhoebeLog.d("MacCoreAudioVolume") { "CoreAudio unavailable: ${error.message}" }
+        }.getOrNull()
+    }
+
+    /** Names mirror the C API exactly; JNA resolves symbols by method name. */
+    internal interface CoreAudioLibrary : Library {
+        /** CoreAudio's `Boolean` is an unsigned char, so take it as a byte, not a JNA int-width boolean. */
+        fun AudioObjectHasProperty(inObjectID: Int, inAddress: AudioObjectPropertyAddress): Byte
+
+        fun AudioObjectGetPropertyData(
+            inObjectID: Int,
+            inAddress: AudioObjectPropertyAddress,
+            inQualifierDataSize: Int,
+            inQualifierData: Pointer?,
+            ioDataSize: IntByReference,
+            outData: Pointer,
+        ): Int
+
+        fun AudioObjectSetPropertyData(
+            inObjectID: Int,
+            inAddress: AudioObjectPropertyAddress,
+            inQualifierDataSize: Int,
+            inQualifierData: Pointer?,
+            inDataSize: Int,
+            inData: Pointer,
+        ): Int
+    }
+
+    @Structure.FieldOrder("mSelector", "mScope", "mElement")
+    internal class AudioObjectPropertyAddress : Structure() {
+        @JvmField var mSelector: Int = 0
+
+        @JvmField var mScope: Int = 0
+
+        @JvmField var mElement: Int = 0
+    }
+
+    private const val NoError = 0
+    private const val FalseByte: Byte = 0
+    private const val SystemObject = 1
+    private const val UnknownDevice = 0
+    private const val IntBytes = 4
+    private const val FloatBytes = 4
+
+    private const val ElementMain = 0
+    private val VolumeElements = intArrayOf(ElementMain, 1, 2)
+
+    /** Four-character codes, as CoreAudio spells them. */
+    private const val PropertyDefaultOutputDevice = 0x644F7574 // 'dOut'
+    private const val PropertyVolumeScalar = 0x766F6C6D // 'volm'
+    private const val ScopeGlobal = 0x676C6F62 // 'glob'
+    private const val ScopeOutput = 0x6F757470 // 'outp'
+}

--- a/ui/media/src/androidMain/kotlin/com/phoebe/app/ui/ArtworkImageLoaderContext.android.kt
+++ b/ui/media/src/androidMain/kotlin/com/phoebe/app/ui/ArtworkImageLoaderContext.android.kt
@@ -1,0 +1,7 @@
+package com.phoebe.app.ui
+
+import coil3.PlatformContext
+import com.phoebe.app.AndroidContextHolder
+
+internal actual fun stableArtworkImageLoaderContext(platformContext: PlatformContext): PlatformContext =
+    AndroidContextHolder.application

--- a/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/ArtworkImageLoaderContext.kt
+++ b/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/ArtworkImageLoaderContext.kt
@@ -1,0 +1,11 @@
+package com.phoebe.app.ui
+
+import coil3.PlatformContext
+
+/**
+ * Context used to key and build the shared Coil [coil3.ImageLoader].
+ *
+ * On Android the Compose local context is usually an Activity, which changes on
+ * configuration updates; callers should use an application-stable context there.
+ */
+internal expect fun stableArtworkImageLoaderContext(platformContext: PlatformContext): PlatformContext

--- a/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeArtwork.kt
+++ b/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeArtwork.kt
@@ -143,7 +143,7 @@ private fun CoilArtworkImage(
                 .build()
         }
     }
-    val imageLoader = remember(platformContext) { phoebeArtworkImageLoader(platformContext) }
+    val imageLoader = rememberPhoebeArtworkImageLoader(platformContext)
     val painter = rememberAsyncImagePainter(model = request, imageLoader = imageLoader)
     val painterState by painter.state.collectAsState()
 
@@ -192,11 +192,41 @@ private fun CoilArtworkImage(
     }
 }
 
+/**
+ * One shared loader for every artwork composable.
+ *
+ * Building a loader per call site also built an HTTP client per call site — on
+ * desktop that is an OkHttp client with its own connection pool and dispatcher
+ * threads, so a screen full of list rows spun up dozens of them. A single loader
+ * also means one shared memory cache, so the same album art decodes once rather
+ * than once per widget.
+ *
+ * Keyed by context so a differing [PlatformContext] (tests, previews) still gets
+ * a correct loader rather than silently reusing another context's.
+ */
+private val artworkImageLoaders = mutableMapOf<PlatformContext, ImageLoader>()
+private val artworkImageLoaderLock = ArtworkCacheLock()
+
+internal fun phoebeArtworkImageLoader(context: PlatformContext): ImageLoader =
+    artworkImageLoaderLock.withCacheLock {
+        artworkImageLoaders.getOrPut(context) { buildArtworkImageLoader(context) }
+    }
+
+@Composable
+private fun rememberPhoebeArtworkImageLoader(context: PlatformContext): ImageLoader =
+    remember(context) { phoebeArtworkImageLoader(context) }
+
 @OptIn(ExperimentalCoilApi::class)
-private fun phoebeArtworkImageLoader(context: PlatformContext): ImageLoader =
+private fun buildArtworkImageLoader(context: PlatformContext): ImageLoader =
     ImageLoader.Builder(context)
         .components {
-            add(KtorNetworkFetcherFactory(createPlatformHttpClient(), ConcurrentRequestStrategy.UNCOORDINATED))
+            // Shares RemoteArtworkCache's client rather than minting another one.
+            add(
+                KtorNetworkFetcherFactory(
+                    RemoteArtworkCache.httpClient,
+                    ConcurrentRequestStrategy.UNCOORDINATED,
+                ),
+            )
         }
         .build()
 

--- a/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeArtwork.kt
+++ b/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeArtwork.kt
@@ -201,20 +201,25 @@ private fun CoilArtworkImage(
  * also means one shared memory cache, so the same album art decodes once rather
  * than once per widget.
  *
- * Keyed by context so a differing [PlatformContext] (tests, previews) still gets
- * a correct loader rather than silently reusing another context's.
+ * Keyed by a lifecycle-stable context ([stableArtworkImageLoaderContext]) so
+ * Android configuration changes do not retain old Activities and their caches.
+ * Non-Android platforms still key by the supplied context for tests and previews.
  */
 private val artworkImageLoaders = mutableMapOf<PlatformContext, ImageLoader>()
 private val artworkImageLoaderLock = ArtworkCacheLock()
 
-internal fun phoebeArtworkImageLoader(context: PlatformContext): ImageLoader =
-    artworkImageLoaderLock.withCacheLock {
-        artworkImageLoaders.getOrPut(context) { buildArtworkImageLoader(context) }
+internal fun phoebeArtworkImageLoader(context: PlatformContext): ImageLoader {
+    val loaderContext = stableArtworkImageLoaderContext(context)
+    return artworkImageLoaderLock.withCacheLock {
+        artworkImageLoaders.getOrPut(loaderContext) { buildArtworkImageLoader(loaderContext) }
     }
+}
 
 @Composable
-private fun rememberPhoebeArtworkImageLoader(context: PlatformContext): ImageLoader =
-    remember(context) { phoebeArtworkImageLoader(context) }
+private fun rememberPhoebeArtworkImageLoader(context: PlatformContext): ImageLoader {
+    val loaderContext = stableArtworkImageLoaderContext(context)
+    return remember(loaderContext) { phoebeArtworkImageLoader(context) }
+}
 
 @OptIn(ExperimentalCoilApi::class)
 private fun buildArtworkImageLoader(context: PlatformContext): ImageLoader =

--- a/ui/media/src/desktopMain/kotlin/com/phoebe/app/ui/ArtworkImageLoaderContext.desktop.kt
+++ b/ui/media/src/desktopMain/kotlin/com/phoebe/app/ui/ArtworkImageLoaderContext.desktop.kt
@@ -1,0 +1,6 @@
+package com.phoebe.app.ui
+
+import coil3.PlatformContext
+
+internal actual fun stableArtworkImageLoaderContext(platformContext: PlatformContext): PlatformContext =
+    platformContext

--- a/ui/media/src/iosMain/kotlin/com/phoebe/app/ui/ArtworkImageLoaderContext.ios.kt
+++ b/ui/media/src/iosMain/kotlin/com/phoebe/app/ui/ArtworkImageLoaderContext.ios.kt
@@ -1,0 +1,6 @@
+package com.phoebe.app.ui
+
+import coil3.PlatformContext
+
+internal actual fun stableArtworkImageLoaderContext(platformContext: PlatformContext): PlatformContext =
+    platformContext

--- a/ui/media/src/wasmJsMain/kotlin/com/phoebe/app/ui/ArtworkImageLoaderContext.wasmJs.kt
+++ b/ui/media/src/wasmJsMain/kotlin/com/phoebe/app/ui/ArtworkImageLoaderContext.wasmJs.kt
@@ -1,0 +1,6 @@
+package com.phoebe.app.ui
+
+import coil3.PlatformContext
+
+internal actual fun stableArtworkImageLoaderContext(platformContext: PlatformContext): PlatformContext =
+    platformContext


### PR DESCRIPTION
## Summary
- Size Skia GPU resource cache from display resolution at startup instead of a fixed 64M budget, reducing texture thrashing on large/HiDPI screens
- Gate desktop audio analysis collection to when the visualizer is actually shown (~20 fps savings otherwise)
- Skip redundant `AudioAnalysisFrame` normalization when already normalized
- Share a single Coil image loader (and HTTP client) across artwork composables instead of one per call site
- Replace macOS volume polling via `osascript` with direct CoreAudio calls, falling back to AppleScript only when CoreAudio is unavailable

## Test plan
- [x] `./gradlew :composeApp:compileKotlinDesktop :playback:compileKotlinDesktop :domain:compileKotlinDesktop`
- [ ] Desktop tests (CI)
- [ ] Manual: verify volume slider tracks hardware keys on macOS
- [ ] Manual: verify artwork loads correctly in lists and now-playing
- [ ] Manual: verify visualizer still animates when enabled


Made with [Cursor](https://cursor.com)