### PR TITLE
Prune backend VCR images in release CI and extend macOS build timeout

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,20 @@
+{
+    "version": 1,
+    "hooks": {
+        "sessionStart": [
+            {
+                "command": "\"$HOME/.andy/bin/andy-status-hook.sh\" working empty"
+            }
+        ],
+        "beforeSubmitPrompt": [
+            {
+                "command": "\"$HOME/.andy/bin/andy-status-hook.sh\" working empty"
+            }
+        ],
+        "stop": [
+            {
+                "command": "\"$HOME/.andy/bin/andy-status-hook.sh\" done empty completed"
+            }
+        ]
+    }
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,7 @@ jobs:
         run: |
           set -euo pipefail
           vercel pull --yes --environment=production --token "${VERCEL_TOKEN}"
+          scripts/prune-phoebe-backend-vcr-images.sh --keep 10 --token "${VERCEL_TOKEN}"
           scripts/validate-phoebe-backend-production-env.sh --vercel-production
           deploy_log="${RUNNER_TEMP}/vercel-phoebe-backend-deploy.log"
           scripts/deploy-phoebe-backend-vercel.sh --prod --yes --token "${VERCEL_TOKEN}" | tee "${deploy_log}"
@@ -703,7 +704,7 @@ jobs:
     needs:
       - version
     runs-on: macos-26
-    timeout-minutes: 90
+    timeout-minutes: 180
     env:
       MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
       PHOEBE_GOOGLE_MAPS_IOS_API_KEY: ${{ secrets.PHOEBE_GOOGLE_MAPS_IOS_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ test-results/
 iosApp/Vendor/GoogleCastSDK/
 .vercel
 .env*
+.andy

--- a/.opencode/plugins/andy-status.js
+++ b/.opencode/plugins/andy-status.js
@@ -1,0 +1,53 @@
+/**
+ * Andy-managed OpenCode plugin — writes lifecycle status via andy-status-hook.sh.
+ *
+ * Installed into project `.opencode/plugins/andy-status.js` by Andy on session start.
+ * Badge authority remains screen scrape; this only writes status.json artifacts.
+ *
+ * Marker string "andy-status-hook" lets Andy replace prior installs without
+ * clobbering other user plugins.
+ */
+import { execFileSync } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const HOOK = join(homedir(), ".andy", "bin", "andy-status-hook.sh");
+
+function runStatus(status) {
+  try {
+    execFileSync(HOOK, [status], {
+      stdio: ["ignore", "ignore", "ignore"],
+      env: process.env,
+      timeout: 5_000,
+    });
+  } catch {
+    // best-effort
+  }
+}
+
+export default async function andyStatusPlugin() {
+  return {
+    event: async ({ event }) => {
+      const type = String(event?.type || event?.name || "").toLowerCase();
+      if (
+        type.includes("session.created") ||
+        type.includes("session.start") ||
+        type.includes("message.user") ||
+        type.includes("tool.execute")
+      ) {
+        runStatus("working");
+        return;
+      }
+      if (type.includes("session.idle") || type.includes("session.deleted")) {
+        runStatus("done");
+        return;
+      }
+      if (type.includes("permission") || type.includes("ask")) {
+        runStatus("blocked");
+      }
+    },
+    "tool.execute.before": async () => {
+      runStatus("working");
+    },
+  };
+}

--- a/scripts/prune-phoebe-backend-vcr-images.sh
+++ b/scripts/prune-phoebe-backend-vcr-images.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository="backend"
+keep_count=10
+dry_run=false
+vercel_token="${VERCEL_TOKEN:-}"
+
+usage() {
+  cat <<'EOF'
+Prune old Phoebe backend images from Vercel Container Registry.
+
+Vercel Hobby projects allow 50 images per repository. Each backend deploy
+creates a new image, so release CI prunes older images before deploying.
+
+Usage:
+  scripts/prune-phoebe-backend-vcr-images.sh [options]
+
+Options:
+  --keep <count>       Number of newest images to retain (default: 10)
+  --repository <name>  VCR repository name (default: backend)
+  --token <token>      Vercel access token (defaults to VERCEL_TOKEN)
+  --dry-run            Print deletions without removing images
+  -h, --help           Show this help
+EOF
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --keep)
+      keep_count="${2:?--keep requires a count}"
+      shift 2
+      ;;
+    --repository)
+      repository="${2:?--repository requires a name}"
+      shift 2
+      ;;
+    --token)
+      vercel_token="${2:?--token requires a value}"
+      shift 2
+      ;;
+    --dry-run)
+      dry_run=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "::error::Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "${keep_count}" -lt 1 ]]; then
+  echo "::error::--keep must be at least 1" >&2
+  exit 1
+fi
+
+vercel_cmd() {
+  if [[ -n "${vercel_token}" ]]; then
+    vercel "$@" --token "${vercel_token}"
+  else
+    vercel "$@"
+  fi
+}
+
+list_images_json() {
+  vercel_cmd vcr image ls "${repository}" --format json --limit 100 "$@"
+}
+
+image_ids_to_delete=()
+while IFS= read -r image_id; do
+  [[ -n "${image_id}" ]] || continue
+  image_ids_to_delete+=("${image_id}")
+done < <(
+  LIST_IMAGES_JSON="$(list_images_json)" \
+  KEEP_COUNT="${keep_count}" \
+  node <<'NODE'
+const payload = JSON.parse(process.env.LIST_IMAGES_JSON || "{}");
+const images = Array.isArray(payload.images) ? payload.images : [];
+const keepCount = Number.parseInt(process.env.KEEP_COUNT || "10", 10);
+
+images.sort((left, right) => new Date(right.createdAt) - new Date(left.createdAt));
+
+if (images.length <= keepCount) {
+  console.error(
+    `Phoebe backend VCR repository has ${images.length} image(s); keeping all (limit ${keepCount}).`,
+  );
+  process.exit(0);
+}
+
+const toDelete = images.slice(keepCount);
+console.error(
+  `Phoebe backend VCR repository has ${images.length} image(s); deleting ${toDelete.length}, keeping ${keepCount}.`,
+);
+
+for (const image of toDelete) {
+  process.stdout.write(`${image.id}\n`);
+}
+NODE
+)
+
+if ((${#image_ids_to_delete[@]} == 0)); then
+  exit 0
+fi
+
+for image_id in "${image_ids_to_delete[@]}"; do
+  if [[ "${dry_run}" == "true" ]]; then
+    echo "Would delete ${repository}/${image_id}"
+    continue
+  fi
+
+  vercel_cmd vcr image rm "${repository}" "${image_id}" --yes
+done
+
+if [[ "${dry_run}" == "true" ]]; then
+  echo "Dry run complete."
+else
+  echo "Pruned ${#image_ids_to_delete[@]} image(s) from ${repository}."
+fi

--- a/scripts/prune-phoebe-backend-vcr-images.sh
+++ b/scripts/prune-phoebe-backend-vcr-images.sh
@@ -72,12 +72,10 @@ list_images_json() {
   vercel_cmd vcr image ls "${repository}" --format json --limit 100 "$@"
 }
 
-image_ids_to_delete=()
-while IFS= read -r image_id; do
-  [[ -n "${image_id}" ]] || continue
-  image_ids_to_delete+=("${image_id}")
-done < <(
-  LIST_IMAGES_JSON="$(list_images_json)" \
+list_images_json="$(list_images_json)"
+
+node_output="$(
+  LIST_IMAGES_JSON="${list_images_json}" \
   KEEP_COUNT="${keep_count}" \
   node <<'NODE'
 const payload = JSON.parse(process.env.LIST_IMAGES_JSON || "{}");
@@ -102,7 +100,15 @@ for (const image of toDelete) {
   process.stdout.write(`${image.id}\n`);
 }
 NODE
-)
+)"
+
+image_ids_to_delete=()
+if [[ -n "${node_output}" ]]; then
+  while IFS= read -r image_id; do
+    [[ -n "${image_id}" ]] || continue
+    image_ids_to_delete+=("${image_id}")
+  done <<< "${node_output}"
+fi
 
 if ((${#image_ids_to_delete[@]} == 0)); then
   exit 0


### PR DESCRIPTION
## Summary
- Add `scripts/prune-phoebe-backend-vcr-images.sh` and run it in release CI before backend deploys to stay under Vercel Hobby's 50-image VCR limit
- Increase the macOS release job timeout from 90 to 180 minutes for longer iOS builds
- Add Andy status hooks for Cursor (`.cursor/hooks.json`) and OpenCode (`.opencode/plugins/andy-status.js`), matching existing Codex/Claude setup

## Test plan
- [ ] Verify `scripts/prune-phoebe-backend-vcr-images.sh --dry-run` lists expected deletions when run with a valid Vercel token
- [ ] Confirm release workflow still deploys backend successfully after pruning step
- [ ] Confirm macOS/iOS release job completes within the new timeout window


Made with [Cursor](https://cursor.com)