### PR TITLE
Speed up iOS release builds with framework prebuild and CI caching

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -278,6 +278,13 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Cache Kotlin/Native toolchain
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml', 'gradle.properties', 'settings.gradle.kts') }}
+          restore-keys: konan-${{ runner.os }}-
+
       - name: Install Google Cast SDK
         run: ./scripts/install-ios-google-cast-sdk.sh
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -188,6 +188,13 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Cache Kotlin/Native toolchain
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml', 'gradle.properties', 'settings.gradle.kts') }}
+          restore-keys: konan-${{ runner.os }}-
+
       - name: Install Google Cast SDK
         run: ./scripts/install-ios-google-cast-sdk.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -728,6 +728,16 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: false
+          gradle-home-cache-cleanup: true
+
+      - name: Cache Kotlin/Native toolchain
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml', 'gradle.properties', 'settings.gradle.kts') }}
+          restore-keys: konan-${{ runner.os }}-
 
       - name: Validate iOS release secrets
         shell: bash
@@ -826,12 +836,16 @@ jobs:
           IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
           IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
 
+      - name: Prebuild Kotlin framework for iOS release
+        shell: bash
+        run: ./scripts/prebuild-ios-framework.sh Release iphoneos
+
       - name: Build and Package iOS App
         shell: bash
         run: |
           if [[ "${SIGN_IOS}" == "true" ]]; then
             echo "Building signed iOS App..."
-            xcodebuild \
+            OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED=YES xcodebuild \
               -project iosApp/iosApp.xcodeproj \
               -scheme iosApp \
               -configuration Release \
@@ -857,7 +871,7 @@ jobs:
             cp "${ipa_path}" "release-artifacts/Phoebe-${VERSION}.ipa"
           else
             echo "Building unsigned iOS App..."
-            xcodebuild \
+            OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED=YES xcodebuild \
               -project iosApp/iosApp.xcodeproj \
               -scheme iosApp \
               -configuration Release \

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,6 +5,7 @@ import org.gradle.api.tasks.Sync
 import org.gradle.api.tasks.testing.Test
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.io.File
+import java.security.MessageDigest
 import java.time.Duration
 
 val phoebeVersionName = providers.gradleProperty("phoebe.versionName")
@@ -500,6 +501,53 @@ compose.desktop {
             }
         }
     }
+}
+
+val recordIosKotlinInputFingerprint = tasks.register("recordIosKotlinInputFingerprint") {
+    val fingerprintFile = layout.buildDirectory.file("ios-kotlin-input-fingerprint")
+    outputs.file(fingerprintFile)
+
+    val rootDirectory = rootProject.layout.projectDirectory
+    val trackedFiles = rootProject.layout.files(
+        rootDirectory.file("gradle/libs.versions.toml"),
+        rootDirectory.file("gradle.properties"),
+        rootDirectory.file("settings.gradle.kts"),
+        layout.projectDirectory.file("build.gradle.kts"),
+    )
+
+    doLast {
+        val digest = MessageDigest.getInstance("SHA-256")
+        trackedFiles.files
+            .filter { it.isFile }
+            .sortedBy { it.relativeTo(rootDirectory.asFile).path }
+            .forEach { file ->
+                digest.update(file.relativeTo(rootDirectory.asFile).path.toByteArray())
+                digest.update(file.readBytes())
+            }
+
+        rootDirectory.asFile.walkTopDown()
+            .onEnter { directory ->
+                !directory.name.startsWith(".") &&
+                    directory.name !in setOf("build", "node_modules", ".gradle", "iosApp")
+            }
+            .filter { file ->
+                file.isFile &&
+                    file.extension in setOf("kt", "kts") &&
+                    file.path.contains("${File.separator}src${File.separator}")
+            }
+            .sortedBy { it.relativeTo(rootDirectory.asFile).path }
+            .forEach { file ->
+                digest.update(file.relativeTo(rootDirectory.asFile).path.toByteArray())
+                digest.update(file.readBytes())
+            }
+
+        fingerprintFile.get().asFile.parentFile.mkdirs()
+        fingerprintFile.get().asFile.writeText(digest.digest().joinToString("") { "%02x".format(it) })
+    }
+}
+
+tasks.matching { it.name == "embedAndSignAppleFrameworkForXcode" }.configureEach {
+    dependsOn(recordIosKotlinInputFingerprint)
 }
 
 val compileMacMediaKeysNative = tasks.register<Exec>("compileMacMediaKeysNative") {

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -541,8 +541,12 @@ val recordIosKotlinInputFingerprint = tasks.register("recordIosKotlinInputFinger
                 digest.update(file.readBytes())
             }
 
-        fingerprintFile.get().asFile.parentFile.mkdirs()
-        fingerprintFile.get().asFile.writeText(digest.digest().joinToString("") { "%02x".format(it) })
+        val fingerprint = digest.digest().joinToString("") { "%02x".format(it) }
+        val outputFile = fingerprintFile.get().asFile
+        outputFile.parentFile.mkdirs()
+        if (!outputFile.exists() || outputFile.readText() != fingerprint) {
+            outputFile.writeText(fingerprint)
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,6 @@
 org.gradle.jvmargs=-Xmx6144m -Dfile.encoding=UTF-8 -XX:-UseOnStackReplacement
+org.gradle.caching=true
+org.gradle.parallel=true
 kotlin.native.jvmArgs=-Xmx6g
 android.useAndroidX=true
 kotlin.code.style=official

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -184,17 +184,20 @@
 /* Begin PBXShellScriptBuildPhase section */
 		05E104082A8AADF800D11C3D /* Compile Kotlin */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 0;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"$(SRCROOT)/../composeApp/build/ios-kotlin-input-fingerprint",
 			);
 			name = "Compile Kotlin";
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"$(SRCROOT)/../composeApp/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)/ComposeApp.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -202,6 +205,7 @@
 		};
 		CP02RS032600AC8F00CF470E /* Copy Google Cast Resources */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 0;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -214,10 +218,11 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/.google-cast-resources.stamp",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\nRESOURCE_DIR=\"$SRCROOT/Vendor/GoogleCastSDK/Resources\"\nDEST_DIR=\"$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH\"\nif [ -d \"$RESOURCE_DIR\" ]; then\n  mkdir -p \"$DEST_DIR\"\n  for bundle in \"$RESOURCE_DIR\"/*.bundle; do\n    [ -e \"$bundle\" ] || continue\n    cp -R \"$bundle\" \"$DEST_DIR\"\n  done\nelse\n  echo \"Google Cast resources not installed at $RESOURCE_DIR. Run scripts/install-ios-google-cast-sdk.sh.\"\nfi\n";
+			shellScript = "set -e\nRESOURCE_DIR=\"$SRCROOT/Vendor/GoogleCastSDK/Resources\"\nDEST_DIR=\"$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH\"\nif [ -d \"$RESOURCE_DIR\" ]; then\n  mkdir -p \"$DEST_DIR\"\n  for bundle in \"$RESOURCE_DIR\"/*.bundle; do\n    [ -e \"$bundle\" ] || continue\n    cp -R \"$bundle\" \"$DEST_DIR\"\n  done\n  touch \"$DEST_DIR/.google-cast-resources.stamp\"\nelse\n  echo \"Google Cast resources not installed at $RESOURCE_DIR. Run scripts/install-ios-google-cast-sdk.sh.\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -115,6 +115,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7555FFA5242A565B00829871 /* Build configuration list for PBXNativeTarget "iosApp" */;
 			buildPhases = (
+				RKIF1NG2A8AADF800D11C3D /* Record Kotlin Input Fingerprint */,
 				05E104082A8AADF800D11C3D /* Compile Kotlin */,
 				7555FF77242A565900829871 /* Sources */,
 				7555FF79242A565900829871 /* Resources */,
@@ -182,6 +183,26 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		RKIF1NG2A8AADF800D11C3D /* Record Kotlin Input Fingerprint */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Record Kotlin Input Fingerprint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SRCROOT)/../composeApp/build/ios-kotlin-input-fingerprint",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "cd \"$SRCROOT/..\"\nif [ -z \"$JAVA_HOME\" ] || [ ! -d \"$JAVA_HOME\" ]; then\n  if [ -d \"$HOME/.sdkman/candidates/java/current\" ]; then\n    export JAVA_HOME=\"$HOME/.sdkman/candidates/java/current\"\n  elif /usr/libexec/java_home -v 21 >/dev/null 2>&1; then\n    export JAVA_HOME=$(/usr/libexec/java_home -v 21)\n  fi\nfi\nif [ -n \"$JAVA_HOME\" ]; then\n  export PATH=\"$JAVA_HOME/bin:$PATH\"\nfi\n./gradlew :composeApp:recordIosKotlinInputFingerprint --quiet\n";
+		};
 		05E104082A8AADF800D11C3D /* Compile Kotlin */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 0;

--- a/scripts/prebuild-ios-framework.sh
+++ b/scripts/prebuild-ios-framework.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIGURATION="${1:-Release}"
+SDK_NAME="${2:-iphoneos}"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [[ -z "${JAVA_HOME:-}" || ! -d "${JAVA_HOME}" ]]; then
+  if [[ -d "${HOME}/.sdkman/candidates/java/current" ]]; then
+    export JAVA_HOME="${HOME}/.sdkman/candidates/java/current"
+  elif /usr/libexec/java_home -v 21 >/dev/null 2>&1; then
+    export JAVA_HOME="$(/usr/libexec/java_home -v 21)"
+  fi
+fi
+if [[ -n "${JAVA_HOME:-}" ]]; then
+  export PATH="${JAVA_HOME}/bin:${PATH}"
+fi
+
+export CONFIGURATION
+export SDK_NAME
+export ARCHS="${ARCHS:-arm64}"
+export PLATFORM_NAME="${PLATFORM_NAME:-iphoneos}"
+export TARGET_BUILD_DIR="${TARGET_BUILD_DIR:-${ROOT_DIR}/iosApp/build/xcode}"
+export BUILT_PRODUCTS_DIR="${BUILT_PRODUCTS_DIR:-${TARGET_BUILD_DIR}}"
+export UNLOCALIZED_RESOURCES_FOLDER_PATH="${UNLOCALIZED_RESOURCES_FOLDER_PATH:-Phoebe.app}"
+export FRAMEWORKS_FOLDER_PATH="${FRAMEWORKS_FOLDER_PATH:-Phoebe.app/Frameworks}"
+
+mkdir -p "${TARGET_BUILD_DIR}"
+
+echo "Prebuilding ComposeApp framework (${CONFIGURATION}/${SDK_NAME})..."
+./gradlew :composeApp:embedAndSignAppleFrameworkForXcode --no-daemon
+
+framework_path="${ROOT_DIR}/composeApp/build/xcode-frameworks/${CONFIGURATION}/${SDK_NAME}/ComposeApp.framework"
+if [[ ! -d "${framework_path}" ]]; then
+  echo "::error::Expected framework was not produced at ${framework_path}" >&2
+  exit 1
+fi
+
+echo "ComposeApp framework ready at ${framework_path}"


### PR DESCRIPTION
## Summary
- Prebuild the ComposeApp Kotlin framework before `xcodebuild` in the release workflow via `scripts/prebuild-ios-framework.sh`
- Skip redundant Kotlin compilation during Xcode builds with `OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED=YES` when the framework is already built
- Add Kotlin/Native (`~/.konan`) toolchain caching across PR, package-smoke, and release CI jobs
- Fingerprint Kotlin inputs so Xcode's "Compile Kotlin" phase only runs when sources or Gradle config change
- Enable Gradle build cache and parallel execution in `gradle.properties`

## Test plan
- [x] PR checks (including iOS build) pass
- [ ] Release workflow iOS job succeeds after merge to main


Made with [Cursor](https://cursor.com)