### PR TITLE
Fall back when JavaFX playback times out on desktop

### DIFF
--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackFailure.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackFailure.kt
@@ -26,11 +26,23 @@ data class PlaybackFailure(
         get() = kind == PlaybackFailureKind.Unreachable || kind == PlaybackFailureKind.Transient
 
     /**
-     * Only codec / player-creation problems are worth trying a different engine against
-     * the same URI. Connection, auth, and HTML-instead-of-audio failures will fail again.
+     * Codec / player-creation problems, and JavaFX startup watchdogs, are worth trying a
+     * different engine against the same URI. Connection, auth, and HTML-instead-of-audio
+     * failures will fail again on every engine.
+     *
+     * JavaFX "did not become ready" is not proof the music server is down: desktop JavaFX
+     * uses its own HTTP/TLS stack, which can stall on Windows while the Java HTTP client
+     * (and web playback) still reach the same stream.
      */
     val shouldTryAlternateEngine: Boolean
-        get() = kind == PlaybackFailureKind.Unsupported
+        get() = kind == PlaybackFailureKind.Unsupported || isPlayerEngineTimeout
+
+    val isPlayerEngineTimeout: Boolean
+        get() {
+            val haystack = message.lowercase()
+            return haystack.contains("did not become ready") ||
+                haystack.contains("never started playing")
+        }
 
     /** Server / network problems that must not walk the queue or retry every engine. */
     val isInfrastructureFailure: Boolean

--- a/playback/src/commonTest/kotlin/com/phoebe/app/player/PlaybackFailureTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/player/PlaybackFailureTest.kt
@@ -170,7 +170,7 @@ class PlaybackFailureTest {
     }
 
     @Test
-    fun remoteStartupTimeoutsAreUnreachableAndDoNotTryAnotherEngine() {
+    fun remoteJavaFxStartupTimeoutsFallBackToAnotherEngineWithoutSkipping() {
         val timeout = PlaybackFailureClassifier.fromMessage(
             "JavaFX media did not become ready in 3000ms",
             streamUri = "https://music.example/Audio/1/stream",
@@ -183,8 +183,23 @@ class PlaybackFailureTest {
         assertEquals(PlaybackFailureKind.Unreachable, timeout.kind)
         assertEquals(PlaybackFailureKind.Unreachable, playingTimeout.kind)
         assertTrue(timeout.holdsQueue)
-        assertFalse(timeout.shouldTryAlternateEngine)
+        assertTrue(timeout.shouldTryAlternateEngine)
+        assertTrue(playingTimeout.shouldTryAlternateEngine)
+        assertTrue(timeout.isPlayerEngineTimeout)
         assertTrue(timeout.isInfrastructureFailure)
+    }
+
+    @Test
+    fun overallPlaybackStartupWatchdogStillStopsWithoutTryingAnotherEngine() {
+        val failure = PlaybackFailureClassifier.fromMessage(
+            "Playback took too long to start.",
+            streamUri = "https://music.example/Audio/1/stream",
+        )
+
+        assertEquals(PlaybackFailureKind.Unreachable, failure.kind)
+        assertTrue(failure.holdsQueue)
+        assertFalse(failure.shouldTryAlternateEngine)
+        assertFalse(failure.isPlayerEngineTimeout)
     }
 
     @Test

--- a/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
+++ b/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
@@ -1580,10 +1580,15 @@ class DesktopAudioPlayer(
     ) {
         PhoebeLog.d("DesktopAudioPlayer") { failure.logLine() }
         diagnostics.playbackError(PlaybackEnginePath.JavaFxMediaPlayer, failure.logLine())
-        if (failure.isInfrastructureFailure) {
+        if (failure.isInfrastructureFailure && !failure.shouldTryAlternateEngine) {
             pendingPlaybackFailure = failure
             finishPlaybackFailed(failure, generation)
             return
+        }
+        if (failure.shouldTryAlternateEngine) {
+            PhoebeLog.d("DesktopAudioPlayer") {
+                "trying alternate engine after JavaFX startup failure"
+            }
         }
         if (!continuePlaybackAfterJavaFxFailure(
                 activeUri = activeUri,

--- a/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
+++ b/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
@@ -1585,6 +1585,7 @@ class DesktopAudioPlayer(
             finishPlaybackFailed(failure, generation)
             return
         }
+        disposeJavaFxBlocking()
         if (failure.shouldTryAlternateEngine) {
             PhoebeLog.d("DesktopAudioPlayer") {
                 "trying alternate engine after JavaFX startup failure"
@@ -1782,14 +1783,14 @@ class DesktopAudioPlayer(
                         failStartup(javaFxErrorFailure(media.error, uri))
                     }
                     mediaPlayer.setOnPlaying {
-                        if (!isPlayRequestCurrent(generation)) return@setOnPlaying
+                        if (startupFailed.get() || !isPlayRequestCurrent(generation)) return@setOnPlaying
                         diagnostics.playbackStartupEvent(PlaybackEnginePath.JavaFxMediaPlayer, "playing")
                         playingStarted.set(true)
                         playingWatchdogStop.set(true)
                         cancelJavaFxStartupWatchdog()
                         syncJavaFxPlayback(mediaPlayer, generation, isBuffering = false)
                         playbackExecutor.execute {
-                            if (!isPlayRequestCurrent(generation)) return@execute
+                            if (startupFailed.get() || !isPlayRequestCurrent(generation)) return@execute
                             applyVolumesFromState()
                             finishPlaybackReady(generation = generation)
                         }
@@ -1798,7 +1799,7 @@ class DesktopAudioPlayer(
                         syncJavaFxPlayback(mediaPlayer, generation, isBuffering = true)
                     }
                     mediaPlayer.setOnReady {
-                        if (!isPlayRequestCurrent(generation)) return@setOnReady
+                        if (startupFailed.get() || !isPlayRequestCurrent(generation)) return@setOnReady
                         diagnostics.playbackStartupEvent(PlaybackEnginePath.JavaFxMediaPlayer, "ready")
                         mediaReady.set(true)
                         cancelJavaFxStartupWatchdog()


### PR DESCRIPTION
## Summary
- Tonight's Sentry logs showed Windows desktop failing every remote Plex MP3 with `JavaFX media did not become ready in 3000ms`, while the same host stayed reachable over the Java HTTP client and web playback.
- #166 classified that watchdog as an unreachable server and skipped alternate engines, so desktop never fell back to HTTP download / ffmpeg.
- JavaFX startup timeouts now try another engine, but still hold the queue if the HTTP fallback also fails.

## Test plan
- [x] `./gradlew :playback:desktopTest --tests 'com.phoebe.app.player.PlaybackFailureTest'`
- [ ] On Windows desktop, play remote Plex MP3s (including skipping after a track that already started)
- [ ] Confirm web playback is unchanged
- [ ] If the music server is actually down, the queue still does not skip through every song


Made with [Cursor](https://cursor.com)