### PR TITLE
Stop skipping songs when the music server is unreachable

### DIFF
--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAudioPlayer.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAudioPlayer.kt
@@ -1,3 +1,5 @@
+@file:androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+
 package com.phoebe.app.player
 
 import android.content.ComponentName
@@ -8,6 +10,7 @@ import androidx.media3.common.AudioAttributes
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
+import androidx.media3.datasource.HttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
@@ -132,6 +135,7 @@ class AndroidAudioPlayer(
     private var retryCount = 0
     private var pendingAutoplayGeneration = -1
     private var pendingAutoplayStartedAtMs = 0L
+    private var holdQueueOnInfrastructureFailure = false
     private val controllerMutex = Mutex()
     private var loadedPlatformQueue: LoadedPlatformQueue? = null
     private var appControllerMutationInProgress = false
@@ -158,8 +162,6 @@ class AndroidAudioPlayer(
         }
 
         override fun onPlayerError(error: PlaybackException) {
-            PhoebeLog.d("AndroidAudioPlayer") { "playback failed: ${error.message}" }
-            diagnostics.playbackError(PlaybackEnginePath.Media3, error.message)
             pendingControllerTarget = null
             stopBufferingTimeout()
             schedulePlaybackRetry(error, activePlayGeneration)
@@ -328,6 +330,7 @@ class AndroidAudioPlayer(
     }
 
     override fun resume() {
+        holdQueueOnInfrastructureFailure = false
         scope.launch {
             val ownedPlayer = ownedCrossfadePlayer()
             if (ownedPlayer != null) {
@@ -337,6 +340,9 @@ class AndroidAudioPlayer(
             } else {
                 controllerMutex.withLock {
                     activeLocalPlayer()?.run {
+                        if (playbackState == Player.STATE_IDLE || playerError != null) {
+                            prepare()
+                        }
                         markPendingAutoplay(activePlayGeneration)
                         volume = effectiveOutputVolume()
                         play()
@@ -678,7 +684,9 @@ class AndroidAudioPlayer(
 
     private fun handlePlatformPlaybackEnded() {
         if (shouldIgnoreAndroidServiceEndedCallback(crossfadeOwnedTrackId, crossfadePlayer != null)) return
+        if (holdQueueOnInfrastructureFailure) return
         val player = activeLocalPlayer()?.takeIf { it.playbackState == Player.STATE_ENDED } ?: return
+        if (player.playerError != null) return
         val endedAppIndex = endedPlatformAppIndex(player)
         if (endedAppIndex != null) {
             val queue = state.value.queue
@@ -1016,11 +1024,13 @@ class AndroidAudioPlayer(
             } catch (e: CancellationException) {
                 throw e
             } catch (error: Throwable) {
-                PhoebeLog.d("AndroidAudioPlayer") { "platform load failed: ${error.message}" }
+                val failure = PlaybackFailureClassifier.fromThrowable(error, currentStreamUri())
+                PhoebeLog.d("AndroidAudioPlayer") { "platform load failed: ${failure.logLine()}" }
                 pendingControllerTarget = null
                 clearPendingAutoplay()
                 stopBufferingTimeout()
-                markPlaybackFailed(generation)
+                holdQueueOnFailure(failure)
+                publishPlaybackFailure(failure, generation)
             }
         }
     }
@@ -1059,6 +1069,7 @@ class AndroidAudioPlayer(
             firstAppIndex = windowStartIndex,
             itemCount = windowTracks.size,
         )
+        holdQueueOnInfrastructureFailure = false
         queue.getOrNull(targetIndex)?.let { updateOptimisticLocalBufferedPosition(it, generation) }
         if (shouldPlay && playWhenReady) {
             markPendingAutoplay(generation)
@@ -1134,6 +1145,7 @@ class AndroidAudioPlayer(
             appControllerIndex >= 0 &&
             appControllerIndex != appState.currentIndex
         ) {
+            if (holdQueueOnInfrastructureFailure) return
             if (appControllerMutationInProgress) return
             val queueIds = appState.queue.map { it.id }
             if (loaded?.queueIds == queueIds && appControllerIndex in appState.queue.indices) {
@@ -1258,6 +1270,7 @@ class AndroidAudioPlayer(
         if (player.isPlaying && playWhenReady) {
             stopBufferingTimeout()
             resetRetries(generation)
+            holdQueueOnInfrastructureFailure = false
             startPositionSyncLoop(generation)
         } else {
             if (buffering && playWhenReady) {
@@ -1427,8 +1440,13 @@ class AndroidAudioPlayer(
         bufferingTimeoutJob = scope.launch {
             delay(PlaybackBufferingTimeoutMs)
             if (!isPlayRequestCurrent(generation) || !state.value.isBuffering) return@launch
-            PhoebeLog.d("AndroidAudioPlayer") { "playback timed out while buffering" }
-            schedulePlaybackRetry(null, generation)
+            handleClassifiedPlaybackFailure(
+                PlaybackFailureClassifier.fromMessage(
+                    "playback timed out while buffering",
+                    currentStreamUri(),
+                ),
+                generation,
+            )
         }
     }
 
@@ -1438,23 +1456,62 @@ class AndroidAudioPlayer(
     }
 
     private fun schedulePlaybackRetry(error: PlaybackException?, generation: Int) {
+        if (error != null) {
+            handleClassifiedPlaybackFailure(error.toPlaybackFailure(currentStreamUri()), generation)
+            return
+        }
         if (!isPlayRequestCurrent(generation) || !playWhenReady) return
-        if (error != null && !error.isRecoverableStreamError()) {
-            clearPendingAutoplay()
-            markPlaybackFailed(generation)
+        if (retryGeneration != generation) {
+            retryGeneration = generation
+            retryCount = 0
+        }
+        if (retryCount >= MaxStreamRetryCount) {
+            handleClassifiedPlaybackFailure(
+                PlaybackFailureClassifier.fromMessage("stream retry exhausted", currentStreamUri()),
+                generation,
+            )
+            return
+        }
+        retryCount++
+        retryCurrentStream(generation)
+    }
+
+    private fun handleClassifiedPlaybackFailure(failure: PlaybackFailure, generation: Int) {
+        if (!isPlayRequestCurrent(generation)) return
+        PhoebeLog.d("AndroidAudioPlayer") { failure.logLine() }
+        diagnostics.playbackError(PlaybackEnginePath.Media3, failure.logLine())
+        if (failure.holdsQueue) {
+            holdQueueOnInfrastructureFailure = true
+        }
+        if (!playWhenReady) {
+            holdQueueOnFailure(failure)
+            return
+        }
+        if (!failure.shouldRetry) {
+            holdQueueOnFailure(failure)
+            publishPlaybackFailure(failure, generation)
             return
         }
         if (retryGeneration != generation) {
             retryGeneration = generation
             retryCount = 0
         }
-        if (retryCount >= MaxStreamRetryCount) {
-            PhoebeLog.d("AndroidAudioPlayer") { "stream retry exhausted" }
-            clearPendingAutoplay()
-            markPlaybackFailed(generation)
+        val maxRetries = if (failure.kind == PlaybackFailureKind.Unreachable) {
+            MaxUnreachableRetryCount
+        } else {
+            MaxStreamRetryCount
+        }
+        if (retryCount >= maxRetries) {
+            PhoebeLog.d("AndroidAudioPlayer") { "stream retry exhausted kind=${failure.kind}" }
+            holdQueueOnFailure(failure)
+            publishPlaybackFailure(failure, generation)
             return
         }
         retryCount++
+        retryCurrentStream(generation)
+    }
+
+    private fun retryCurrentStream(generation: Int) {
         retryJob?.cancel()
         val delayMs = StreamRetryBaseDelayMs * retryCount
         retryJob = scope.launch {
@@ -1480,6 +1537,45 @@ class AndroidAudioPlayer(
             }
             syncFromController(generation)
         }
+    }
+
+    private fun holdQueueOnFailure(failure: PlaybackFailure) {
+        clearPendingAutoplay()
+        holdQueueOnInfrastructureFailure = failure.holdsQueue
+        if (failure.holdsQueue) {
+            cancelPlayIntent()
+            scope.launch {
+                controllerMutex.withLock {
+                    activeLocalPlayer()?.pause()
+                }
+            }
+        }
+    }
+
+    private fun currentStreamUri(): String? {
+        val track = state.value.currentTrack
+        return track?.localUri?.takeIf { it.isNotBlank() }
+            ?: track?.streamUrl?.takeIf { it.isNotBlank() }
+    }
+
+    private fun PlaybackException.toPlaybackFailure(streamUri: String?): PlaybackFailure {
+        val httpError = generateSequence(this as Throwable) { it.cause }
+            .filterIsInstance<HttpDataSource.InvalidResponseCodeException>()
+            .firstOrNull()
+        val causeChain = generateSequence(this as Throwable) { it.cause }
+            .drop(1)
+            .map { throwable ->
+                listOfNotNull(throwable::class.simpleName, throwable.message).joinToString(": ")
+            }
+            .filter { it.isNotBlank() }
+            .toList()
+        return PlaybackFailureClassifier.fromMedia3(
+            errorCode = errorCode,
+            message = message,
+            causeChain = causeChain,
+            httpStatus = httpError?.responseCode,
+            streamUri = httpError?.dataSpec?.uri?.toString() ?: streamUri,
+        )
     }
 
     private fun resetRetries(generation: Int) {
@@ -1524,12 +1620,6 @@ class AndroidAudioPlayer(
         AndroidPlaybackBridge.onLocalMediaSessionState?.invoke(null)
     }
 
-    private fun PlaybackException.isRecoverableStreamError(): Boolean =
-        errorCode == PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED ||
-            errorCode == PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT ||
-            errorCode == PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS ||
-            errorCode == PlaybackException.ERROR_CODE_IO_UNSPECIFIED
-
     private fun reportPlaybackDiagnostics(
         engine: PlaybackEnginePath,
         positionMs: Long,
@@ -1561,6 +1651,7 @@ class AndroidAudioPlayer(
         const val PlaybackBufferingTimeoutMs = 30_000L
         const val AutoplayStartRetryMs = 2_000L
         const val MaxStreamRetryCount = 5
+        const val MaxUnreachableRetryCount = 1
         const val StreamRetryBaseDelayMs = 1_000L
         const val SeekSettleTimeoutMs = 1_500L
         const val SeekSettlePollMs = 50L

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackFailure.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackFailure.kt
@@ -1,0 +1,233 @@
+package com.phoebe.app.player
+
+/**
+ * Why a track failed to start. Used to decide retry vs. stop, and to keep the queue
+ * from marching through every song when the music server is unreachable.
+ */
+enum class PlaybackFailureKind {
+    Unreachable,
+    Unauthorized,
+    NotFound,
+    NotAudio,
+    Unsupported,
+    Transient,
+    Unknown,
+}
+
+data class PlaybackFailure(
+    val kind: PlaybackFailureKind,
+    val message: String,
+    val statusCode: Int? = null,
+    val streamUri: String? = null,
+    val cause: String? = null,
+) {
+    /** Retry the same stream a limited number of times. */
+    val shouldRetry: Boolean
+        get() = kind == PlaybackFailureKind.Unreachable || kind == PlaybackFailureKind.Transient
+
+    /**
+     * Only codec / player-creation problems are worth trying a different engine against
+     * the same URI. Connection, auth, and HTML-instead-of-audio failures will fail again.
+     */
+    val shouldTryAlternateEngine: Boolean
+        get() = kind == PlaybackFailureKind.Unsupported
+
+    /** Server / network problems that must not walk the queue or retry every engine. */
+    val isInfrastructureFailure: Boolean
+        get() = kind == PlaybackFailureKind.Unreachable ||
+            kind == PlaybackFailureKind.Unauthorized ||
+            kind == PlaybackFailureKind.NotAudio ||
+            kind == PlaybackFailureKind.Transient
+
+    /**
+     * Infrastructure / unknown start failures must not advance the queue. A down server
+     * would otherwise look like "every song is broken."
+     */
+    val holdsQueue: Boolean
+        get() = kind != PlaybackFailureKind.NotFound && kind != PlaybackFailureKind.Unsupported
+
+    fun userMessage(trackTitle: String?): String {
+        val title = trackTitle?.takeIf { it.isNotBlank() }
+        return when (kind) {
+            PlaybackFailureKind.Unreachable ->
+                "Can't reach the music server. Check your connection and try again."
+            PlaybackFailureKind.Unauthorized ->
+                "The music server rejected this stream. Try reconnecting, then play again."
+            PlaybackFailureKind.NotAudio ->
+                "The music server didn't send audio. Check the server connection and try again."
+            PlaybackFailureKind.NotFound ->
+                title?.let { "Couldn't find a playable file for $it." } ?: "Couldn't find a playable file."
+            PlaybackFailureKind.Unsupported ->
+                title?.let { "Phoebe couldn't play $it on this device." } ?: "Phoebe couldn't play that song on this device."
+            PlaybackFailureKind.Transient ->
+                "The music server hit a temporary error. Try playing again."
+            PlaybackFailureKind.Unknown ->
+                title?.let { "Couldn't play $it." } ?: "Couldn't play that song."
+        }
+    }
+
+    fun logLine(): String = buildString {
+        append("playback failed: ")
+        append(kind.name)
+        message.takeIf { it.isNotBlank() }?.let { append(" message=").append(it) }
+        statusCode?.let { append(" status=").append(it) }
+        streamUri?.let { append(" uri=").append(PlaybackFailureClassifier.redactStreamUri(it)) }
+        cause?.takeIf { it.isNotBlank() }?.let { append(" cause=").append(it) }
+    }
+}
+
+object PlaybackFailureClassifier {
+    // Media3 PlaybackException error codes (kept here so common tests can classify them).
+    const val Media3IoUnspecified = 2000
+    const val Media3IoNetworkConnectionFailed = 2001
+    const val Media3IoNetworkConnectionTimeout = 2002
+    const val Media3IoInvalidHttpContentType = 2003
+    const val Media3IoBadHttpStatus = 2004
+    const val Media3IoFileNotFound = 2005
+    const val Media3ParsingContainerMalformed = 3001
+    const val Media3ParsingContainerUnsupported = 3003
+    const val Media3DecoderInitFailed = 4001
+    const val Media3DecodingFormatUnsupported = 4004
+
+    fun fromThrowable(error: Throwable?, streamUri: String? = null): PlaybackFailure {
+        if (error == null) {
+            return fromMessage(null, streamUri)
+        }
+        val chain = generateSequence(error) { it.cause }.toList()
+        val statusCode = chain.firstNotNullOfOrNull { statusCodeFromMessage(it.message) }
+        return fromSignals(
+            texts = chain.flatMap { throwable ->
+                listOfNotNull(throwable::class.simpleName, throwable.message)
+            },
+            streamUri = streamUri,
+            statusCode = statusCode,
+        )
+    }
+
+    fun fromMessage(message: String?, streamUri: String? = null): PlaybackFailure =
+        fromSignals(
+            texts = listOfNotNull(message),
+            streamUri = streamUri,
+            statusCode = statusCodeFromMessage(message),
+        )
+
+    fun fromMedia3(
+        errorCode: Int,
+        message: String?,
+        causeChain: List<String> = emptyList(),
+        httpStatus: Int? = null,
+        streamUri: String? = null,
+    ): PlaybackFailure {
+        val texts = (listOfNotNull(message) + causeChain).filter { it.isNotBlank() }
+        val statusCode = httpStatus ?: texts.firstNotNullOfOrNull { statusCodeFromMessage(it) }
+        val fromCode = when (errorCode) {
+            Media3IoNetworkConnectionFailed,
+            Media3IoNetworkConnectionTimeout,
+            -> PlaybackFailureKind.Unreachable
+            Media3IoInvalidHttpContentType -> PlaybackFailureKind.NotAudio
+            Media3IoFileNotFound -> PlaybackFailureKind.NotFound
+            Media3IoBadHttpStatus -> kindForHttpStatus(statusCode)
+            Media3ParsingContainerMalformed -> PlaybackFailureKind.NotAudio
+            Media3ParsingContainerUnsupported,
+            Media3DecoderInitFailed,
+            Media3DecodingFormatUnsupported,
+            -> PlaybackFailureKind.Unsupported
+            else -> null
+        }
+        if (fromCode != null) {
+            return PlaybackFailure(
+                kind = fromCode,
+                message = message?.takeIf { it.isNotBlank() } ?: fromCode.name,
+                statusCode = statusCode,
+                streamUri = streamUri,
+                cause = causeChain.firstOrNull { it.isNotBlank() },
+            )
+        }
+        return fromSignals(texts, streamUri, statusCode)
+    }
+
+    fun fromSignals(
+        texts: List<String>,
+        streamUri: String? = null,
+        statusCode: Int? = null,
+    ): PlaybackFailure {
+        val haystack = texts.joinToString(" ").lowercase()
+        val kind = when {
+            statusCode != null && statusCode !in 200..299 -> kindForHttpStatus(statusCode)
+            haystack.contains("unrecognized file signature") ||
+                haystack.contains("didn't send audio") ||
+                haystack.contains("instead of audio") ||
+                haystack.contains("invalid content type") ||
+                (haystack.contains("source error") && looksLikeHttpUri(streamUri) && haystack.contains("html"))
+                -> kindForUnrecognizedSignature(streamUri)
+            haystack.contains("could not create player") ||
+                haystack.contains("unsupported") && haystack.contains("format")
+                -> PlaybackFailureKind.Unsupported
+            haystack.contains("401") || haystack.contains("unauthorized") || haystack.contains("403")
+                -> PlaybackFailureKind.Unauthorized
+            haystack.contains("404") || haystack.contains("not found")
+                -> PlaybackFailureKind.NotFound
+            haystack.contains("media_inaccessible") ||
+                haystack.contains("media_unavailable") ||
+                haystack.contains("connectexception") ||
+                haystack.contains("connection refused") ||
+                haystack.contains("connection reset") ||
+                haystack.contains("failed to connect") ||
+                haystack.contains("network is unreachable") ||
+                haystack.contains("unknownhost") ||
+                haystack.contains("unable to resolve host") ||
+                haystack.contains("no address associated") ||
+                haystack.contains("connect timed out") ||
+                haystack.contains("connection timed out") ||
+                haystack.contains("http connect timed out") ||
+                haystack.contains("socket timeout") ||
+                haystack.contains("timed out while buffering") ||
+                haystack.contains("did not become ready") ||
+                haystack.contains("never started playing") ||
+                haystack.contains("took too long to start") ||
+                haystack.contains("handshake") && haystack.contains("terminat")
+                -> if (streamUri == null || looksLikeHttpUri(streamUri) || haystack.contains("timed out while buffering")) {
+                    PlaybackFailureKind.Unreachable
+                } else {
+                    PlaybackFailureKind.Unknown
+                }
+            haystack.contains("source error") -> PlaybackFailureKind.Unreachable
+            haystack.contains("503") || haystack.contains("502") || haystack.contains("500")
+                -> PlaybackFailureKind.Transient
+            else -> PlaybackFailureKind.Unknown
+        }
+        return PlaybackFailure(
+            kind = kind,
+            message = texts.firstOrNull { it.isNotBlank() } ?: kind.name,
+            statusCode = statusCode,
+            streamUri = streamUri,
+            cause = texts.drop(1).firstOrNull { it.isNotBlank() },
+        )
+    }
+
+    fun redactStreamUri(uri: String): String {
+        val withoutQuery = uri.substringBefore('?')
+        return if (withoutQuery.length <= 240) withoutQuery else withoutQuery.take(240)
+    }
+
+    private fun kindForHttpStatus(statusCode: Int?): PlaybackFailureKind = when (statusCode) {
+        401, 403 -> PlaybackFailureKind.Unauthorized
+        404, 410 -> PlaybackFailureKind.NotFound
+        in 500..599 -> PlaybackFailureKind.Transient
+        in 400..499 -> PlaybackFailureKind.Unauthorized
+        else -> PlaybackFailureKind.Transient
+    }
+
+    private fun kindForUnrecognizedSignature(streamUri: String?): PlaybackFailureKind =
+        if (looksLikeHttpUri(streamUri)) PlaybackFailureKind.NotAudio else PlaybackFailureKind.Unsupported
+
+    private fun looksLikeHttpUri(uri: String?): Boolean =
+        uri?.startsWith("http://", ignoreCase = true) == true ||
+            uri?.startsWith("https://", ignoreCase = true) == true
+
+    private fun statusCodeFromMessage(message: String?): Int? {
+        if (message.isNullOrBlank()) return null
+        val match = Regex("""\b(401|403|404|410|500|502|503)\b""").find(message) ?: return null
+        return match.groupValues[1].toInt()
+    }
+}

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackFailure.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackFailure.kt
@@ -69,10 +69,14 @@ data class PlaybackFailure(
     fun logLine(): String = buildString {
         append("playback failed: ")
         append(kind.name)
-        message.takeIf { it.isNotBlank() }?.let { append(" message=").append(it) }
+        message.takeIf { it.isNotBlank() }?.let {
+            append(" message=").append(PlaybackFailureClassifier.redactSensitiveText(it))
+        }
         statusCode?.let { append(" status=").append(it) }
         streamUri?.let { append(" uri=").append(PlaybackFailureClassifier.redactStreamUri(it)) }
-        cause?.takeIf { it.isNotBlank() }?.let { append(" cause=").append(it) }
+        cause?.takeIf { it.isNotBlank() }?.let {
+            append(" cause=").append(PlaybackFailureClassifier.redactSensitiveText(it))
+        }
     }
 }
 
@@ -191,7 +195,8 @@ object PlaybackFailureClassifier {
                 } else {
                     PlaybackFailureKind.Unknown
                 }
-            haystack.contains("source error") -> PlaybackFailureKind.Unreachable
+            haystack.contains("source error") ->
+                if (looksLikeHttpUri(streamUri)) PlaybackFailureKind.Unreachable else PlaybackFailureKind.Unknown
             haystack.contains("503") || haystack.contains("502") || haystack.contains("500")
                 -> PlaybackFailureKind.Transient
             else -> PlaybackFailureKind.Unknown
@@ -206,13 +211,19 @@ object PlaybackFailureClassifier {
     }
 
     fun redactStreamUri(uri: String): String {
-        val withoutQuery = uri.substringBefore('?')
+        val withoutQuery = redactSensitiveText(uri).substringBefore('?')
         return if (withoutQuery.length <= 240) withoutQuery else withoutQuery.take(240)
     }
+
+    fun redactSensitiveText(text: String): String =
+        text.replace(Regex("""(https?://[^\s"'<>?]+)(\?[^\s"'<>]*)""", RegexOption.IGNORE_CASE)) { match ->
+            match.groupValues[1]
+        }
 
     private fun kindForHttpStatus(statusCode: Int?): PlaybackFailureKind = when (statusCode) {
         401, 403 -> PlaybackFailureKind.Unauthorized
         404, 410 -> PlaybackFailureKind.NotFound
+        408, 429 -> PlaybackFailureKind.Transient
         in 500..599 -> PlaybackFailureKind.Transient
         in 400..499 -> PlaybackFailureKind.Unauthorized
         else -> PlaybackFailureKind.Transient
@@ -227,7 +238,12 @@ object PlaybackFailureClassifier {
 
     private fun statusCodeFromMessage(message: String?): Int? {
         if (message.isNullOrBlank()) return null
-        val match = Regex("""\b(401|403|404|410|500|502|503)\b""").find(message) ?: return null
+        val labeled = Regex(
+            """(?:failed\s*\(|response code:?\s*|status(?: code)?:?\s*)([4-5]\d{2})\b""",
+            RegexOption.IGNORE_CASE,
+        ).find(message)
+        if (labeled != null) return labeled.groupValues[1].toInt()
+        val match = Regex("""\b(401|403|404|408|410|429|500|502|503|504)\b""").find(message) ?: return null
         return match.groupValues[1].toInt()
     }
 }

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 internal const val PlaybackReadyBufferedAheadMs = 2_000L
@@ -580,8 +579,26 @@ abstract class SimpleAudioPlayer(
         }
     }
 
-    protected fun markPlaybackFailed(generation: Int = playGeneration, message: String? = null) {
+    protected fun publishPlaybackFailure(
+        failure: PlaybackFailure,
+        generation: Int = playGeneration,
+    ) {
+        markPlaybackFailed(
+            generation = generation,
+            message = failure.userMessage(mutableState.value.currentTrack?.title),
+            cancelPlayIntent = failure.holdsQueue,
+        )
+    }
+
+    protected fun markPlaybackFailed(
+        generation: Int = playGeneration,
+        message: String? = null,
+        cancelPlayIntent: Boolean = false,
+    ) {
         if (!isPlayRequestCurrent(generation)) return
+        if (cancelPlayIntent) {
+            playWhenReady = false
+        }
         stopPlaybackStartupWatchdog()
         val current = mutableState.value
         mutableState.value = current.copy(
@@ -678,6 +695,7 @@ abstract class SimpleAudioPlayer(
     protected open fun cancelGaplessPrepareOnPlatform(generation: Int) = Unit
 
     protected fun advanceAfterPlatformTrackEnded(generation: Int = playGeneration) {
+        if (!playWhenReady) return
         if (commitPreparedGapless(generation)) return
         advanceNext(allowCrossfade = false)
     }
@@ -781,23 +799,17 @@ abstract class SimpleAudioPlayer(
 
     protected open fun onPlaybackStartupTimedOut(generation: Int) {
         if (!isPlayRequestCurrent(generation)) return
-        stopPlaybackStartupWatchdog()
-        val previousErrorSerial = mutableState.value.playbackErrorSerial
-        mutableState.update { current ->
-            if (!isPlayRequestCurrent(generation) || !current.isBuffering) {
-                current
-            } else {
-                current.copy(
-                    isBuffering = false,
-                    isPlaying = false,
-                    playbackErrorSerial = current.playbackErrorSerial + 1,
-                    playbackErrorMessage = "Playback took too long to start.",
-                )
-            }
+        if (!mutableState.value.isBuffering) {
+            stopPlaybackStartupWatchdog()
+            return
         }
-        if (mutableState.value.playbackErrorSerial != previousErrorSerial) {
-            stopProgressTicker()
-        }
+        val track = mutableState.value.currentTrack
+        val streamUri = track?.localUri?.takeIf { it.isNotBlank() }
+            ?: track?.streamUrl?.takeIf { it.isNotBlank() }
+        publishPlaybackFailure(
+            PlaybackFailureClassifier.fromMessage("Playback took too long to start.", streamUri),
+            generation,
+        )
     }
 
     protected open val playbackStartupTimeoutMs: Long

--- a/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
@@ -4,6 +4,8 @@ import com.phoebe.app.domain.AudioProcessingSettings
 import com.phoebe.app.domain.EqualizerProfile
 import com.phoebe.app.domain.Track
 import com.phoebe.app.domain.RepeatMode
+import com.phoebe.app.player.PlaybackFailure
+import com.phoebe.app.player.PlaybackFailureClassifier
 import com.phoebe.app.player.SimpleAudioPlayer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -92,7 +94,11 @@ class PlayerStateTest {
         runCurrent()
         assertFalse(player.state.value.isPlaying)
         assertEquals(1, player.state.value.playbackErrorSerial)
-        assertEquals("Playback took too long to start.", player.state.value.playbackErrorMessage)
+        assertEquals(
+            "Can't reach the music server. Check your connection and try again.",
+            player.state.value.playbackErrorMessage,
+        )
+        assertFalse(player.playIntentActive())
     }
 
     @Test
@@ -466,6 +472,31 @@ class PlayerStateTest {
 
         assertEquals(1, player.state.value.playbackErrorSerial)
         assertEquals(null, player.state.value.playbackErrorMessage)
+    }
+
+    @Test
+    fun infrastructureFailureStopsPlayIntentAndDoesNotAdvanceQueue() {
+        val player = PlatformStateTestPlayer()
+        val tracks = listOf(
+            Track("t1", "One", "Artist", "Album", 60_000, "http://a", ""),
+            Track("t2", "Two", "Artist", "Album", 90_000, "http://b", ""),
+        )
+
+        player.play(tracks, 0)
+        val failure = PlaybackFailureClassifier.fromMessage(
+            "ConnectException: Connection refused",
+            streamUri = tracks[0].streamUrl,
+        )
+        player.publishFailure(failure)
+
+        assertEquals(tracks[0], player.state.value.currentTrack)
+        assertFalse(player.state.value.isPlaying)
+        assertFalse(player.playIntentActive())
+        assertEquals("Can't reach the music server. Check your connection and try again.", player.state.value.playbackErrorMessage)
+
+        player.endCurrentTrack()
+
+        assertEquals(tracks[0], player.state.value.currentTrack)
     }
 
     @Test
@@ -985,6 +1016,8 @@ private open class SlowTestPlayer(
         resumeCalls++
     }
 
+    fun playIntentActive(): Boolean = playWhenReady
+
     override fun playQueueOnPlatform(queue: List<Track>, startIndex: Int, track: Track, generation: Int) {
         pendingLoads += generation
     }
@@ -1134,8 +1167,18 @@ private class PlatformStateTestPlayer : SimpleAudioPlayer() {
         adoptPlatformPlayIntent(playWhenReady)
     }
 
-    fun failPlayback(message: String? = null) {
-        markPlaybackFailed(message = message)
+    fun failPlayback(message: String? = null, cancelPlayIntent: Boolean = false) {
+        markPlaybackFailed(message = message, cancelPlayIntent = cancelPlayIntent)
+    }
+
+    fun playIntentActive(): Boolean = playWhenReady
+
+    fun publishFailure(failure: PlaybackFailure) {
+        publishPlaybackFailure(failure)
+    }
+
+    fun endCurrentTrack() {
+        advanceAfterPlatformTrackEnded()
     }
 }
 

--- a/playback/src/commonTest/kotlin/com/phoebe/app/player/PlaybackFailureTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/player/PlaybackFailureTest.kt
@@ -109,6 +109,55 @@ class PlaybackFailureTest {
     }
 
     @Test
+    fun exceptionTextIsLoggedWithoutQuerySecrets() {
+        val failure = PlaybackFailure(
+            kind = PlaybackFailureKind.Unauthorized,
+            message = "HttpDataSourceException: https://plex.example/library/parts/1?X-Plex-Token=s3cret",
+            statusCode = 401,
+            streamUri = "https://plex.example/library/parts/1?X-Plex-Token=s3cret",
+            cause = "InvalidResponseCodeException: https://plex.example/library/parts/1?X-Plex-Token=s3cret",
+        )
+
+        val line = failure.logLine()
+        assertTrue(line.contains("https://plex.example/library/parts/1"))
+        assertFalse(line.contains("s3cret"))
+        assertFalse(line.contains("X-Plex-Token"))
+        assertFalse(line.contains("?"))
+    }
+
+    @Test
+    fun gatewayAndRateLimitStatusesAreInfrastructureFailures() {
+        val gateway = PlaybackFailureClassifier.fromMessage(
+            "Plex stream request failed (504)",
+            streamUri = "https://plex.example/library/parts/1",
+        )
+        val rateLimited = PlaybackFailureClassifier.fromMessage(
+            "Plex stream request failed (429)",
+            streamUri = "https://plex.example/library/parts/1",
+        )
+
+        assertEquals(PlaybackFailureKind.Transient, gateway.kind)
+        assertEquals(504, gateway.statusCode)
+        assertTrue(gateway.isInfrastructureFailure)
+        assertEquals(PlaybackFailureKind.Transient, rateLimited.kind)
+        assertEquals(429, rateLimited.statusCode)
+        assertTrue(rateLimited.isInfrastructureFailure)
+    }
+
+    @Test
+    fun localSourceErrorIsNotTreatedAsAnUnreachableServer() {
+        val failure = PlaybackFailureClassifier.fromMedia3(
+            errorCode = PlaybackFailureClassifier.Media3IoUnspecified,
+            message = "Source error",
+            streamUri = "file:///music/track.flac",
+        )
+
+        assertEquals(PlaybackFailureKind.Unknown, failure.kind)
+        assertFalse(failure.isInfrastructureFailure)
+        assertFalse(failure.shouldRetry)
+    }
+
+    @Test
     fun javaFxCouldNotCreatePlayerStaysACodecProblem() {
         val failure = PlaybackFailureClassifier.fromMessage(
             "com.sun.media.jfxmedia.MediaException: Could not create player!",

--- a/playback/src/commonTest/kotlin/com/phoebe/app/player/PlaybackFailureTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/player/PlaybackFailureTest.kt
@@ -1,0 +1,169 @@
+package com.phoebe.app.player
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PlaybackFailureTest {
+    @Test
+    fun connectionFailuresHoldTheQueueAndRetryOnce() {
+        val failure = PlaybackFailureClassifier.fromMessage(
+            "ConnectException: Connection refused",
+            streamUri = "http://10.10.0.1:8096/emby/Audio/1/stream",
+        )
+
+        assertEquals(PlaybackFailureKind.Unreachable, failure.kind)
+        assertTrue(failure.shouldRetry)
+        assertTrue(failure.holdsQueue)
+        assertTrue(failure.userMessage("Song").contains("Can't reach the music server"))
+    }
+
+    @Test
+    fun sourceErrorIsTreatedAsUnreachableSoTheQueueDoesNotAdvance() {
+        val failure = PlaybackFailureClassifier.fromMedia3(
+            errorCode = PlaybackFailureClassifier.Media3IoUnspecified,
+            message = "Source error",
+            streamUri = "https://music.example/stream",
+        )
+
+        assertEquals(PlaybackFailureKind.Unreachable, failure.kind)
+        assertTrue(failure.holdsQueue)
+        assertTrue(failure.shouldRetry)
+    }
+
+    @Test
+    fun unauthorizedStreamIsNotRetriedAndDoesNotSkip() {
+        val failure = PlaybackFailureClassifier.fromMessage(
+            "Plex stream request failed (401)",
+            streamUri = "https://plex.example/library/parts/1?X-Plex-Token=secret",
+        )
+
+        assertEquals(PlaybackFailureKind.Unauthorized, failure.kind)
+        assertFalse(failure.shouldRetry)
+        assertTrue(failure.holdsQueue)
+        assertEquals(401, failure.statusCode)
+    }
+
+    @Test
+    fun htmlInsteadOfAudioIsAServerProblemNotABadTrack() {
+        val remote = PlaybackFailureClassifier.fromMessage(
+            "Unrecognized file signature!",
+            streamUri = "https://emby.example/Audio/1/stream",
+        )
+        val local = PlaybackFailureClassifier.fromMessage(
+            "Unrecognized file signature!",
+            streamUri = "file:///music/track.flac",
+        )
+
+        assertEquals(PlaybackFailureKind.NotAudio, remote.kind)
+        assertTrue(remote.holdsQueue)
+        assertFalse(remote.shouldRetry)
+        assertEquals(PlaybackFailureKind.Unsupported, local.kind)
+        assertFalse(local.holdsQueue)
+    }
+
+    @Test
+    fun media3HttpStatusCodesMapToAuthAndNotFound() {
+        val unauthorized = PlaybackFailureClassifier.fromMedia3(
+            errorCode = PlaybackFailureClassifier.Media3IoBadHttpStatus,
+            message = "Response code: 401",
+            httpStatus = 401,
+            streamUri = "https://plex.example/library/parts/1",
+        )
+        val missing = PlaybackFailureClassifier.fromMedia3(
+            errorCode = PlaybackFailureClassifier.Media3IoBadHttpStatus,
+            message = "Response code: 404",
+            httpStatus = 404,
+            streamUri = "https://plex.example/library/parts/missing",
+        )
+
+        assertEquals(PlaybackFailureKind.Unauthorized, unauthorized.kind)
+        assertTrue(unauthorized.holdsQueue)
+        assertEquals(PlaybackFailureKind.NotFound, missing.kind)
+        assertFalse(missing.holdsQueue)
+    }
+
+    @Test
+    fun bufferingTimeoutIsUnreachable() {
+        val failure = PlaybackFailureClassifier.fromMessage("playback timed out while buffering")
+
+        assertEquals(PlaybackFailureKind.Unreachable, failure.kind)
+        assertTrue(failure.shouldRetry)
+        assertTrue(failure.holdsQueue)
+    }
+
+    @Test
+    fun streamUrisAreLoggedWithoutQuerySecrets() {
+        val failure = PlaybackFailure(
+            kind = PlaybackFailureKind.Unauthorized,
+            message = "Plex stream request failed (401)",
+            statusCode = 401,
+            streamUri = "https://plex.example/library/parts/1?X-Plex-Token=s3cret",
+        )
+
+        val line = failure.logLine()
+        assertTrue(line.contains("uri=https://plex.example/library/parts/1"))
+        assertFalse(line.contains("s3cret"))
+        assertFalse(line.contains("X-Plex-Token"))
+    }
+
+    @Test
+    fun javaFxCouldNotCreatePlayerStaysACodecProblem() {
+        val failure = PlaybackFailureClassifier.fromMessage(
+            "com.sun.media.jfxmedia.MediaException: Could not create player!",
+            streamUri = "https://music.example/track.m4a",
+        )
+
+        assertEquals(PlaybackFailureKind.Unsupported, failure.kind)
+        assertFalse(failure.holdsQueue)
+        assertTrue(failure.shouldTryAlternateEngine)
+    }
+
+    @Test
+    fun remoteStartupTimeoutsAreUnreachableAndDoNotTryAnotherEngine() {
+        val timeout = PlaybackFailureClassifier.fromMessage(
+            "JavaFX media did not become ready in 3000ms",
+            streamUri = "https://music.example/Audio/1/stream",
+        )
+        val playingTimeout = PlaybackFailureClassifier.fromMessage(
+            "JavaFX media ready but never started playing",
+            streamUri = "http://10.10.0.1:8096/emby/Audio/1/stream",
+        )
+
+        assertEquals(PlaybackFailureKind.Unreachable, timeout.kind)
+        assertEquals(PlaybackFailureKind.Unreachable, playingTimeout.kind)
+        assertTrue(timeout.holdsQueue)
+        assertFalse(timeout.shouldTryAlternateEngine)
+        assertTrue(timeout.isInfrastructureFailure)
+    }
+
+    @Test
+    fun htmlAndUnauthorizedFailuresDoNotFallThroughToAnotherEngine() {
+        val html = PlaybackFailureClassifier.fromMessage(
+            "Unrecognized file signature!",
+            streamUri = "https://emby.example/Audio/1/stream",
+        )
+        val unauthorized = PlaybackFailureClassifier.fromMessage(
+            "Plex stream request failed (401)",
+            streamUri = "https://plex.example/library/parts/1",
+        )
+
+        assertFalse(html.shouldTryAlternateEngine)
+        assertTrue(html.isInfrastructureFailure)
+        assertFalse(unauthorized.shouldTryAlternateEngine)
+        assertTrue(unauthorized.isInfrastructureFailure)
+    }
+
+    @Test
+    fun javaFxUnavailableMediaIsUnreachable() {
+        val failure = PlaybackFailureClassifier.fromSignals(
+            texts = listOf("MediaException", "MEDIA_UNAVAILABLE", "Connection refused"),
+            streamUri = "https://music.example/stream",
+        )
+
+        assertEquals(PlaybackFailureKind.Unreachable, failure.kind)
+        assertTrue(failure.isInfrastructureFailure)
+        assertFalse(failure.shouldTryAlternateEngine)
+    }
+}

--- a/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
+++ b/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
@@ -11,6 +11,7 @@ import javazoom.spi.vorbis.sampled.file.VorbisAudioFileReader
 import javafx.application.Platform
 import javafx.scene.media.AudioSpectrumListener
 import javafx.scene.media.Media
+import javafx.scene.media.MediaException
 import javafx.scene.media.MediaPlayer
 import java.io.BufferedInputStream
 import java.io.ByteArrayInputStream
@@ -106,6 +107,8 @@ class DesktopAudioPlayer(
     private var pendingManualSeekPositionMs = 0L
     private var pendingManualSeekUntilMs = 0L
     private var javaFxStartupWatchdogStop: AtomicBoolean? = null
+    private var pendingPlaybackFailure: PlaybackFailure? = null
+    private var reloadOnResume = false
     private val httpClient = HttpClient.newBuilder()
         .version(HttpClient.Version.HTTP_1_1)
         .connectTimeout(Duration.ofSeconds(15))
@@ -313,12 +316,16 @@ class DesktopAudioPlayer(
         isKnownLiveStream: Boolean,
     ) {
         if (uri.isBlank()) {
-            finishPlaybackFailed()
+            finishPlaybackFailed(
+                PlaybackFailureClassifier.fromMessage("Missing playback URI", streamUri = null),
+            )
             return
         }
         val generation = activePlayGeneration
         playbackExecutor.execute {
             if (!isPlayRequestCurrent(generation)) return@execute
+            pendingPlaybackFailure = null
+            reloadOnResume = false
             runCatching {
                 disposeAllOnPlaybackThread()
                 if (!isPlayRequestCurrent(generation)) return@execute
@@ -345,6 +352,7 @@ class DesktopAudioPlayer(
                         return@execute
                     }
                     PhoebeLog.d("DesktopAudioPlayer") { "gapless ffmpeg pcm route unavailable; falling back to JavaFX" }
+                    if (finishIfInfrastructureFailure(generation)) return@execute
                 }
                 val routePcmBeforeJavaFx = file == null &&
                     !DesktopSandboxPlayback.isFlatpakSandbox() &&
@@ -361,6 +369,7 @@ class DesktopAudioPlayer(
                     if (tryStartFfmpegPcmStream(activeUri, generation)) {
                         return@execute
                     }
+                    if (finishIfInfrastructureFailure(generation)) return@execute
                     if (isKnownLiveStream) {
                         if (tryLiveRadioSampledPlayback(
                                 activeUri = activeUri,
@@ -375,6 +384,7 @@ class DesktopAudioPlayer(
                             "ffmpeg live stream unavailable for $activeUri; trying JavaFX and sampled fallbacks"
                         }
                     }
+                    if (finishIfInfrastructureFailure(generation)) return@execute
                 }
                 if (file == null) {
                     val streamingExtension = preferredStreamingExtension ?: streamingSampledExtensionFromUri(activeUri)
@@ -389,6 +399,7 @@ class DesktopAudioPlayer(
                     ) {
                         return@execute
                     }
+                    if (finishIfInfrastructureFailure(generation)) return@execute
                     if (!isPlayRequestCurrent(generation)) return@execute
                 }
                 if (file == null && shouldEagerlyBufferRemotePlayback(activeUri, preferredSampledExtension)) {
@@ -480,6 +491,7 @@ class DesktopAudioPlayer(
                 ) {
                     return@execute
                 }
+                if (finishIfInfrastructureFailure(generation)) return@execute
                 if (!isPlayRequestCurrent(generation)) return@execute
                 val playbackUri = file?.toURI()?.toString() ?: activeUri
                 fullyBufferedPlayback = file != null
@@ -492,18 +504,16 @@ class DesktopAudioPlayer(
                         preferJavaFxForLocalStreaming = preferJavaFxForLocalStreaming,
                     )
                 ) {
-                    val javaFxScheduled = startJavaFxPlayback(playbackUri, generation) {
-                        if (!continuePlaybackAfterJavaFxFailure(
-                                activeUri = activeUri,
-                                downloadUri = downloadUri,
-                                preferredSampledExtension = preferredSampledExtension,
-                                preferredStreamingExtension = preferredStreamingExtension,
-                                file = file,
-                                generation = generation,
-                            )
-                        ) {
-                            finishPlaybackFailed(generation = generation)
-                        }
+                    val javaFxScheduled = startJavaFxPlayback(playbackUri, generation) { failure ->
+                        handleJavaFxStartupFailure(
+                            failure = failure,
+                            activeUri = activeUri,
+                            downloadUri = downloadUri,
+                            preferredSampledExtension = preferredSampledExtension,
+                            preferredStreamingExtension = preferredStreamingExtension,
+                            file = file,
+                            generation = generation,
+                        )
                     }
                     if (!javaFxScheduled &&
                         !continuePlaybackAfterJavaFxFailure(
@@ -515,7 +525,7 @@ class DesktopAudioPlayer(
                             generation = generation,
                         )
                     ) {
-                        finishPlaybackFailed(generation = generation)
+                        finishPendingOrGenericFailure(generation)
                     }
                     return@execute
                 }
@@ -528,14 +538,13 @@ class DesktopAudioPlayer(
                         generation = generation,
                     )
                 ) {
-                    diagnostics.playbackError(PlaybackEnginePath.JavaFxMediaPlayer, "Desktop playback failed to start")
-                    finishPlaybackFailed(generation = generation)
+                    finishPendingOrGenericFailure(generation)
                 }
             }.onFailure { error ->
                 if (!isPlayRequestCurrent(generation)) return@execute
-                logPlaybackFailure(error)
-                diagnostics.playbackError(PlaybackEnginePath.JavaFxMediaPlayer, error.message)
-                finishPlaybackFailed(generation = generation)
+                val failure = rememberPlaybackFailure(error, uri)
+                diagnostics.playbackError(PlaybackEnginePath.JavaFxMediaPlayer, failure.logLine())
+                finishPlaybackFailed(failure, generation)
             }
         }
     }
@@ -566,10 +575,27 @@ class DesktopAudioPlayer(
             val clip = sampledClip
             if (clip != null) {
                 runCatching { clip.start() }
-            } else {
-                JavaFxRuntime.runLater { player?.play() }
+                return@execute
+            }
+            if (reloadOnResume) {
+                reloadCurrentTrack()
+                return@execute
+            }
+            JavaFxRuntime.runLater {
+                val mediaPlayer = player
+                if (mediaPlayer == null || mediaPlayer.error != null) {
+                    playbackExecutor.execute { reloadCurrentTrack() }
+                } else {
+                    mediaPlayer.play()
+                }
             }
         }
+    }
+
+    private fun reloadCurrentTrack() {
+        reloadOnResume = false
+        val track = state.value.currentTrack ?: return
+        playTrack(track, preferJavaFxForLocalStreaming = false)
     }
 
     override fun seek(positionMs: Long) {
@@ -1498,12 +1524,78 @@ class DesktopAudioPlayer(
 
     private fun finishPlaybackReady(isPlaying: Boolean = true, generation: Int = activePlayGeneration) {
         DesktopInlineRadioMapCoordinator.endLiveRadioStartup()
+        pendingPlaybackFailure = null
+        reloadOnResume = false
         markPlaybackReady(isPlaying = isPlaying, generation = generation)
     }
 
     private fun finishPlaybackFailed(generation: Int = activePlayGeneration, message: String? = null) {
         DesktopInlineRadioMapCoordinator.endLiveRadioStartup()
         markPlaybackFailed(generation = generation, message = message)
+    }
+
+    private fun finishPlaybackFailed(failure: PlaybackFailure, generation: Int = activePlayGeneration) {
+        DesktopInlineRadioMapCoordinator.endLiveRadioStartup()
+        reloadOnResume = failure.holdsQueue
+        publishPlaybackFailure(failure, generation)
+    }
+
+    private fun currentStreamUri(): String? {
+        val track = state.value.currentTrack
+        return track?.localUri?.takeIf { it.isNotBlank() }
+            ?: track?.streamUrl?.takeIf { it.isNotBlank() }
+    }
+
+    private fun rememberPlaybackFailure(error: Throwable, streamUri: String?): PlaybackFailure {
+        val failure = PlaybackFailureClassifier.fromThrowable(error, streamUri ?: currentStreamUri())
+        PhoebeLog.d("DesktopAudioPlayer") { failure.logLine() }
+        if (!failure.shouldTryAlternateEngine && failure.isInfrastructureFailure) {
+            pendingPlaybackFailure = failure
+        }
+        return failure
+    }
+
+    private fun finishIfInfrastructureFailure(generation: Int): Boolean {
+        val failure = pendingPlaybackFailure?.takeIf { it.isInfrastructureFailure } ?: return false
+        finishPlaybackFailed(failure, generation)
+        return true
+    }
+
+    private fun finishPendingOrGenericFailure(generation: Int) {
+        val failure = pendingPlaybackFailure
+            ?: PlaybackFailureClassifier.fromMessage("Desktop playback failed to start", currentStreamUri())
+        pendingPlaybackFailure = null
+        diagnostics.playbackError(PlaybackEnginePath.JavaFxMediaPlayer, failure.logLine())
+        finishPlaybackFailed(failure, generation)
+    }
+
+    private fun handleJavaFxStartupFailure(
+        failure: PlaybackFailure,
+        activeUri: String,
+        downloadUri: String?,
+        preferredSampledExtension: String?,
+        preferredStreamingExtension: String?,
+        file: File?,
+        generation: Int,
+    ) {
+        PhoebeLog.d("DesktopAudioPlayer") { failure.logLine() }
+        diagnostics.playbackError(PlaybackEnginePath.JavaFxMediaPlayer, failure.logLine())
+        if (failure.isInfrastructureFailure) {
+            pendingPlaybackFailure = failure
+            finishPlaybackFailed(failure, generation)
+            return
+        }
+        if (!continuePlaybackAfterJavaFxFailure(
+                activeUri = activeUri,
+                downloadUri = downloadUri,
+                preferredSampledExtension = preferredSampledExtension,
+                preferredStreamingExtension = preferredStreamingExtension,
+                file = file,
+                generation = generation,
+            )
+        ) {
+            finishPlaybackFailed(pendingPlaybackFailure ?: failure, generation)
+        }
     }
 
     private fun tryLiveRadioSampledPlayback(
@@ -1562,9 +1654,11 @@ class DesktopAudioPlayer(
         ) {
             return true
         }
+        if (pendingPlaybackFailure?.isInfrastructureFailure == true) return false
         if (file == null && tryStartFfmpegPcmStream(activeUri, generation)) {
             return true
         }
+        if (pendingPlaybackFailure?.isInfrastructureFailure == true) return false
         if (file == null &&
             tryBufferedRemotePlaybackFallback(activeUri, downloadUri, preferredSampledExtension, generation)
         ) {
@@ -1591,7 +1685,6 @@ class DesktopAudioPlayer(
                 stop.set(true)
                 playbackExecutor.execute {
                     if (!isPlayRequestCurrent(generation)) return@execute
-                    PhoebeLog.d("DesktopAudioPlayer") { "JavaFX media did not become ready in ${JavaFxMediaReadyTimeoutMs}ms" }
                     disposeJavaFxBlocking()
                     onStartupFailed()
                 }
@@ -1601,7 +1694,7 @@ class DesktopAudioPlayer(
     private fun startJavaFxPlayback(
         uri: String,
         generation: Int,
-        onStartupFailed: () -> Unit,
+        onStartupFailed: (PlaybackFailure) -> Unit,
     ): Boolean {
         if (JavaFxRuntime.hasFailed) return false
         diagnostics.playbackStartupEvent(PlaybackEnginePath.JavaFxMediaPlayer, "scheduled")
@@ -1612,13 +1705,13 @@ class DesktopAudioPlayer(
         val playingStarted = AtomicBoolean(false)
         val playingWatchdogStop = AtomicBoolean(false)
         val startupFailed = AtomicBoolean(false)
-        fun failStartup() {
+        fun failStartup(failure: PlaybackFailure) {
             if (!startupFailed.compareAndSet(false, true)) return
             cancelJavaFxStartupWatchdog()
             playingWatchdogStop.set(true)
             playbackExecutor.execute {
                 if (!isPlayRequestCurrent(generation)) return@execute
-                onStartupFailed()
+                onStartupFailed(failure)
             }
         }
         fun schedulePlayingWatchdog() {
@@ -1628,10 +1721,12 @@ class DesktopAudioPlayer(
                 playingWatchdogStop.set(true)
                 playbackExecutor.execute {
                     if (playingStarted.get() || !isPlayRequestCurrent(generation)) return@execute
-                    PhoebeLog.d("DesktopAudioPlayer") {
-                        "JavaFX media ready but never started playing within ${JavaFxMediaPlayingTimeoutMs}ms"
-                    }
-                    failStartup()
+                    failStartup(
+                        PlaybackFailureClassifier.fromMessage(
+                            "JavaFX media ready but never started playing within ${JavaFxMediaPlayingTimeoutMs}ms",
+                            uri,
+                        ),
+                    )
                 }
             }
         }
@@ -1639,7 +1734,14 @@ class DesktopAudioPlayer(
             stop = watchdogStop,
             generation = generation,
             mediaReady = mediaReady,
-            onStartupFailed = { failStartup() },
+            onStartupFailed = {
+                failStartup(
+                    PlaybackFailureClassifier.fromMessage(
+                        "JavaFX media did not become ready in ${JavaFxMediaReadyTimeoutMs}ms",
+                        uri,
+                    ),
+                )
+            },
         )
         JavaFxRuntime.runLater(
             block = {
@@ -1664,11 +1766,7 @@ class DesktopAudioPlayer(
                         }
                     }
                     mediaPlayer.setOnError {
-                        PhoebeLog.d("DesktopAudioPlayer") {
-                            "playback error: ${mediaPlayer.error?.message ?: mediaPlayer.error?.type}"
-                        }
-                        diagnostics.playbackError(PlaybackEnginePath.JavaFxMediaPlayer, mediaPlayer.error?.message)
-                        failStartup()
+                        failStartup(javaFxErrorFailure(mediaPlayer.error, uri))
                     }
                     mediaPlayer.setOnEndOfMedia {
                         if (isPlayRequestCurrent(generation) && player === mediaPlayer) {
@@ -1676,9 +1774,7 @@ class DesktopAudioPlayer(
                         }
                     }
                     media.setOnError {
-                        PhoebeLog.d("DesktopAudioPlayer") { "media error: ${media.error?.message}" }
-                        diagnostics.playbackError(PlaybackEnginePath.JavaFxMediaPlayer, media.error?.message)
-                        failStartup()
+                        failStartup(javaFxErrorFailure(media.error, uri))
                     }
                     mediaPlayer.setOnPlaying {
                         if (!isPlayRequestCurrent(generation)) return@setOnPlaying
@@ -1719,15 +1815,11 @@ class DesktopAudioPlayer(
                         mediaPlayer.play()
                     }
                 }.onFailure { error ->
-                    logPlaybackFailure(error)
-                    diagnostics.playbackError(PlaybackEnginePath.JavaFxMediaPlayer, error.message)
-                    failStartup()
+                    failStartup(PlaybackFailureClassifier.fromThrowable(error, uri))
                 }
             },
             onError = { error ->
-                logPlaybackFailure(error)
-                diagnostics.playbackError(PlaybackEnginePath.JavaFxMediaPlayer, error.message)
-                failStartup()
+                failStartup(PlaybackFailureClassifier.fromThrowable(error, uri))
             },
         )
         return true
@@ -1802,10 +1894,13 @@ class DesktopAudioPlayer(
             return false
         }
         fullyBufferedPlayback = true
-        return startJavaFxPlayback(downloaded.toURI().toString(), generation) {
-            if (!trySampledFallbackAfterJavaFxFailure(downloaded, generation)) {
-                finishPlaybackFailed(generation = generation)
+        return startJavaFxPlayback(downloaded.toURI().toString(), generation) { failure ->
+            if (failure.shouldTryAlternateEngine &&
+                trySampledFallbackAfterJavaFxFailure(downloaded, generation)
+            ) {
+                return@startJavaFxPlayback
             }
+            finishPlaybackFailed(pendingPlaybackFailure ?: failure, generation)
         }
     }
 
@@ -1813,8 +1908,8 @@ class DesktopAudioPlayer(
         if (!isRemoteUri(uri) || !isPlayRequestCurrent(generation)) return false
         val response = runCatching { openRemoteAudioStream(uri) }
             .getOrElse { error ->
-                logPlaybackFailure(error)
-                diagnostics.playbackError(PlaybackEnginePath.SampledStream, error.message)
+                val failure = rememberPlaybackFailure(error, uri)
+                diagnostics.playbackError(PlaybackEnginePath.SampledStream, failure.logLine())
                 return false
             }
         val resolvedExtension = extension ?: sampledStreamingExtensionFromContentType(response.contentType)
@@ -2487,9 +2582,9 @@ class DesktopAudioPlayer(
                 }
             } catch (error: Throwable) {
                 if (isPlayRequestCurrent(generation) && sampledStream === playback && !playback.stopped.get()) {
-                    logPlaybackFailure(error)
-                    diagnostics.playbackError(PlaybackEnginePath.SampledStream, error.message)
-                    finishPlaybackFailed(generation = generation)
+                    val failure = rememberPlaybackFailure(error, sampledStreamSource?.uri)
+                    diagnostics.playbackError(PlaybackEnginePath.SampledStream, failure.logLine())
+                    finishPlaybackFailed(failure, generation)
                 }
             } finally {
                 if (sampledStream === playback) {
@@ -3376,9 +3471,22 @@ class DesktopAudioPlayer(
         else -> null
     }
 
-    private fun logPlaybackFailure(error: Throwable) {
-        val message = error.message ?: error::class.simpleName.orEmpty()
-        PhoebeLog.d("DesktopAudioPlayer") { "playback error: $message" }
+    private fun javaFxErrorFailure(error: Throwable?, uri: String): PlaybackFailure {
+        val mediaException = error as? MediaException
+        return PlaybackFailureClassifier.fromSignals(
+            texts = listOfNotNull(
+                error?.javaClass?.simpleName,
+                error?.message,
+                mediaException?.type?.name,
+                error?.cause?.javaClass?.simpleName,
+                error?.cause?.message,
+            ),
+            streamUri = uri,
+        )
+    }
+
+    private fun logPlaybackFailure(error: Throwable, streamUri: String? = currentStreamUri()) {
+        rememberPlaybackFailure(error, streamUri)
     }
 
     private companion object {


### PR DESCRIPTION
## Summary
- Classify playback start failures (unreachable server, 401/403, HTML instead of audio) instead of treating them as bad tracks.
- Hold the queue on infrastructure failures: Android retries unreachable streams once, then stops; desktop does not fall through sampled/ffmpeg/download against the same dead host.
- Log redacted stream URIs and HTTP status on Android so Sentry can show which server failed without leaking query tokens.

## Test plan
- [x] `:playback:desktopTest` for `PlaybackFailureTest`, `PlayerStateTest`, `DesktopPlaybackStartupPolicyTest`
- [x] `:playback:compileAndroidMain` and `:playback:testAndroidHostTest` for the same common tests
- [ ] On Android/Windows with the media server offline, play a queue and confirm it stays on the current track with a connection/auth message instead of skip-storming
- [ ] After the server is back, tap play and confirm the same track starts
- [ ] Confirm a genuinely unsupported local/codec failure can still try an alternate desktop engine


Made with [Cursor](https://cursor.com)