### PR TITLE
Fix iOS release timeout by removing redundant framework prebuild

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -836,16 +836,12 @@ jobs:
           IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
           IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
 
-      - name: Prebuild Kotlin framework for iOS release
-        shell: bash
-        run: ./scripts/prebuild-ios-framework.sh Release iphoneos
-
       - name: Build and Package iOS App
         shell: bash
         run: |
           if [[ "${SIGN_IOS}" == "true" ]]; then
             echo "Building signed iOS App..."
-            OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED=YES xcodebuild \
+            xcodebuild \
               -project iosApp/iosApp.xcodeproj \
               -scheme iosApp \
               -configuration Release \
@@ -871,7 +867,7 @@ jobs:
             cp "${ipa_path}" "release-artifacts/Phoebe-${VERSION}.ipa"
           else
             echo "Building unsigned iOS App..."
-            OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED=YES xcodebuild \
+            xcodebuild \
               -project iosApp/iosApp.xcodeproj \
               -scheme iosApp \
               -configuration Release \

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,5 @@
 org.gradle.jvmargs=-Xmx6144m -Dfile.encoding=UTF-8 -XX:-UseOnStackReplacement
 org.gradle.caching=true
-org.gradle.parallel=true
 kotlin.native.jvmArgs=-Xmx6g
 android.useAndroidX=true
 kotlin.code.style=official


### PR DESCRIPTION
## Summary
- Remove the separate `prebuild-ios-framework.sh` step from the release workflow; it duplicated the ~2.5h Release framework link and caused the iOS job to hit its 180-minute timeout before `xcodebuild` could archive
- Restore direct `xcodebuild` for iOS release (same path that succeeded in ~158 minutes on the prior release)
- Drop `org.gradle.parallel=true` to reduce memory pressure during Kotlin/Native linking on CI runners

## Context
Release run https://github.com/j-roskopf/Phoebe/actions/runs/31107993698 cancelled during `linkReleaseFrameworkIosArm64` in the prebuild step after ~2.5 hours.

## Test plan
- [ ] PR checks pass (including iOS build)
- [ ] iOS release job succeeds on the next main release workflow


Made with [Cursor](https://cursor.com)