### PR TITLE
Improve Plex web playback resilience and memory pressure

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
@@ -31,6 +31,7 @@ import com.phoebe.app.domain.PlayHistoryKind
 import com.phoebe.app.domain.PlaybackQueueOrigin
 import com.phoebe.app.domain.PlayerQueueSnapshot
 import com.phoebe.app.domain.PlayerState
+import com.phoebe.app.domain.PlayerTimelineState
 import com.phoebe.app.domain.PlayerTransportState
 import com.phoebe.app.domain.ShellPlaybackState
 import com.phoebe.app.domain.PlexPin
@@ -85,6 +86,7 @@ import com.phoebe.app.domain.RecentSearchItem
 import com.phoebe.app.platform.MemoryPressureLevel
 import com.phoebe.app.platform.PhoebeAppLifecycle
 import com.phoebe.app.platform.PhoebeLog
+import com.phoebe.app.platform.shouldDeferCatalogMemoryUpdates
 import com.phoebe.app.platform.currentNetworkMeteringStatus
 import com.phoebe.app.platform.currentTimeMs
 import com.phoebe.app.platform.defaultDownloadWifiOnly
@@ -210,6 +212,26 @@ class AppState(
                 shuffle = player.value.shuffle,
                 repeat = player.value.repeat,
                 volume = player.value.volume,
+            ),
+        )
+    val playerTimeline: StateFlow<PlayerTimelineState> = player
+        .map { playback ->
+            PlayerTimelineState(
+                positionMs = playback.positionMs,
+                bufferedPositionMs = playback.bufferedPositionMs,
+                durationMs = playback.durationMs,
+                currentTrackId = playback.currentTrack?.id,
+            )
+        }
+        .distinctUntilChanged()
+        .stateIn(
+            playbackScope,
+            SharingStarted.Eagerly,
+            PlayerTimelineState(
+                positionMs = player.value.positionMs,
+                bufferedPositionMs = player.value.bufferedPositionMs,
+                durationMs = player.value.durationMs,
+                currentTrackId = player.value.currentTrack?.id,
             ),
         )
     val playerQueue: StateFlow<PlayerQueueSnapshot> = combine(
@@ -1632,6 +1654,7 @@ class AppState(
     }
 
     private fun shouldDeferBackgroundPlayHistorySync(): Boolean {
+        if (shouldDeferCatalogMemoryUpdates()) return true
         if (PhoebeAppLifecycle.isUiVisible) return false
         return dependencies.audioPlayer.state.value.isPlaying
     }
@@ -1689,6 +1712,10 @@ class AppState(
     private fun cancelPlexPlayCountRefresh() {
         plexPlayCountRefreshJob?.cancel()
         plexPlayCountRefreshJob = null
+    }
+
+    internal fun onPageVisibilityChanged(visible: Boolean) {
+        dependencies.audioPlayer.onPageVisibilityChanged(visible)
     }
 
     internal fun onMemoryPressure(level: MemoryPressureLevel) {

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeRoot.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeRoot.kt
@@ -2954,7 +2954,9 @@ private fun MobilePlayerHost(
     onDragEnd: (Float) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
-    val player by appState.player.collectAsState()
+    val player by appState.playerTimeline.collectAsState()
+    val shellPlayback by appState.shellPlayback.collectAsState()
+    val playerTransport by appState.playerTransport.collectAsState()
     val appSettings by appState.appSettings.collectAsState()
     val collectAudioAnalysis = expansionFraction > 0.6f &&
         appSettings.nowPlayingVisualizerPreset != NowPlayingVisualizerPreset.Artwork
@@ -2968,7 +2970,7 @@ private fun MobilePlayerHost(
     val equalizerProfile by appState.equalizerProfile.collectAsState()
     val equalizerRemoteUnavailable by appState.equalizerRemoteUnavailable.collectAsState()
     val listenBrainzFeedbackTarget by appState.listenBrainzFeedbackTarget.collectAsState()
-    val showStartingState = playbackStarting && track?.id != player.currentTrack?.id
+    val showStartingState = playbackStarting && track?.id != player.currentTrackId
     MobilePlaybackRoute(
         state = MobilePlaybackRouteState(
             track = track,
@@ -2976,10 +2978,10 @@ private fun MobilePlayerHost(
             upNextDivider = upNextDivider,
             keepPlayingEnabled = appSettings.keepPlayingEnabled,
             previousTrack = previousTrack,
-            isPlaying = if (showStartingState) false else player.isPlaying,
-            isBuffering = player.isBuffering || showStartingState,
-            shuffle = player.shuffle,
-            repeat = player.repeat,
+            isPlaying = if (showStartingState) false else shellPlayback.isPlaying,
+            isBuffering = shellPlayback.isBuffering || showStartingState,
+            shuffle = playerTransport.shuffle,
+            repeat = playerTransport.repeat,
             positionMs = if (showStartingState) 0L else player.positionMs,
             bufferedPositionMs = if (showStartingState) 0L else player.bufferedPositionMs,
             currentIndex = currentIndex,

--- a/composeApp/src/wasmJsMain/kotlin/com/phoebe/app/PlatformAppLifecycle.web.kt
+++ b/composeApp/src/wasmJsMain/kotlin/com/phoebe/app/PlatformAppLifecycle.web.kt
@@ -1,6 +1,9 @@
 package com.phoebe.app
 
+import com.phoebe.app.platform.PhoebeAppLifecycle
+import com.phoebe.app.platform.configurePlaybackMemoryPressure
 import com.phoebe.app.ui.RemoteArtworkCache
+import kotlinx.browser.document
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -10,10 +13,31 @@ import kotlinx.coroutines.launch
 
 private val lifecycleScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
+@OptIn(ExperimentalWasmJsInterop::class)
+@JsFun("() => !document.hidden")
+private external fun isWebDocumentVisible(): Boolean
+
 actual fun bindPlatformAppLifecycle(state: AppState) {
+    document.addEventListener("visibilitychange", {
+        val visible = isWebDocumentVisible()
+        PhoebeAppLifecycle.setUiVisible(visible)
+        if (visible) {
+            RemoteArtworkCache.retryFailedLoadsNow()
+            state.onPageVisibilityChanged(true)
+        }
+    })
     lifecycleScope.launch {
-        state.player
-            .map { player -> player.currentTrack?.id }
+        state.shellPlayback
+            .map { shell -> shell.isPlaying || shell.isBuffering }
+            .distinctUntilChanged()
+            .collect { active ->
+                configurePlaybackMemoryPressure(active)
+                RemoteArtworkCache.configurePlaybackMemoryMode(active)
+            }
+    }
+    lifecycleScope.launch {
+        state.shellPlayback
+            .map { shell -> shell.currentTrack?.id }
             .distinctUntilChanged()
             .collect { trackId ->
                 if (trackId != null) {

--- a/core/platform/src/androidMain/kotlin/com/phoebe/app/platform/AndroidPlatform.kt
+++ b/core/platform/src/androidMain/kotlin/com/phoebe/app/platform/AndroidPlatform.kt
@@ -515,6 +515,10 @@ actual fun remoteArtworkLoadParallelism(): Int = 2
 
 actual fun catalogTrackIndexParallelism(): Int = 6
 
+actual fun configurePlaybackMemoryPressure(active: Boolean) = Unit
+
+actual fun shouldDeferCatalogMemoryUpdates(): Boolean = false
+
 actual fun downloadParallelism(): Int = 2
 
 actual fun schedulePlatformDownloadRunner() = Unit

--- a/core/platform/src/commonMain/kotlin/com/phoebe/app/platform/Platform.kt
+++ b/core/platform/src/commonMain/kotlin/com/phoebe/app/platform/Platform.kt
@@ -76,6 +76,11 @@ expect fun remoteArtworkLoadParallelism(): Int
 /** Concurrent Plex library track-index page fetches during catalog sync. */
 expect fun catalogTrackIndexParallelism(): Int
 
+/** Web playback: skip publishing large in-memory catalog mutations while audio is active. */
+expect fun configurePlaybackMemoryPressure(active: Boolean)
+
+expect fun shouldDeferCatalogMemoryUpdates(): Boolean
+
 /** Concurrent audio downloads during offline download batches. */
 expect fun downloadParallelism(): Int
 

--- a/core/platform/src/desktopMain/kotlin/com/phoebe/app/platform/DesktopPlatform.kt
+++ b/core/platform/src/desktopMain/kotlin/com/phoebe/app/platform/DesktopPlatform.kt
@@ -292,6 +292,10 @@ actual fun remoteArtworkLoadParallelism(): Int = 8
 
 actual fun catalogTrackIndexParallelism(): Int = 6
 
+actual fun configurePlaybackMemoryPressure(active: Boolean) = Unit
+
+actual fun shouldDeferCatalogMemoryUpdates(): Boolean = false
+
 actual fun downloadParallelism(): Int = 6
 
 actual fun schedulePlatformDownloadRunner() = Unit

--- a/core/platform/src/iosMain/kotlin/com/phoebe/app/platform/IosPlatform.kt
+++ b/core/platform/src/iosMain/kotlin/com/phoebe/app/platform/IosPlatform.kt
@@ -286,6 +286,10 @@ actual fun remoteArtworkLoadParallelism(): Int = 8
 
 actual fun catalogTrackIndexParallelism(): Int = 6
 
+actual fun configurePlaybackMemoryPressure(active: Boolean) = Unit
+
+actual fun shouldDeferCatalogMemoryUpdates(): Boolean = false
+
 actual fun downloadParallelism(): Int = 3
 
 actual fun schedulePlatformDownloadRunner() = Unit

--- a/core/platform/src/wasmJsMain/kotlin/com/phoebe/app/platform/WebPlatform.kt
+++ b/core/platform/src/wasmJsMain/kotlin/com/phoebe/app/platform/WebPlatform.kt
@@ -176,11 +176,19 @@ actual fun currentTimeMs(): Long = jsDateNow().toLong()
 
 actual fun prefersReducedArtworkEffects(): Boolean = true
 
-actual fun remoteArtworkCacheMaxEstimatedBytes(): Long = 6L * 1024L * 1024L
+actual fun remoteArtworkCacheMaxEstimatedBytes(): Long = 8L * 1024L * 1024L
 
-actual fun remoteArtworkLoadParallelism(): Int = 8
+actual fun remoteArtworkLoadParallelism(): Int = 4
 
 actual fun catalogTrackIndexParallelism(): Int = 1
+
+private var webPlaybackMemoryPressureActive = false
+
+actual fun configurePlaybackMemoryPressure(active: Boolean) {
+    webPlaybackMemoryPressureActive = active
+}
+
+actual fun shouldDeferCatalogMemoryUpdates(): Boolean = webPlaybackMemoryPressureActive
 
 actual fun downloadParallelism(): Int = 3
 

--- a/data/catalog/src/commonMain/kotlin/com/phoebe/app/data/CatalogRepository.kt
+++ b/data/catalog/src/commonMain/kotlin/com/phoebe/app/data/CatalogRepository.kt
@@ -7762,7 +7762,15 @@ class CatalogRepository(
 
     private fun withSmartPlaylists(snapshot: CatalogSnapshot): CatalogSnapshot {
         if (shouldDeferCatalogMemoryUpdates()) {
-            return snapshot.withoutSmartPlaylistArtifacts()
+            val preserved = mutableCatalog.value
+            val base = snapshot.withoutSmartPlaylistArtifacts()
+            val smartPlaylists = preserved.playlists.filter { it.isSmartPlaylist() }
+            if (smartPlaylists.isEmpty()) return base
+            val smartTracksByParent = preserved.tracksByParent.filterKeys { it.startsWith(SmartPlaylist.IdPrefix) }
+            return base.copy(
+                playlists = (smartPlaylists.sortedBy { it.title.lowercase() } + base.playlists.sortedBy { it.title.lowercase() }),
+                tracksByParent = base.tracksByParent + smartTracksByParent,
+            )
         }
         val base = snapshot.withoutSmartPlaylistArtifacts()
         val smartPlaylists = userArtifactsRepository.smartPlaylists.value.filter { it.enabled }

--- a/data/catalog/src/commonMain/kotlin/com/phoebe/app/data/CatalogRepository.kt
+++ b/data/catalog/src/commonMain/kotlin/com/phoebe/app/data/CatalogRepository.kt
@@ -78,6 +78,7 @@ import com.phoebe.app.platform.PhoebeLog
 import com.phoebe.app.platform.catalogTrackIndexParallelism
 import com.phoebe.app.platform.currentTimeMs
 import com.phoebe.app.platform.downloadParallelism
+import com.phoebe.app.platform.shouldDeferCatalogMemoryUpdates
 import com.phoebe.app.platform.isDesktopPlatform
 import com.phoebe.app.platform.platformStreamHttpDownloadToStorage
 import com.phoebe.app.sources.CatalogMerge
@@ -3171,6 +3172,7 @@ class CatalogRepository(
         }
 
     private suspend fun publishIndexedPlexTracks(rawTracks: List<Track>) {
+        if (shouldDeferCatalogMemoryUpdates()) return
         val tracksByAlbum = rawTracks
             .map { it.withPlexPrefix() }
             .groupBy { track -> resolveIndexedTrackParentId(track, mutableCatalog.value) }
@@ -7759,6 +7761,9 @@ class CatalogRepository(
     }
 
     private fun withSmartPlaylists(snapshot: CatalogSnapshot): CatalogSnapshot {
+        if (shouldDeferCatalogMemoryUpdates()) {
+            return snapshot.withoutSmartPlaylistArtifacts()
+        }
         val base = snapshot.withoutSmartPlaylistArtifacts()
         val smartPlaylists = userArtifactsRepository.smartPlaylists.value.filter { it.enabled }
         if (smartPlaylists.isEmpty()) return base

--- a/domain/src/commonMain/kotlin/com/phoebe/app/domain/Models.kt
+++ b/domain/src/commonMain/kotlin/com/phoebe/app/domain/Models.kt
@@ -2108,6 +2108,14 @@ data class PlayerTransportState(
     val volume: Float = 1f,
 )
 
+/** Progress fields for now-playing UI without queue-sized player updates. */
+data class PlayerTimelineState(
+    val positionMs: Long = 0L,
+    val bufferedPositionMs: Long = 0L,
+    val durationMs: Long = 0L,
+    val currentTrackId: String? = null,
+)
+
 /** Queue snapshot for up-next / skip UI; ignores position-only player updates. */
 data class PlayerQueueSnapshot(
     val queue: List<Track> = emptyList(),

--- a/feature/playback/src/commonMain/kotlin/com/phoebe/app/feature/playback/MobilePlayer.kt
+++ b/feature/playback/src/commonMain/kotlin/com/phoebe/app/feature/playback/MobilePlayer.kt
@@ -771,7 +771,7 @@ fun MobilePlayer(
                         FlippableSongArtwork(
                             track = t,
                             modifier = Modifier.fillMaxSize(),
-                            maxDecodeDimension = HeroArtworkMaxDecodeDimension,
+                            maxDecodeDimension = playerHeroArtworkMaxDecodeDimension(),
                             shape = artworkContentShape,
                             forceSquare = false,
                         ) {

--- a/playback/src/commonMain/kotlin/com/phoebe/app/data/PlexPlaybackReporter.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/data/PlexPlaybackReporter.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -123,7 +124,18 @@ class PlexPlaybackReporter(
         }
 
         try {
-            combine(audioPlayer.state, session) { player, sess -> player to sess }
+            combine(
+                audioPlayer.state.distinctUntilChangedBy { player ->
+                    PlaybackReporterKey(
+                        trackId = player.currentTrack?.id,
+                        isPlaying = player.isPlaying,
+                        isBuffering = player.isBuffering,
+                        queueSize = player.queue.size,
+                        currentIndex = player.currentIndex,
+                    )
+                },
+                session,
+            ) { player, sess -> player to sess }
                 .collect { (player, sess) ->
                     if (sess != null) lastSession = sess
                     val track = player.currentTrack
@@ -383,3 +395,11 @@ class PlexPlaybackReporter(
         }
     }
 }
+
+private data class PlaybackReporterKey(
+    val trackId: String?,
+    val isPlaying: Boolean,
+    val isBuffering: Boolean,
+    val queueSize: Int,
+    val currentIndex: Int,
+)

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/AudioPlayer.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/AudioPlayer.kt
@@ -80,6 +80,9 @@ interface AudioPlayer {
     fun setSystemVolumeScale(scale: Float) = Unit
 
     fun close() = Unit
+
+    /** Browser tab visibility; web uses this to resume queue playback after backgrounding. */
+    fun onPageVisibilityChanged(visible: Boolean) = Unit
 }
 
 private val EmptyAudioOutputDevicesState = MutableStateFlow<List<AudioOutputDevice>>(emptyList())

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/PlexTranscodeUrls.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/PlexTranscodeUrls.kt
@@ -1,10 +1,12 @@
 package com.phoebe.app.player
 
+import com.phoebe.app.data.PlexClient
 import com.phoebe.app.domain.Track
 import io.ktor.http.URLBuilder
 import io.ktor.http.Url
 import io.ktor.http.encodedPath
 import io.ktor.http.takeFrom
+import kotlin.random.Random
 
 /** Plex rating key for universal transcode URLs, with or without a `plex:` id prefix. */
 internal fun Track.plexRatingKey(): String? {
@@ -41,7 +43,53 @@ internal fun Track.jellyfinFamilyMp3TranscodeUrl(): String? {
 internal fun jellyfinFamilyAudioItemId(encodedPath: String): String? =
     Regex("""/Audio/([^/]+)/stream(?:\.[^/]+)?""").find(encodedPath)?.groupValues?.getOrNull(1)
 
-internal fun Track.plexUniversalMp3TranscodeUrl(): String? {
+internal fun Track.plexUniversalMp3TranscodeUrl(): String? =
+    buildPlexUniversalMp3TranscodeUrl()
+
+/**
+ * Plex Web uses a slimmer query than Chromecast/Flatpak. Extra transcode knobs such as
+ * `directPlay=0` or `X-Plex-Client-Profile-Extra` can make current PMS builds return 400.
+ */
+internal fun Track.plexWebUniversalMp3TranscodeUrl(): String? {
+    val ratingKey = plexRatingKey() ?: return null
+    val parsed = runCatching { Url(streamUrl) }.getOrNull() ?: return null
+    val token = parsed.parameters["X-Plex-Token"].orEmpty()
+    if (parsed.protocol.name.isBlank() || parsed.host.isBlank() || token.isBlank()) return null
+    val metadataPath = URLBuilder()
+        .takeFrom(parsed)
+        .apply {
+            encodedPath = "/library/metadata/$ratingKey"
+            parameters.clear()
+        }
+        .buildString()
+    return runCatching {
+        URLBuilder()
+            .takeFrom(parsed)
+            .apply {
+                encodedPath = "/music/:/transcode/universal/start.mp3"
+                parameters.clear()
+                parameters.append("path", metadataPath)
+                parameters.append("mediaIndex", "0")
+                parameters.append("partIndex", "0")
+                parameters.append("maxAudioBitrate", "320")
+                parameters.append("protocol", parsed.protocol.name)
+                parameters.append("session", randomPlexTranscodeSession())
+                parameters.append("offset", "0")
+                parameters.append("X-Plex-Token", token)
+                parameters.append("X-Plex-Client-Identifier", PlexClient.ClientIdentifier)
+                parameters.append("X-Plex-Product", "Phoebe")
+                parameters.append("X-Plex-Version", "0.1.0")
+                parameters.append("X-Plex-Platform", "Chrome")
+                parameters.append("X-Plex-Device", "Web")
+                parameters.append("X-Plex-Device-Name", "Phoebe Web")
+            }
+            .buildString()
+    }.getOrNull()
+}
+
+private fun Track.buildPlexUniversalMp3TranscodeUrl(
+    extraParameters: Map<String, String> = emptyMap(),
+): String? {
     val ratingKey = plexRatingKey() ?: return null
     val parsed = runCatching { Url(streamUrl) }.getOrNull() ?: return null
     val token = parsed.parameters["X-Plex-Token"].orEmpty()
@@ -55,16 +103,25 @@ internal fun Track.plexUniversalMp3TranscodeUrl(): String? {
                 parameters.append("path", "/library/metadata/$ratingKey")
                 parameters.append("mediaIndex", "0")
                 parameters.append("partIndex", "0")
-                parameters.append("protocol", "http")
+                parameters.append("protocol", parsed.protocol.name)
                 parameters.append("format", "mp3")
                 parameters.append("audioCodec", "mp3")
                 parameters.append("directPlay", "0")
                 parameters.append("directStream", "0")
                 parameters.append("X-Plex-Token", token)
+                extraParameters.forEach { (key, value) -> parameters.append(key, value) }
             }
             .buildString()
     }.getOrNull()
 }
+
+private fun randomPlexTranscodeSession(): String =
+    buildString(16) {
+        val chars = "abcdefghijklmnopqrstuvwxyz0123456789"
+        repeat(16) {
+            append(chars[Random.nextInt(chars.length)])
+        }
+    }
 
 internal fun Track.hasChromecastDirectPlayableCodec(): Boolean =
     when (audioCodec?.lowercase()) {
@@ -114,3 +171,16 @@ private fun normalizeAudioCodecSuffix(codec: String): String =
 /** MP3 transcode URL for formats Java Sound cannot decode in Flatpak (Plex, Jellyfin, Emby). */
 internal fun Track.flatpakSandboxTranscodeUrl(): String? =
     plexUniversalMp3TranscodeUrl() ?: jellyfinFamilyMp3TranscodeUrl()
+
+/**
+ * Browser playback keeps MP3/AAC/M4A on the direct Plex part URL. Lossless sources can opt into
+ * Plex Web's slimmer universal MP3 transcode endpoint when the browser cannot decode them safely.
+ */
+internal fun Track.webPlaybackStreamUrl(): String {
+    if (streamUrl.isBlank()) return streamUrl
+    if (hasChromecastDirectPlayableCodec()) return streamUrl
+    return plexWebUniversalMp3TranscodeUrl() ?: jellyfinFamilyMp3TranscodeUrl() ?: streamUrl
+}
+
+internal fun String.isPlexWebTranscodeUrl(): Boolean =
+    contains("/music/:/transcode/universal/start.mp3", ignoreCase = true)

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
@@ -508,8 +508,8 @@ abstract class SimpleAudioPlayer(
         } else {
             stopProgressTicker()
         }
-        maybeStartCrossfade(generation)
-        maybeStartGapless(generation)
+        maybeStartCrossfadeAtPosition(generation, positionMs)
+        maybeStartGaplessAtPosition(generation, positionMs)
     }
 
     protected fun publishAudioAnalysis(frame: AudioAnalysisFrame) {
@@ -750,8 +750,8 @@ abstract class SimpleAudioPlayer(
                 if (!current.isPlaying) break
                 val nextPosition = (current.positionMs + 1000L).coerceAtMost(current.durationMs)
                 mutableState.value = current.copy(positionMs = nextPosition)
-                maybeStartCrossfade(activePlayGeneration)
-                maybeStartGapless(activePlayGeneration)
+                maybeStartCrossfadeAtPosition(activePlayGeneration, nextPosition)
+                maybeStartGaplessAtPosition(activePlayGeneration, nextPosition)
                 if (nextPosition >= current.durationMs && current.durationMs > 0L) break
             }
         }
@@ -776,6 +776,10 @@ abstract class SimpleAudioPlayer(
     }
 
     private fun markPlaybackStartupTimedOut(generation: Int) {
+        onPlaybackStartupTimedOut(generation)
+    }
+
+    protected open fun onPlaybackStartupTimedOut(generation: Int) {
         if (!isPlayRequestCurrent(generation)) return
         stopPlaybackStartupWatchdog()
         val previousErrorSerial = mutableState.value.playbackErrorSerial
@@ -799,14 +803,14 @@ abstract class SimpleAudioPlayer(
     protected open val playbackStartupTimeoutMs: Long
         get() = PlaybackStartupTimeoutMs
 
-    private fun maybeStartCrossfade(generation: Int) {
+    protected fun maybeStartCrossfadeAtPosition(generation: Int, positionMs: Long) {
         val duration = crossfadeDurationMs
         if (duration <= 0L || !isPlayRequestCurrent(generation)) return
         val current = mutableState.value
         if (!current.isPlaying || current.durationMs <= 0L || current.currentIndex !in current.queue.indices) return
         if (manualSeekCrossfadeSuppression?.matches(generation, current.currentTrack?.id) == true) return
         if (current.currentIndex >= current.queue.lastIndex && current.repeat != RepeatMode.All) return
-        val remaining = current.durationMs - current.positionMs
+        val remaining = current.durationMs - positionMs
         if (remaining > duration) return
         val target = when (current.repeat) {
             RepeatMode.One -> current.currentIndex
@@ -836,7 +840,7 @@ abstract class SimpleAudioPlayer(
         return false
     }
 
-    private fun maybeStartGapless(generation: Int) {
+    protected fun maybeStartGaplessAtPosition(generation: Int, positionMs: Long) {
         if (!isGaplessConfigured || !isPlayRequestCurrent(generation)) return
         val current = mutableState.value
         if (!current.isPlaying ||
@@ -846,7 +850,7 @@ abstract class SimpleAudioPlayer(
         ) {
             return
         }
-        val remainingMs = current.durationMs - current.positionMs
+        val remainingMs = current.durationMs - positionMs
         if (remainingMs > GaplessPrepareWindowMs) return
         val targetIndex = gaplessTargetIndex(current) ?: return
         val targetTrack = current.queue.getOrNull(targetIndex)?.takeIf { it.isGaplessCandidate() } ?: return

--- a/playback/src/commonTest/kotlin/com/phoebe/app/CastControllerTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/CastControllerTest.kt
@@ -251,7 +251,7 @@ class CastControllerTest {
 
         assertEquals("audio/mpeg", descriptor.contentType)
         assertEquals(
-            "https://plex.example:32400/music/:/transcode/universal/start.mp3?path=%2Flibrary%2Fmetadata%2F12345&mediaIndex=0&partIndex=0&protocol=http&format=mp3&audioCodec=mp3&directPlay=0&directStream=0&X-Plex-Token=token",
+            "https://plex.example:32400/music/:/transcode/universal/start.mp3?path=%2Flibrary%2Fmetadata%2F12345&mediaIndex=0&partIndex=0&protocol=https&format=mp3&audioCodec=mp3&directPlay=0&directStream=0&X-Plex-Token=token",
             descriptor.castUrl,
         )
     }

--- a/playback/src/commonTest/kotlin/com/phoebe/app/player/PlexTranscodeUrlsTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/player/PlexTranscodeUrlsTest.kt
@@ -4,6 +4,7 @@ import com.phoebe.app.domain.Track
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class PlexTranscodeUrlsTest {
     @Test
@@ -51,8 +52,86 @@ class PlexTranscodeUrlsTest {
             audioCodec = "aac",
         )
         assertEquals(
-            "https://plex.example:32400/music/:/transcode/universal/start.mp3?path=%2Flibrary%2Fmetadata%2F124&mediaIndex=0&partIndex=0&protocol=http&format=mp3&audioCodec=mp3&directPlay=0&directStream=0&X-Plex-Token=token",
+            "https://plex.example:32400/music/:/transcode/universal/start.mp3?path=%2Flibrary%2Fmetadata%2F124&mediaIndex=0&partIndex=0&protocol=https&format=mp3&audioCodec=mp3&directPlay=0&directStream=0&X-Plex-Token=token",
             plexTrack.flatpakSandboxTranscodeUrl(),
         )
+    }
+
+    @Test
+    fun webPlaybackStreamUrlTranscodesLosslessPlexTracksForBrowser() {
+        val plexFlacTrack = Track(
+            id = "plex:456",
+            title = "Track",
+            artist = "Artist",
+            album = "Album",
+            durationMs = 240_000,
+            streamUrl = "https://plex.example:32400/library/parts/9.flac?X-Plex-Token=token",
+            downloadUrl = "",
+            audioCodec = "flac",
+        )
+        val playbackUrl = plexFlacTrack.webPlaybackStreamUrl()
+        assertEquals(
+            "https://plex.example:32400/music/:/transcode/universal/start.mp3",
+            playbackUrl.substringBefore('?'),
+        )
+        assertTrue(
+            playbackUrl.contains("path=https%3A%2F%2Fplex.example%3A32400%2Flibrary%2Fmetadata%2F456"),
+        )
+        assertTrue(playbackUrl.contains("protocol=https"))
+        assertTrue(playbackUrl.contains("X-Plex-Client-Identifier=phoebe-compose-multiplatform"))
+        assertTrue(playbackUrl.contains("session="))
+    }
+
+    @Test
+    fun webPlaybackStreamUrlDirectPlaysPlexMp3() {
+        val plexMp3Track = Track(
+            id = "plex:124",
+            title = "Track",
+            artist = "Artist",
+            album = "Album",
+            durationMs = 180_000,
+            streamUrl = "https://plex.example:32400/library/parts/2.mp3?X-Plex-Token=token",
+            downloadUrl = "",
+            audioCodec = "mp3",
+        )
+        assertEquals(plexMp3Track.streamUrl, plexMp3Track.webPlaybackStreamUrl())
+    }
+
+    @Test
+    fun plexWebUniversalMp3TranscodeUrlUsesAbsoluteMetadataPath() {
+        val plexFlacTrack = Track(
+            id = "plex:456",
+            title = "Track",
+            artist = "Artist",
+            album = "Album",
+            durationMs = 240_000,
+            streamUrl = "https://plex.example:32400/library/parts/9.flac?X-Plex-Token=token",
+            downloadUrl = "",
+            audioCodec = "flac",
+        )
+        val transcodeUrl = plexFlacTrack.plexWebUniversalMp3TranscodeUrl().orEmpty()
+        assertTrue(
+            transcodeUrl.contains(
+                "path=https%3A%2F%2Fplex.example%3A32400%2Flibrary%2Fmetadata%2F456",
+            ),
+        )
+        assertTrue(transcodeUrl.contains("session="))
+        assertTrue(transcodeUrl.contains("X-Plex-Client-Identifier=phoebe-compose-multiplatform"))
+        assertTrue(!transcodeUrl.contains("Client-Profile-Extra"))
+        assertTrue(!transcodeUrl.contains("directPlay=0"))
+    }
+
+    @Test
+    fun webPlaybackStreamUrlFallsBackToDirectStreamForUnsupportedSources() {
+        val track = Track(
+            id = "remote-1",
+            title = "Track",
+            artist = "Artist",
+            album = "Album",
+            durationMs = 180_000,
+            streamUrl = "https://music.example.test/track.mp3",
+            downloadUrl = "",
+        )
+        assertEquals(track.streamUrl, track.webPlaybackStreamUrl())
     }
 }

--- a/playback/src/desktopTest/kotlin/com/phoebe/app/player/DesktopPlaybackStartupPolicyTest.kt
+++ b/playback/src/desktopTest/kotlin/com/phoebe/app/player/DesktopPlaybackStartupPolicyTest.kt
@@ -252,7 +252,7 @@ class DesktopPlaybackStartupPolicyTest {
                 filepath = "/music/Artist/Album/02 Track.m4a",
             )
             assertEquals(
-                "https://plex.example:32400/music/:/transcode/universal/start.mp3?path=%2Flibrary%2Fmetadata%2F124&mediaIndex=0&partIndex=0&protocol=http&format=mp3&audioCodec=mp3&directPlay=0&directStream=0&X-Plex-Token=token",
+                "https://plex.example:32400/music/:/transcode/universal/start.mp3?path=%2Flibrary%2Fmetadata%2F124&mediaIndex=0&partIndex=0&protocol=https&format=mp3&audioCodec=mp3&directPlay=0&directStream=0&X-Plex-Token=token",
                 DesktopSandboxPlayback.playbackStreamUrlForTrack(track),
             )
         } finally {

--- a/playback/src/wasmJsMain/kotlin/com/phoebe/app/player/WebAudioPlayer.kt
+++ b/playback/src/wasmJsMain/kotlin/com/phoebe/app/player/WebAudioPlayer.kt
@@ -376,6 +376,9 @@ private class WebAudioPlayer(
             playWebAudio(generation)
         }
         syncFromAudio(generation, isBuffering = false)
+        if (hotStarted) {
+            startWebPositionPoll(generation, incoming)
+        }
         return true
     }
 
@@ -644,6 +647,7 @@ private class WebAudioPlayer(
             incomingTrackId = queue[targetIndex].id,
         )
         syncFromAudio(generation, isBuffering = false)
+        startWebPositionPoll(generation, incoming)
         startWebAudioPrefetchIfNeeded(currentUri, generation)
     }
 

--- a/playback/src/wasmJsMain/kotlin/com/phoebe/app/player/WebAudioPlayer.kt
+++ b/playback/src/wasmJsMain/kotlin/com/phoebe/app/player/WebAudioPlayer.kt
@@ -1,6 +1,7 @@
 package com.phoebe.app.player
 
 import com.phoebe.app.domain.EqualizerProfile
+import com.phoebe.app.domain.RepeatMode
 import com.phoebe.app.domain.Track
 import com.phoebe.app.platform.resolveWebDownloadObjectUrl
 import com.phoebe.app.sources.resolveWebLocalAudioUri
@@ -53,23 +54,60 @@ private class WebAudioPlayer(
     private var webGaplessHotStartRequested = false
     private var webGaplessHotStarted = false
     private var webGaplessHotStartJob: Job? = null
+    private var directStreamFallbackUri: String? = null
+    private var lastSyncedPositionMs = -1L
+    private var lastSyncedPlaying = false
+    private var lastSyncedBuffering = false
+    private var webPositionPollJob: Job? = null
+    private var remoteTrackLoadJob: Job? = null
+    private var remoteFreshAudioRetryAttempted = false
+    private var webAdvanceAfterEndGeneration = -1
 
     private var audio = createAudioElement(useCors = true)
 
+    override fun onPageVisibilityChanged(visible: Boolean) {
+        if (!visible) return
+        val generation = activePlayGeneration
+        if (!playWhenReady || !isPlayRequestCurrent(generation)) return
+        maybeAdvanceWhenWebAudioEnded(generation)
+        if (audio.paused && !isWebAudioEnded(audio) && !isWebAudioAtEnd(audio)) {
+            playWebAudio(generation)
+        } else if (!webPositionPollJobActive()) {
+            startWebPositionPoll(generation, audio)
+        }
+    }
+
+    override fun onPlaybackStartupTimedOut(generation: Int) {
+        if (isPlayRequestCurrent(generation) && state.value.isBuffering &&
+            shouldSkipToNextWebTrackAfterFailure(generation)
+        ) {
+            requestAdvanceAfterWebTrackEnded(generation)
+            return
+        }
+        super.onPlaybackStartupTimedOut(generation)
+    }
+
     override fun stopCurrentPlaybackImmediately() {
+        stopWebPositionPoll()
+        remoteTrackLoadJob?.cancel()
+        remoteTrackLoadJob = null
         retryJob?.cancel()
         stopWebCrossfade()
         stopWebGapless()
         stopWebAudioAnalysis(audio)
+        clearWebAudioEventHandlers(audio)
         cancelWebAudioPrefetch()
         resetWebAudioPrefetch()
         clearPendingReloadRestore()
+        releaseWebAudioMediaBuffers(audio)
         audio.pause()
     }
 
     override fun playTrack(track: Track) {
+        val directStreamUri = track.streamUrl.takeIf { it.isNotBlank() }
         val localUri = track.localUri?.takeIf { it.isNotBlank() }
-        val streamUri = track.streamUrl.takeIf { it.isNotBlank() }
+        val streamUri = track.webPlaybackStreamUrl().takeIf { it.isNotBlank() }
+        directStreamFallbackUri = directStreamUri?.takeIf { streamUri != null && it != streamUri }
         playUri(
             uri = localUri ?: streamUri.orEmpty(),
             fallbackUri = streamUri?.takeIf { localUri?.startsWith("web-download://") == true },
@@ -78,6 +116,12 @@ private class WebAudioPlayer(
 
     override fun playUri(uri: String) {
         playUri(uri, fallbackUri = null)
+    }
+
+    private fun webPlaybackUriForTrack(track: Track): String {
+        val localUri = track.localUri?.takeIf { it.isNotBlank() }
+        if (localUri != null) return localUri
+        return track.webPlaybackStreamUrl().takeIf { it.isNotBlank() }.orEmpty()
     }
 
     private fun playUri(uri: String, fallbackUri: String?) {
@@ -106,6 +150,9 @@ private class WebAudioPlayer(
 
     private fun playResolvedUri(playbackUri: String) {
         val generation = activePlayGeneration
+        stopWebPositionPoll()
+        remoteTrackLoadJob?.cancel()
+        remoteTrackLoadJob = null
         diagnostics.engineSelected(PlaybackEnginePath.WebAudioElement)
         currentUri = playbackUri
         retryGeneration = generation
@@ -113,15 +160,23 @@ private class WebAudioPlayer(
         stopWebCrossfade()
         stopWebGapless()
         corsFallbackAttempted = false
+        remoteFreshAudioRetryAttempted = false
+        webAdvanceAfterEndGeneration = -1
         equalizerUnavailableForCurrentStream = false
         equalizerUnavailableNoticeShown = false
         retryJob?.cancel()
         cancelWebAudioPrefetch()
         resetWebAudioPrefetch(generation)
+        lastSyncedPositionMs = -1L
+        lastSyncedPlaying = false
+        lastSyncedBuffering = false
         stopWebAudioAnalysis(audio)
+        clearWebAudioEventHandlers(audio)
         teardownWebAudioRouting(audio)
         releaseWebAudioMediaBuffers(audio)
         sourcePreparedForWebEqualizer = false
+        // Reuse the same <audio> element for remote streams. Creating a fresh element per track
+        // lets Chrome retain decoded media buffers and climbs renderer memory during shuffle.
         val needsFreshAudioElement = GraphicEqualizerProcessor.isActive(equalizerProfile.normalized()) ||
             isWebEqualizerAttached(audio)
         if (needsFreshAudioElement) {
@@ -138,14 +193,27 @@ private class WebAudioPlayer(
             audioUsesCors = true
             disposeWebAudioElement(previousAudio)
         }
-        prepareAudioElementForCurrentEqualizer()
-        setWebAudioCurrentTime(audio, 0.0)
-        installAudioEventHandlers(generation)
-        audio.src = playbackUri
-        audio.load()
-        applyCurrentEqualizer()
-        if (playWhenReady) {
-            playWebAudio(generation)
+
+        fun startPlayback() {
+            if (!isPlayRequestCurrent(generation) || currentUri != playbackUri) return
+            prepareAudioElementForCurrentEqualizer()
+            setWebAudioCurrentTime(audio, 0.0)
+            installAudioEventHandlers(generation)
+            audio.src = playbackUri
+            audio.load()
+            applyCurrentEqualizer()
+            if (playWhenReady) {
+                playWebAudio(generation)
+            }
+        }
+
+        if (playbackUri.isRemoteWebAudioUri()) {
+            remoteTrackLoadJob = scope.launch {
+                delay(WebRemoteTrackLoadDeferMs)
+                startPlayback()
+            }
+        } else {
+            startPlayback()
         }
     }
 
@@ -203,9 +271,11 @@ private class WebAudioPlayer(
         generation: Int,
     ): Boolean {
         if (targetIndex !in queue.indices || audio.paused) return false
-        val rawUri = track.localUri?.takeIf { it.isNotBlank() } ?: track.streamUrl.takeIf { it.isNotBlank() } ?: return false
+        val rawUri = webPlaybackUriForTrack(track).takeIf { it.isNotBlank() } ?: return false
         if (rawUri.startsWith("web-download://")) return false
         val playbackUri = resolveWebLocalAudioUri(rawUri)
+        // Preloading a second remote stream doubles Chrome media memory on web.
+        if (playbackUri.isRemoteWebAudioUri()) return false
         stopWebGapless()
         val prepared = createAudioElement(useCors = audioUsesCors, preload = webAudioPreloadForUri(playbackUri))
         webGaplessAudio = prepared
@@ -354,7 +424,7 @@ private class WebAudioPlayer(
         onResolved: (String) -> Unit,
     ): Boolean {
         val localUri = track.localUri?.takeIf { it.isNotBlank() }
-        val streamUri = track.streamUrl.takeIf { it.isNotBlank() }
+        val streamUri = track.webPlaybackStreamUrl().takeIf { it.isNotBlank() }
         val uri = localUri ?: streamUri.orEmpty()
         if (uri.isBlank()) return false
         if (uri.startsWith("web-download://")) {
@@ -654,6 +724,12 @@ private class WebAudioPlayer(
         applyWebEqualizer(audio, webEqualizerPayload(effectiveProfile))
     }
 
+    private fun maybeResumeWebPlaybackAfterLoad(generation: Int, eventAudio: HTMLAudioElement) {
+        if (!isPlayRequestCurrent(generation) || audio !== eventAudio || !playWhenReady) return
+        if (!eventAudio.paused || isWebAudioEnded(eventAudio)) return
+        playWebAudio(generation)
+    }
+
     private fun installAudioEventHandlers(generation: Int) {
         val eventAudio = audio
 
@@ -663,11 +739,13 @@ private class WebAudioPlayer(
         eventAudio.onloadedmetadata = {
             if (isCurrentAudioEvent()) {
                 restorePendingReloadPosition(generation)
+                maybeResumeWebPlaybackAfterLoad(generation, eventAudio)
                 syncFromAudio(generation, isBuffering = eventAudio.paused && playWhenReady)
             }
         }
         eventAudio.onloadeddata = {
             if (isCurrentAudioEvent()) {
+                maybeResumeWebPlaybackAfterLoad(generation, eventAudio)
                 syncFromAudio(generation, isBuffering = eventAudio.paused && playWhenReady)
             }
         }
@@ -681,6 +759,7 @@ private class WebAudioPlayer(
                 retryCount = 0
                 startWebAudioPrefetchIfNeeded(currentUri, generation)
                 syncFromAudio(generation, isBuffering = false)
+                startWebPositionPoll(generation, eventAudio)
                 diagnostics.platformPlaying(
                     PlaybackEnginePath.WebAudioElement,
                     (eventAudio.currentTime * 1000.0).toLong().coerceAtLeast(0L),
@@ -694,6 +773,9 @@ private class WebAudioPlayer(
         }
         eventAudio.onpause = {
             if (isCurrentAudioEvent()) {
+                if (!playWhenReady) {
+                    stopWebPositionPoll()
+                }
                 syncFromAudio(generation, isBuffering = false)
             }
         }
@@ -711,41 +793,47 @@ private class WebAudioPlayer(
         eventAudio.oncanplay = {
             if (isCurrentAudioEvent()) {
                 restorePendingReloadPosition(generation)
+                maybeResumeWebPlaybackAfterLoad(generation, eventAudio)
                 syncFromAudio(generation, isBuffering = eventAudio.paused && playWhenReady)
             }
         }
         eventAudio.oncanplaythrough = {
             if (isCurrentAudioEvent()) {
+                maybeResumeWebPlaybackAfterLoad(generation, eventAudio)
                 syncFromAudio(generation, isBuffering = eventAudio.paused && playWhenReady)
             }
         }
-        installWebAudioProgressHandler(eventAudio) {
-            if (isCurrentAudioEvent()) {
-                syncFromAudio(generation, isBuffering = eventAudio.paused && playWhenReady)
+        if (currentUri?.isRemoteWebAudioUri() != true) {
+            installWebAudioProgressHandler(eventAudio) {
+                if (isCurrentAudioEvent()) {
+                    syncFromAudio(generation, isBuffering = eventAudio.paused && playWhenReady)
+                }
             }
+        } else {
+            eventAudio.onprogress = null
         }
         eventAudio.onsuspend = {
             if (isCurrentAudioEvent()) {
                 syncFromAudio(generation, isBuffering = eventAudio.paused && playWhenReady)
             }
         }
-        eventAudio.ontimeupdate = {
-            if (isCurrentAudioEvent()) {
-                syncFromAudio(generation, isBuffering = false)
-            }
-        }
+        eventAudio.ontimeupdate = null
         eventAudio.onended = {
             if (isCurrentAudioEvent()) {
-                syncEndedPositionFromAudio(generation)
-                advanceAfterPlatformTrackEnded(generation)
+                if (webCrossfadeGeneration != generation) {
+                    requestAdvanceAfterWebTrackEnded(generation)
+                }
             }
         }
         eventAudio.onerror = { _, _, _, _, _ ->
             if (isCurrentAudioEvent()) {
                 val message = webAudioErrorMessage(eventAudio)
-                if (!shouldIgnoreBrowserPlaybackFailure(eventAudio, message)) {
+                if (!shouldIgnoreWebAudioLoadError(eventAudio, message)) {
                     clearPendingReloadRestore()
-                    if (!retryWithoutCors(generation)) {
+                    if (!retryWithFreshRemoteAudioElement(generation, message) &&
+                        !retryDirectStreamAfterTranscodeFailure(generation, message) &&
+                        !retryWithoutCors(generation)
+                    ) {
                         diagnostics.playbackError(PlaybackEnginePath.WebAudioElement, message)
                         scheduleRetry(generation, reload = true)
                     }
@@ -779,6 +867,40 @@ private class WebAudioPlayer(
     private fun clearPendingReloadRestore() {
         pendingSeekAfterLoadSeconds = null
         pendingPlayAfterLoad = false
+    }
+
+    private fun retryWithFreshRemoteAudioElement(generation: Int, message: String): Boolean {
+        val uri = currentUri ?: return false
+        if (!isPlayRequestCurrent(generation) ||
+            remoteFreshAudioRetryAttempted ||
+            !message.isUnsupportedSourceFailure() ||
+            !uri.isRemoteWebAudioUri()
+        ) {
+            return false
+        }
+        remoteFreshAudioRetryAttempted = true
+        val previousAudio = audio
+        audio = createAudioElement(useCors = audioUsesCors, preload = webAudioPreloadForUri(uri))
+        disposeWebAudioElement(previousAudio)
+        audio.volume = effectiveOutputVolume().toDouble().coerceIn(0.0, 1.0)
+        prepareAudioElementForCurrentEqualizer()
+        setWebAudioCurrentTime(audio, 0.0)
+        installAudioEventHandlers(generation)
+        audio.src = uri
+        audio.load()
+        applyCurrentEqualizer()
+        if (playWhenReady) {
+            playWebAudio(generation)
+        }
+        return true
+    }
+
+    private fun retryDirectStreamAfterTranscodeFailure(generation: Int, message: String): Boolean {
+        val fallbackUri = directStreamFallbackUri ?: return false
+        if (!isPlayRequestCurrent(generation) || !message.isWebTranscodePlaybackFailure()) return false
+        directStreamFallbackUri = null
+        playResolvedUri(resolveWebLocalAudioUri(fallbackUri))
+        return true
     }
 
     private fun retryWithoutCors(generation: Int): Boolean {
@@ -829,8 +951,23 @@ private class WebAudioPlayer(
             browserDurationSeconds = audio.duration,
         )
         val positionMs = (audio.currentTime * 1000.0).toLong().coerceAtLeast(0L)
+        maybeStartCrossfadeAtPosition(generation, positionMs)
+        maybeStartGaplessAtPosition(generation, positionMs)
         maybeHotStartWebGapless(generation, positionMs, durationMs)
         maybeCommitWebGaplessBoundary(generation, positionMs, durationMs)
+        val isPlaying = !audio.paused && !isBuffering
+        val positionDeltaMs = kotlin.math.abs(positionMs - lastSyncedPositionMs)
+        val shouldSyncProgress = isBuffering != lastSyncedBuffering ||
+            isPlaying != lastSyncedPlaying ||
+            lastSyncedPositionMs < 0L ||
+            positionDeltaMs >= WebProgressSyncMinStepMs
+        if (!shouldSyncProgress) {
+            maybeAdvanceWhenWebAudioEnded(generation)
+            return
+        }
+        lastSyncedPositionMs = positionMs
+        lastSyncedPlaying = isPlaying
+        lastSyncedBuffering = isBuffering
         diagnostics.playbackProgress(PlaybackEnginePath.WebAudioElement, positionMs, durationMs)
         if (!audio.paused && !isBuffering) {
             diagnostics.platformPlaying(PlaybackEnginePath.WebAudioElement, positionMs, durationMs)
@@ -843,6 +980,44 @@ private class WebAudioPlayer(
             bufferedPositionMs = bufferedPositionMs(positionMs, durationMs),
             generation = generation,
         )
+        maybeAdvanceWhenWebAudioEnded(generation)
+    }
+
+    private fun requestAdvanceAfterWebTrackEnded(generation: Int) {
+        if (!isPlayRequestCurrent(generation) || webAdvanceAfterEndGeneration == generation) return
+        webAdvanceAfterEndGeneration = generation
+        stopWebPositionPoll()
+        syncEndedPositionFromAudio(generation)
+        scope.launch {
+            advanceAfterPlatformTrackEnded(generation)
+        }
+    }
+
+    private fun maybeAdvanceWhenWebAudioEnded(generation: Int, eventAudio: HTMLAudioElement = audio): Boolean {
+        if (!isPlayRequestCurrent(generation) || audio !== eventAudio) return false
+        if (webCrossfadeGeneration == generation) return false
+        if (!isWebAudioEnded(eventAudio) && !isWebAudioAtEnd(eventAudio)) return false
+        requestAdvanceAfterWebTrackEnded(generation)
+        return true
+    }
+
+    private fun shouldSkipToNextWebTrackAfterFailure(generation: Int): Boolean {
+        if (!isPlayRequestCurrent(generation) || !playWhenReady) return false
+        val current = state.value
+        if (current.queue.isEmpty() || current.currentIndex < 0) return false
+        return when (current.repeat) {
+            RepeatMode.All -> true
+            RepeatMode.Off -> current.currentIndex < current.queue.lastIndex
+            RepeatMode.One -> false
+        }
+    }
+
+    private fun failOrAdvanceWebPlayback(generation: Int, message: String? = null) {
+        if (shouldSkipToNextWebTrackAfterFailure(generation)) {
+            requestAdvanceAfterWebTrackEnded(generation)
+            return
+        }
+        markPlaybackFailed(generation = generation, message = message)
     }
 
     private fun maybeHotStartWebGapless(
@@ -890,6 +1065,26 @@ private class WebAudioPlayer(
             return
         }
         commitPreparedGapless(generation)
+    }
+
+    private fun stopWebPositionPoll() {
+        webPositionPollJob?.cancel()
+        webPositionPollJob = null
+    }
+
+    private fun webPositionPollJobActive(): Boolean = webPositionPollJob?.isActive == true
+
+    private fun startWebPositionPoll(generation: Int, eventAudio: HTMLAudioElement) {
+        stopWebPositionPoll()
+        webPositionPollJob = scope.launch {
+            while (isPlayRequestCurrent(generation) && audio === eventAudio && playWhenReady) {
+                if (maybeAdvanceWhenWebAudioEnded(generation, eventAudio)) break
+                if (!eventAudio.paused) {
+                    syncFromAudio(generation, isBuffering = false)
+                }
+                delay(WebPositionPollIntervalMs)
+            }
+        }
     }
 
     private fun syncEndedPositionFromAudio(generation: Int) {
@@ -975,7 +1170,7 @@ private class WebAudioPlayer(
             retryCount = 0
         }
         if (retryCount >= MaxStreamRetryCount) {
-            markPlaybackFailed(generation)
+            failOrAdvanceWebPlayback(generation)
             return
         }
         retryCount++
@@ -1007,6 +1202,7 @@ private class WebAudioPlayer(
         val playbackAudio = audio
         playWebAudio(playbackAudio) { message ->
             if (shouldIgnoreBrowserPlaybackFailure(playbackAudio, message)) return@playWebAudio
+            if (shouldIgnoreWebAudioLoadError(playbackAudio, message)) return@playWebAudio
             if (!isPlayRequestCurrent(generation) || !playWhenReady) return@playWebAudio
             if (message.isBrowserAutoplayBlockedFailure()) {
                 markPlaybackWaitingForUserGesture(generation)
@@ -1015,14 +1211,25 @@ private class WebAudioPlayer(
             if (audioUsesCors && currentUri?.isRemoteWebAudioUri() == true && retryWithoutCors(generation)) {
                 return@playWebAudio
             }
+            if (retryWithFreshRemoteAudioElement(generation, message)) {
+                return@playWebAudio
+            }
             diagnostics.playbackError(PlaybackEnginePath.WebAudioElement, message)
-            markPlaybackFailed(generation = generation, message = message)
+            failOrAdvanceWebPlayback(generation, message)
         }
     }
 
     private fun shouldIgnoreBrowserPlaybackFailure(playbackAudio: HTMLAudioElement, message: String?): Boolean {
         if (audio !== playbackAudio) return true
         return message.isUnsupportedSourceFailure() && isWebAudioEnded(playbackAudio)
+    }
+
+    private fun shouldIgnoreWebAudioLoadError(playbackAudio: HTMLAudioElement, message: String?): Boolean {
+        if (shouldIgnoreBrowserPlaybackFailure(playbackAudio, message)) return true
+        if (!webAudioHasActiveSource(playbackAudio)) return true
+        val uri = currentUri ?: return message.isUnsupportedSourceFailure()
+        if (message.isUnsupportedSourceFailure() && !webAudioSourceMatchesUri(playbackAudio, uri)) return true
+        return false
     }
 
     private companion object {
@@ -1070,6 +1277,14 @@ private fun String?.isUnsupportedSourceFailure(): Boolean {
     return "no supported source" in text ||
         "src_not_supported" in text ||
         ("not supported" in text && "source" in text)
+}
+
+private fun String?.isWebTranscodePlaybackFailure(): Boolean {
+    if (isUnsupportedSourceFailure()) return true
+    val text = this?.lowercase() ?: return false
+    return "media_err_network" in text ||
+        "htmlmediaelement error 2" in text ||
+        "htmlmediaelement error 4" in text
 }
 
 private fun String?.isBrowserAutoplayBlockedFailure(): Boolean {
@@ -1136,6 +1351,9 @@ private fun org.w3c.dom.TimeRanges.toWebAudioTimeRanges(): List<WebAudioTimeRang
 }
 
 private const val WebAudioRangeStartToleranceMs = 250L
+private const val WebProgressSyncMinStepMs = 1_000L
+private const val WebPositionPollIntervalMs = 250L
+private const val WebRemoteTrackLoadDeferMs = 100L
 private const val WebAudioDurationEndToleranceMs = 750L
 private const val WebAudioPrefetchUpdateThreshold = 0.005
 private const val WebGaplessHotStartLeadMs = 90L
@@ -1149,6 +1367,44 @@ private external fun installWebAudioProgressHandler(audio: HTMLAudioElement, cal
 @OptIn(ExperimentalWasmJsInterop::class)
 @JsFun("() => {}")
 private external fun cancelWebAudioPrefetch()
+
+@OptIn(ExperimentalWasmJsInterop::class)
+@JsFun(
+    """(audio) => {
+        if (!audio) return;
+        audio.onloadedmetadata = null;
+        audio.onloadeddata = null;
+        audio.ondurationchange = null;
+        audio.onplaying = null;
+        audio.onpause = null;
+        audio.onwaiting = null;
+        audio.onstalled = null;
+        audio.oncanplay = null;
+        audio.oncanplaythrough = null;
+        audio.onprogress = null;
+        audio.onsuspend = null;
+        audio.ontimeupdate = null;
+        audio.onended = null;
+        audio.onerror = null;
+    }""",
+)
+private external fun clearWebAudioEventHandlers(audio: HTMLAudioElement)
+
+@OptIn(ExperimentalWasmJsInterop::class)
+@JsFun("(audio) => !!(audio && audio.src)")
+private external fun webAudioHasActiveSource(audio: HTMLAudioElement): Boolean
+
+@OptIn(ExperimentalWasmJsInterop::class)
+@JsFun(
+    """(audio, uri) => {
+        if (!audio || !uri) return false;
+        const src = String(audio.src || "");
+        const expected = String(uri || "");
+        if (!src || !expected) return false;
+        return src === expected || src.endsWith(expected) || expected.endsWith(src);
+    }""",
+)
+private external fun webAudioSourceMatchesUri(audio: HTMLAudioElement, uri: String): Boolean
 
 @OptIn(ExperimentalWasmJsInterop::class)
 @JsFun(
@@ -1188,6 +1444,7 @@ private external fun teardownWebAudioRouting(audio: HTMLAudioElement)
         if (!audio) return;
         try { audio.pause(); } catch (_) {}
         audio.removeAttribute("src");
+        audio.src = "";
         try { audio.load(); } catch (_) {}
     }""",
 )
@@ -1381,6 +1638,7 @@ private external fun stopWebAudioAnalysis(audio: HTMLAudioElement)
         }
         try { audio.pause(); } catch (_) {}
         audio.removeAttribute("src");
+        audio.src = "";
         try { audio.load(); } catch (_) {}
         audio.onloadedmetadata = null;
         audio.onloadeddata = null;
@@ -1420,6 +1678,19 @@ private external fun webAudioErrorMessage(audio: HTMLAudioElement): String
 @OptIn(ExperimentalWasmJsInterop::class)
 @JsFun("(audio) => !!(audio && audio.ended)")
 private external fun isWebAudioEnded(audio: HTMLAudioElement): Boolean
+
+@OptIn(ExperimentalWasmJsInterop::class)
+@JsFun(
+    """(audio) => {
+        if (!audio) return false;
+        if (audio.ended) return true;
+        const duration = Number(audio.duration);
+        const position = Number(audio.currentTime);
+        if (!Number.isFinite(duration) || duration <= 0 || !Number.isFinite(position)) return false;
+        return position + 0.25 >= duration;
+    }""",
+)
+private external fun isWebAudioAtEnd(audio: HTMLAudioElement): Boolean
 
 @OptIn(ExperimentalWasmJsInterop::class)
 @JsFun(

--- a/playback/src/wasmJsTest/kotlin/com/phoebe/app/player/WebAudioPlayerLifecycleTest.kt
+++ b/playback/src/wasmJsTest/kotlin/com/phoebe/app/player/WebAudioPlayerLifecycleTest.kt
@@ -179,6 +179,75 @@ class WebAudioPlayerLifecycleTest {
     }
 
     @Test
+    fun queuedWebAudioAdvancesWhenCanplayArrivesAfterInitialPlayAttempt() = runTest {
+        installMockWebAudioElement(mode = "delayed-canplay", durationSeconds = 0.2)
+        val diagnostics = RecordingPlaybackDiagnostics()
+        val player = createWebAudioPlayerForTests(diagnostics)
+        try {
+            val first = playbackTrack(
+                id = "web-delayed-canplay-first",
+                streamUrl = "https://music.example.test/delayed-canplay-first.mp3",
+                durationMs = 200L,
+            )
+            val second = playbackTrack(
+                id = "web-delayed-canplay-second",
+                streamUrl = "https://music.example.test/delayed-canplay-second.mp3",
+                durationMs = 200L,
+            )
+
+            player.play(listOf(first, second), 0)
+
+            assertTrue(
+                waitUntil(timeoutMs = 3_000L) {
+                    player.state.value.currentTrack?.id == second.id
+                },
+                "Delayed canplay should still advance to the next track; state=${player.state.value} " +
+                    "errors=${diagnostics.errors}",
+            )
+            assertTrue(
+                diagnostics.errors.isEmpty(),
+                "Delayed canplay queue advance should not surface playback errors; errors=${diagnostics.errors}",
+            )
+        } finally {
+            player.stopPlayback()
+            restoreMockWebAudioElement()
+        }
+    }
+
+    @Test
+    fun clearedSourceErrorDuringRemoteTrackTransitionDoesNotStopQueue() = runTest {
+        installMockWebAudioElement(mode = "clear-src-error-on-empty-load", durationSeconds = 0.2)
+        val diagnostics = RecordingPlaybackDiagnostics()
+        val player = createWebAudioPlayerForTests(diagnostics)
+        try {
+            val tracks = (1..4).map { index ->
+                playbackTrack(
+                    id = "web-clear-src-$index",
+                    streamUrl = "https://music.example.test/clear-src-$index.mp3",
+                    durationMs = 200L,
+                )
+            }
+
+            player.play(tracks, 0)
+
+            assertTrue(
+                waitUntil(timeoutMs = 4_000L) {
+                    player.state.value.currentTrack?.id == tracks.last().id
+                },
+                "Queue should advance past cleared-source errors; state=${player.state.value} " +
+                    "errors=${diagnostics.errors}",
+            )
+            assertTrue(
+                diagnostics.errors.isEmpty(),
+                "Cleared-source transition errors should be ignored; errors=${diagnostics.errors}",
+            )
+        } finally {
+            player.stopPlayback()
+            restoreMockWebAudioElement()
+        }
+    }
+
+    @Test
     fun queuedWebAudioAdvancesThroughSeveralTracksWithoutFailure() = runTest {
         installMockWebAudioElement(mode = "complete", durationSeconds = 0.2)
         val diagnostics = RecordingPlaybackDiagnostics()
@@ -237,6 +306,42 @@ class WebAudioPlayerLifecycleTest {
                 },
                 "Web audio should publish the completed first-track position before advancing; " +
                     "state=${player.state.value} progress=${diagnostics.progress}",
+            )
+        } finally {
+            player.stopPlayback()
+            restoreMockWebAudioElement()
+        }
+    }
+
+    @Test
+    fun queuedWebAudioAdvancesWhenOnendedNeverFires() = runTest {
+        installMockWebAudioElement(mode = "end-without-onended", durationSeconds = 0.2)
+        val diagnostics = RecordingPlaybackDiagnostics()
+        val player = createWebAudioPlayerForTests(diagnostics)
+        try {
+            val first = playbackTrack(
+                id = "web-no-onended-first",
+                streamUrl = "https://music.example.test/no-onended-first.mp3",
+                durationMs = 200L,
+            )
+            val second = playbackTrack(
+                id = "web-no-onended-second",
+                streamUrl = "https://music.example.test/no-onended-second.mp3",
+                durationMs = 200L,
+            )
+
+            player.play(listOf(first, second), 0)
+
+            assertTrue(
+                waitUntil(timeoutMs = 3_000L) {
+                    player.state.value.currentTrack?.id == second.id
+                },
+                "Position poll should advance when onended never fires; state=${player.state.value} " +
+                    "errors=${diagnostics.errors}",
+            )
+            assertTrue(
+                diagnostics.errors.isEmpty(),
+                "Missing onended should not surface playback errors; errors=${diagnostics.errors}",
             )
         } finally {
             player.stopPlayback()
@@ -481,7 +586,8 @@ class WebAudioPlayerLifecycleTest {
                     duration: Number(durationSeconds) || 0.25,
                     paused: true,
                     src: "",
-                    timer: null
+                    timer: null,
+                    playAttempts: 0,
                 };
                 stateByElement.set(audio, state);
             }
@@ -509,6 +615,12 @@ class WebAudioPlayerLifecycleTest {
             }
         });
         define("paused", { get() { return stateFor(this).paused; } });
+        define("ended", {
+            get() {
+                const state = stateFor(this);
+                return state.duration > 0 && state.currentTime >= state.duration;
+            }
+        });
         define("src", {
             get() { return stateFor(this).src; },
             set(value) { stateFor(this).src = String(value || ""); }
@@ -527,19 +639,35 @@ class WebAudioPlayerLifecycleTest {
         proto.load = function() {
             const audio = this;
             const state = stateFor(audio);
+            if (mode === "clear-src-error-on-empty-load" && !state.src) {
+                setTimeout(() => {
+                    try { audio.error = { code: 4 }; } catch (_) {}
+                    call(audio, audio.onerror, "error");
+                }, 0);
+                return;
+            }
             state.currentTime = 0;
-            setTimeout(() => {
+            const emitReady = () => {
                 call(audio, audio.onloadedmetadata, "loadedmetadata");
                 call(audio, audio.ondurationchange, "durationchange");
                 call(audio, audio.onloadeddata, "loadeddata");
                 call(audio, audio.oncanplay, "canplay");
                 call(audio, audio.oncanplaythrough, "canplaythrough");
-            }, 0);
+            };
+            if (mode === "delayed-canplay") {
+                setTimeout(emitReady, 30);
+            } else {
+                setTimeout(emitReady, 0);
+            }
         };
         proto.play = function() {
             const audio = this;
             const state = stateFor(audio);
             const playCall = ++playCalls;
+            state.playAttempts = (state.playAttempts || 0) + 1;
+            if (mode === "delayed-canplay" && state.playAttempts === 1) {
+                return Promise.resolve();
+            }
             if (mode === "reject") {
                 return Promise.reject(new Error("Mock play rejected"));
             }
@@ -582,7 +710,9 @@ class WebAudioPlayerLifecycleTest {
                     timers.delete(state.timer);
                     state.timer = null;
                     state.paused = true;
-                    call(audio, audio.onended, "ended");
+                    if (mode !== "end-without-onended") {
+                        call(audio, audio.onended, "ended");
+                    }
                 }
             }, 20);
             timers.add(state.timer);

--- a/ui/core/src/commonMain/kotlin/com/phoebe/app/ui/ArtworkDecodeDimensions.kt
+++ b/ui/core/src/commonMain/kotlin/com/phoebe/app/ui/ArtworkDecodeDimensions.kt
@@ -1,5 +1,7 @@
 package com.phoebe.app.ui
 
+import com.phoebe.app.platform.prefersReducedArtworkEffects
+
 const val ThumbnailArtworkMaxDecodeDimension = 160
 
 /** Default decode cap for list/grid tiles (~48-92dp). Hero art should pass a larger value explicitly. */
@@ -7,6 +9,17 @@ const val ListArtworkMaxDecodeDimension = 256
 
 /** Decode cap for single, large artwork surfaces such as the mobile full-screen player. */
 const val HeroArtworkMaxDecodeDimension = 1024
+
+/** Smaller hero decode cap for memory-constrained web playback. */
+const val WebHeroArtworkMaxDecodeDimension = 256
+
+/** Decode cap for the now-playing hero surface on the current platform. */
+fun playerHeroArtworkMaxDecodeDimension(): Int =
+    if (prefersReducedArtworkEffects()) {
+        WebHeroArtworkMaxDecodeDimension
+    } else {
+        HeroArtworkMaxDecodeDimension
+    }
 
 /** Upper decode cap for library grid tiles at the largest supported item size. */
 const val GridArtworkMaxDecodeDimension = 512

--- a/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeArtwork.kt
+++ b/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeArtwork.kt
@@ -436,6 +436,8 @@ object RemoteArtworkCache {
     private const val DefaultLoadPermits = 8
     private const val DownloadModeMaxEntries = 32
     private const val DownloadModeMaxEstimatedBytes = 4L * 1024L * 1024L
+    private const val PlaybackModeMaxEntries = 4
+    private const val PlaybackModeMaxEstimatedBytes = 1L * 1024L * 1024L
 
     private data class CacheKey(
         val url: String,
@@ -492,6 +494,19 @@ object RemoteArtworkCache {
             if (enabled) {
                 maxEntries = DownloadModeMaxEntries
                 maxEstimatedBytes = minOf(platformMaxEstimatedBytes, DownloadModeMaxEstimatedBytes)
+            } else {
+                maxEntries = DefaultMaxEntries
+                maxEstimatedBytes = platformMaxEstimatedBytes
+            }
+            trimToLimitsLocked()
+        }
+    }
+
+    fun configurePlaybackMemoryMode(enabled: Boolean) {
+        withCacheLock {
+            if (enabled) {
+                maxEntries = PlaybackModeMaxEntries
+                maxEstimatedBytes = minOf(platformMaxEstimatedBytes, PlaybackModeMaxEstimatedBytes)
             } else {
                 maxEntries = DefaultMaxEntries
                 maxEstimatedBytes = platformMaxEstimatedBytes

--- a/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/PhoebePlaybackControls.kt
+++ b/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/PhoebePlaybackControls.kt
@@ -304,13 +304,21 @@ fun rememberTimelineBufferedPositionMs(
     }
     LaunchedEffect(track?.id, remoteDurationMs, isPlaying, isBuffering) {
         val duration = remoteDurationMs ?: return@LaunchedEffect
-        if (!isPlaying) return@LaunchedEffect
+        if (!isPlaying) {
+            estimatedRemoteBufferedPositionMs = max(positionMs, bufferedPositionMs)
+            return@LaunchedEffect
+        }
+        if (!isBuffering) {
+            estimatedRemoteBufferedPositionMs = max(positionMs, bufferedPositionMs).coerceAtMost(duration)
+            return@LaunchedEffect
+        }
         while (estimatedRemoteBufferedPositionMs < duration) {
             delay(TimelineBufferFallbackTickMs)
             val platformFloor = max(latestPositionMs, latestBufferedPositionMs)
             estimatedRemoteBufferedPositionMs = max(estimatedRemoteBufferedPositionMs, platformFloor)
                 .plus(TimelineBufferFallbackAdvanceMs)
                 .coerceAtMost(duration)
+            if (latestBufferedPositionMs > latestPositionMs + TimelineBufferFallbackAdvanceMs) break
         }
     }
     return remember(remoteDurationMs, bufferedPositionMs, estimatedRemoteBufferedPositionMs) {


### PR DESCRIPTION
## Summary
- Add a Plex Web-specific universal MP3 transcode URL for lossless sources that avoids query parameters that trigger 400s on current PMS builds, while keeping MP3/AAC/M4A on direct part URLs.
- Reduce web renderer memory pressure by reusing the `<audio>` element across tracks, deferring remote stream loads, skipping remote gapless preload, throttling progress UI updates via `PlayerTimelineState`, and deferring catalog memory updates during active playback.
- Harden web playback lifecycle: page visibility resume, startup-timeout skip-to-next, direct-stream fallback after transcode failure, and crossfade timing that stays accurate even when UI progress sync is throttled.

## Test plan
- [x] `./gradlew :playback:desktopTest --tests "com.phoebe.app.player.PlexTranscodeUrlsTest"`
- [x] `./gradlew :playback:wasmJsTest`
- [ ] Manual: play lossless Plex tracks in web and confirm playback starts without 400 errors
- [ ] Manual: shuffle a large playlist in Chrome and confirm renderer memory stays stable
- [ ] Manual: verify crossfade still ramps between local/remote tracks


Made with [Cursor](https://cursor.com)