### PR TITLE
Recover playback from stale Plex relay URLs

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
@@ -82,6 +82,8 @@ import com.phoebe.app.playlists.PlaylistExportFormat
 import com.phoebe.app.player.MusicAssistantRemotePlayback
 import com.phoebe.app.player.asPlayerState
 import com.phoebe.app.player.isPlaybackActive
+import com.phoebe.app.player.playbackOriginCandidates
+import com.phoebe.app.player.withPlaybackOrigins
 import com.phoebe.app.domain.RecentSearchItem
 import com.phoebe.app.platform.MemoryPressureLevel
 import com.phoebe.app.platform.PhoebeAppLifecycle
@@ -846,7 +848,7 @@ class AppState(
                 allowWeakFallback = nativeCandidates.isEmpty(),
             ) ?: return@withContext emptyList()
             plan.tracks
-                .withFreshPlaybackUrls(session.value)
+                .withFreshPlaybackUrls(session.value, currentPlaybackOrigin())
                 .let { tracks -> if (shuffle) tracks.shuffled() else tracks }
         }
         if (additions.isEmpty()) {
@@ -2631,6 +2633,14 @@ class AppState(
         mutableDecadeMixNotice.value = null
     }
 
+    private fun currentPlaybackOrigin(): String? {
+        val server = session.value?.selectedServer ?: return null
+        return dependencies.appGraph.plexClient.mediaBaseUrl(server)
+            .trimEnd('/')
+            .ifBlank { server.uri.trimEnd('/') }
+            .takeIf { it.isNotBlank() }
+    }
+
     fun playTracks(
         tracks: List<Track>,
         index: Int = 0,
@@ -2641,7 +2651,7 @@ class AppState(
         preserveQueueContext: Boolean = false,
     ): Boolean {
         collectionMixGeneration++
-        val playbackTracks = tracks.withFreshPlaybackUrls(session.value)
+        val playbackTracks = tracks.withFreshPlaybackUrls(session.value, currentPlaybackOrigin())
         if (playbackTracks.isEmpty()) return false
         val startIndex = index.coerceIn(playbackTracks.indices)
         val track = playbackTracks[startIndex]
@@ -3962,24 +3972,41 @@ private fun PlexSession?.topTracksMixSessionSignature(): String? {
     return "$serverId:$libraryKey"
 }
 
-internal fun List<Track>.withFreshPlaybackUrls(session: PlexSession?): List<Track> {
+internal fun List<Track>.withFreshPlaybackUrls(
+    session: PlexSession?,
+    liveOrigin: String? = null,
+): List<Track> {
     if (session == null || isEmpty()) return this
     var changed = false
     val refreshed = map { track ->
-        val next = track.withFreshPlaybackUrls(session)
+        val next = track.withFreshPlaybackUrls(session, liveOrigin)
         if (next !== track) changed = true
         next
     }
     return if (changed) refreshed else this
 }
 
-internal fun Track.withFreshPlaybackUrls(session: PlexSession): Track {
-    val refreshedStreamUrl = streamUrl.withFreshPlaybackAuth(session)
-    val refreshedDownloadUrl = downloadUrl.withFreshPlaybackAuth(session)
-    if (refreshedStreamUrl == streamUrl && refreshedDownloadUrl == downloadUrl) return this
-    return copy(
+internal fun Track.withFreshPlaybackUrls(
+    session: PlexSession,
+    liveOrigin: String? = null,
+): Track {
+    val origins = playbackOriginCandidates(session.selectedServer, liveOrigin)
+    val withOrigins = if (origins.isEmpty()) this else withPlaybackOrigins(origins.first(), origins.drop(1))
+    val refreshedStreamUrl = withOrigins.streamUrl.withFreshPlaybackAuth(session)
+    val refreshedDownloadUrl = withOrigins.downloadUrl.withFreshPlaybackAuth(session)
+    val refreshedFallbacks = withOrigins.playbackFallbackUrls.map { url ->
+        url.withFreshPlaybackAuth(session)
+    }.filter { it.isNotBlank() && it != refreshedStreamUrl }.distinct()
+    if (refreshedStreamUrl == streamUrl &&
+        refreshedDownloadUrl == downloadUrl &&
+        refreshedFallbacks == playbackFallbackUrls
+    ) {
+        return this
+    }
+    return withOrigins.copy(
         streamUrl = refreshedStreamUrl,
         downloadUrl = refreshedDownloadUrl,
+        playbackFallbackUrls = refreshedFallbacks,
     )
 }
 

--- a/composeApp/src/commonTest/kotlin/com/phoebe/app/PlaybackUrlRefreshTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/phoebe/app/PlaybackUrlRefreshTest.kt
@@ -1,10 +1,12 @@
 package com.phoebe.app
 
 import com.phoebe.app.domain.MediaProviderType
+import com.phoebe.app.domain.PlexServer
 import com.phoebe.app.domain.PlexSession
 import com.phoebe.app.domain.Track
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class PlaybackUrlRefreshTest {
     @Test
@@ -25,6 +27,41 @@ class PlaybackUrlRefreshTest {
         assertEquals(
             "https://plex.example/library/parts/1/file.mp3?download=1&X-Plex-Token=fresh",
             refreshed.downloadUrl,
+        )
+    }
+
+    @Test
+    fun plexPlaybackUrlsRebaseStaleRelayHostsOntoTheLiveServerOrigin() {
+        val track = playbackTrack(
+            streamUrl = "https://23-239-17-63.abc.plex.direct:8443/library/parts/36576/file.mp3?X-Plex-Token=old",
+            downloadUrl = "https://23-239-17-63.abc.plex.direct:8443/library/parts/36576/file.mp3?download=1&X-Plex-Token=old",
+        )
+        val live = "https://45-79-210-225.abc.plex.direct:8443"
+        val session = PlexSession(
+            token = "fresh",
+            providerType = MediaProviderType.Plex,
+            selectedServer = PlexServer(
+                id = "plex",
+                name = "Plex",
+                uri = live,
+                owned = true,
+                connectionUris = listOf(live, "https://23-239-17-63.abc.plex.direct:8443"),
+                advertisedConnectionUris = listOf(live, "https://23-239-17-63.abc.plex.direct:8443"),
+            ),
+        )
+
+        val refreshed = listOf(track).withFreshPlaybackUrls(session, live).single()
+
+        assertEquals(
+            "$live/library/parts/36576/file.mp3?X-Plex-Token=fresh",
+            refreshed.streamUrl,
+        )
+        assertEquals(
+            "$live/library/parts/36576/file.mp3?download=1&X-Plex-Token=fresh",
+            refreshed.downloadUrl,
+        )
+        assertTrue(
+            refreshed.playbackFallbackUrls.any { it.contains("23-239-17-63") && it.contains("X-Plex-Token=fresh") },
         )
     }
 

--- a/domain/src/commonMain/kotlin/com/phoebe/app/domain/Models.kt
+++ b/domain/src/commonMain/kotlin/com/phoebe/app/domain/Models.kt
@@ -535,6 +535,11 @@ data class Track(
     val artistSort: String? = null,
     val albumSort: String? = null,
     val radioNowPlayingSource: RadioNowPlayingSource? = null,
+    /**
+     * Alternate stream origins to try when the primary URL times out or the music-server
+     * connection used at catalog time is no longer reachable. Ephemeral; not persisted.
+     */
+    val playbackFallbackUrls: List<String> = emptyList(),
 )
 
 fun List<Track>.mergeDownloadCopiesById(): List<Track> {

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAudioPlayer.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAudioPlayer.kt
@@ -1501,40 +1501,54 @@ class AndroidAudioPlayer(
         } else {
             MaxStreamRetryCount
         }
-        if (retryCount >= maxRetries) {
-            PhoebeLog.d("AndroidAudioPlayer") { "stream retry exhausted kind=${failure.kind}" }
-            holdQueueOnFailure(failure)
-            publishPlaybackFailure(failure, generation)
+        if (retryCount < maxRetries) {
+            retryCount++
+            retryCurrentStream(generation)
             return
         }
-        retryCount++
-        retryCurrentStream(generation)
+        if (replayWithFailoverUri(generation, failure.streamUri ?: currentStreamUri())) {
+            retryCount = 0
+            return
+        }
+        PhoebeLog.d("AndroidAudioPlayer") { "stream retry exhausted kind=${failure.kind}" }
+        holdQueueOnFailure(failure)
+        publishPlaybackFailure(failure, generation)
     }
 
     private fun retryCurrentStream(generation: Int) {
         retryJob?.cancel()
         val delayMs = StreamRetryBaseDelayMs * retryCount
         retryJob = scope.launch {
-            val player = activeLocalPlayer() ?: return@launch
-            val positionMs = player.currentPosition.coerceAtLeast(0L)
+            delay(delayMs)
+            if (!isPlayRequestCurrent(generation) || !playWhenReady) return@launch
+            val uri = currentStreamUri() ?: return@launch
+            val positionMs = controllerMutex.withLock {
+                activeLocalPlayer()?.currentPosition?.coerceAtLeast(0L) ?: 0L
+            }
             applyPlatformPlayback(
                 positionMs = positionMs,
-                durationMs = player.duration.coerceAtLeast(0L),
+                durationMs = state.value.durationMs,
                 isPlaying = false,
                 isBuffering = true,
-                bufferedPositionMs = player.bufferedPosition.coerceAtLeast(positionMs).coerceAtLeast(0L),
+                bufferedPositionMs = state.value.bufferedPositionMs.coerceAtLeast(positionMs),
                 generation = generation,
                 forceBuffering = true,
             )
-            delay(delayMs)
-            if (!isPlayRequestCurrent(generation) || !playWhenReady) return@launch
+            stopBufferingTimeout()
             controllerMutex.withLock {
                 val retryPlayer = activeLocalPlayer() ?: return@withLock
-                retryPlayer.seekTo(positionMs)
+                val track = state.value.currentTrack
+                val mediaItem = if (track != null) {
+                    playbackMediaItem(track.copy(streamUrl = uri), inAppPlayback = true)
+                } else {
+                    MediaItem.Builder().setUri(uri).build()
+                }
+                retryPlayer.setMediaItem(mediaItem, positionMs)
                 retryPlayer.prepare()
                 markPendingAutoplay(generation)
                 retryPlayer.play()
             }
+            startBufferingTimeout(generation)
             syncFromController(generation)
         }
     }

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAudioPlayer.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAudioPlayer.kt
@@ -270,9 +270,17 @@ class AndroidAudioPlayer(
         startIndex: Int,
         track: Track,
         generation: Int,
+        startPositionMs: Long,
     ) {
         runPlatformLoad(generation) { player ->
-            loadQueueOnPlayer(player, queue, startIndex.coerceIn(queue.indices), queue.map { it.id }, generation)
+            loadQueueOnPlayer(
+                player = player,
+                queue = queue,
+                targetIndex = startIndex.coerceIn(queue.indices),
+                queueIds = queue.map { it.id },
+                generation = generation,
+                startPositionMs = startPositionMs.coerceAtLeast(0L),
+            )
         }
     }
 

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidPlaybackDiagnostics.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidPlaybackDiagnostics.kt
@@ -13,11 +13,14 @@ import androidx.media3.common.audio.AudioProcessor
 import androidx.media3.common.audio.BaseAudioProcessor
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.common.util.Util
+import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.audio.AudioSink
 import androidx.media3.exoplayer.audio.DefaultAudioSink
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import com.phoebe.app.domain.EqualizerProfile
 import com.phoebe.app.platform.PhoebeAppLifecycle
 import java.nio.ByteBuffer
@@ -33,6 +36,10 @@ internal object AndroidPlaybackDiagnostics {
         engine: PlaybackEnginePath,
     ): ExoPlayer.Builder {
         diagnostics.engineSelected(engine)
+        val httpDataSourceFactory = DefaultHttpDataSource.Factory()
+            .setAllowCrossProtocolRedirects(true)
+            .setConnectTimeoutMs(15_000)
+            .setReadTimeoutMs(20_000)
         return ExoPlayer.Builder(
             context,
             PhoebeRenderersFactory(
@@ -40,6 +47,8 @@ internal object AndroidPlaybackDiagnostics {
                 diagnostics = diagnostics,
                 engine = engine,
             ),
+        ).setMediaSourceFactory(
+            DefaultMediaSourceFactory(DefaultDataSource.Factory(context, httpDataSourceFactory)),
         ).setLoadControl(
             PhoebeLoadControlConfig.create(
                 engine = engine,

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackUrlOrigins.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackUrlOrigins.kt
@@ -1,0 +1,118 @@
+package com.phoebe.app.player
+
+import com.phoebe.app.data.reachableBaseUris
+import com.phoebe.app.domain.PlexServer
+import com.phoebe.app.domain.Track
+import io.ktor.http.Url
+
+private const val MaxPlaybackFallbackOrigins = 8
+
+internal fun isMusicServerStreamUrl(url: String): Boolean {
+    if (url.isBlank()) return false
+    val parsed = runCatching { Url(url) }.getOrNull() ?: return false
+    if (parsed.protocol.name != "http" && parsed.protocol.name != "https") return false
+    if (parsed.host.endsWith(".plex.direct", ignoreCase = true)) return true
+    val path = parsed.encodedPath.lowercase()
+    return path.contains("/library/parts/") ||
+        path.contains("/library/metadata/") ||
+        path.contains("/music/:/transcode/") ||
+        (path.contains("/audio/") && path.contains("/stream")) ||
+        path.contains("/rest/stream") ||
+        path.contains("/rest/download")
+}
+
+internal fun rebaseHttpUrlOrigin(url: String, origin: String): String? {
+    if (url.isBlank() || origin.isBlank()) return null
+    val parsed = runCatching { Url(url) }.getOrNull() ?: return null
+    if (parsed.protocol.name != "http" && parsed.protocol.name != "https") return null
+    val originTrimmed = origin.trimEnd('/')
+    val originParsed = runCatching { Url(originTrimmed) }.getOrNull() ?: return null
+    if (originParsed.host.isBlank()) return null
+    if (parsed.protocol.name == originParsed.protocol.name &&
+        parsed.host.equals(originParsed.host, ignoreCase = true) &&
+        parsed.port == originParsed.port
+    ) {
+        return url
+    }
+    val path = parsed.encodedPath.ifBlank { "/" }
+    val query = if ('?' in url) {
+        url.substringAfter('?').substringBefore('#')
+    } else {
+        ""
+    }
+    val fragment = if ('#' in url) url.substringAfter('#') else ""
+    return buildString {
+        append(originTrimmed)
+        if (!path.startsWith('/')) append('/')
+        append(path)
+        if (query.isNotEmpty()) {
+            append('?')
+            append(query)
+        }
+        if (fragment.isNotEmpty()) {
+            append('#')
+            append(fragment)
+        }
+    }
+}
+
+fun playbackOriginCandidates(
+    server: PlexServer?,
+    preferredOrigin: String? = null,
+): List<String> {
+    val preferred = preferredOrigin?.trimEnd('/')?.takeIf { it.isNotBlank() }
+        ?: server?.uri?.trimEnd('/')?.takeIf { it.isNotBlank() }
+    val fromServer = server?.reachableBaseUris(preferred).orEmpty().map { it.trimEnd('/') }
+    return (listOfNotNull(preferred) + fromServer)
+        .filter { it.isNotBlank() }
+        .distinct()
+}
+
+internal fun playbackUrlsForOrigins(url: String, origins: List<String>): List<String> {
+    if (url.isBlank() || !isMusicServerStreamUrl(url)) return listOf(url)
+    val rebased = origins
+        .asSequence()
+        .mapNotNull { origin -> rebaseHttpUrlOrigin(url, origin) }
+        .distinct()
+        .take(MaxPlaybackFallbackOrigins + 1)
+        .toList()
+    return rebased.ifEmpty { listOf(url) }
+}
+
+internal fun Track.playbackUriCandidates(): List<String> {
+    localUri?.takeIf { it.isNotBlank() }?.let { return listOf(it) }
+    val primary = streamUrl.takeIf { it.isNotBlank() }
+    return (listOfNotNull(primary) + playbackFallbackUrls)
+        .filter { it.isNotBlank() }
+        .distinct()
+}
+
+fun Track.withPlaybackOrigins(
+    preferredOrigin: String?,
+    fallbackOrigins: List<String> = emptyList(),
+): Track {
+    if (id.startsWith("radio:")) return this
+    if (!localUri.isNullOrBlank()) return this
+    val origins = (listOfNotNull(preferredOrigin?.trimEnd('/')?.takeIf { it.isNotBlank() }) + fallbackOrigins)
+        .map { it.trimEnd('/') }
+        .filter { it.isNotBlank() }
+        .distinct()
+    if (origins.isEmpty()) return this
+    val streamCandidates = playbackUrlsForOrigins(streamUrl, origins)
+    val downloadCandidates = if (downloadUrl.isNotBlank() && isMusicServerStreamUrl(downloadUrl)) {
+        playbackUrlsForOrigins(downloadUrl, origins)
+    } else {
+        listOf(downloadUrl)
+    }
+    val nextStream = streamCandidates.firstOrNull().orEmpty()
+    val nextDownload = downloadCandidates.firstOrNull().orEmpty()
+    val nextFallbacks = streamCandidates.drop(1)
+    if (nextStream == streamUrl && nextDownload == downloadUrl && nextFallbacks == playbackFallbackUrls) {
+        return this
+    }
+    return copy(
+        streamUrl = nextStream.ifBlank { streamUrl },
+        downloadUrl = nextDownload.ifBlank { downloadUrl },
+        playbackFallbackUrls = nextFallbacks,
+    )
+}

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
@@ -7,6 +7,7 @@ import com.phoebe.app.domain.EqualizerProfile
 import com.phoebe.app.domain.PlayerState
 import com.phoebe.app.domain.RepeatMode
 import com.phoebe.app.domain.Track
+import com.phoebe.app.platform.PhoebeLog
 import com.phoebe.app.platform.currentTimeMs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -42,6 +43,8 @@ abstract class SimpleAudioPlayer(
     private var preferUnityOutputVolume = false
     private var systemVolumeScale = 1f
     private var playGeneration = 0
+    private var failoverGeneration = -1
+    private val triedPlaybackUris = linkedSetOf<String>()
     private var crossfadeDurationMs = 0L
     private var crossfadeRequestKey: String? = null
     private var manualSeekCrossfadeSuppression: ManualSeekCrossfadeSuppression? = null
@@ -124,6 +127,8 @@ abstract class SimpleAudioPlayer(
         )
         setOutputVolume(effectiveOutputVolume())
         if (track != null) {
+            resetPlaybackUriFailover(generation)
+            track.playbackUriCandidates().firstOrNull()?.let { notePlaybackUri(it, generation) }
             startPlaybackStartupWatchdog(generation)
             if (sameQueue) {
                 skipToInQueueOnPlatform(queue, index, track, generation)
@@ -806,9 +811,61 @@ abstract class SimpleAudioPlayer(
         val track = mutableState.value.currentTrack
         val streamUri = track?.localUri?.takeIf { it.isNotBlank() }
             ?: track?.streamUrl?.takeIf { it.isNotBlank() }
+        if (replayWithFailoverUri(generation, streamUri)) return
         publishPlaybackFailure(
             PlaybackFailureClassifier.fromMessage("Playback took too long to start.", streamUri),
             generation,
+        )
+    }
+
+    protected fun resetPlaybackUriFailover(generation: Int) {
+        failoverGeneration = generation
+        triedPlaybackUris.clear()
+    }
+
+    protected fun notePlaybackUri(uri: String, generation: Int) {
+        if (failoverGeneration != generation) {
+            resetPlaybackUriFailover(generation)
+        }
+        if (uri.isNotBlank()) triedPlaybackUris += uri
+    }
+
+    protected fun nextPlaybackFailoverUri(generation: Int, failedUri: String?): String? {
+        notePlaybackUri(failedUri.orEmpty(), generation)
+        val track = mutableState.value.currentTrack ?: return null
+        return track.playbackUriCandidates().firstOrNull { candidate ->
+            candidate.isNotBlank() && candidate !in triedPlaybackUris
+        }
+    }
+
+    protected fun replayWithFailoverUri(generation: Int, failedUri: String?): Boolean {
+        if (!isPlayRequestCurrent(generation) || !playWhenReady) return false
+        val next = nextPlaybackFailoverUri(generation, failedUri) ?: return false
+        notePlaybackUri(next, generation)
+        adoptFailoverStreamUrl(next)
+        val current = mutableState.value
+        val track = current.currentTrack ?: return false
+        val index = current.currentIndex.takeIf { it in current.queue.indices } ?: return false
+        mutableState.value = current.copy(
+            isBuffering = true,
+            isPlaying = false,
+            playbackErrorMessage = null,
+        )
+        PhoebeLog.d("AudioPlayer") { "playback failover uri=$next" }
+        startPlaybackStartupWatchdog(generation)
+        playQueueOnPlatform(mutableState.value.queue, index, track.copy(streamUrl = next), generation)
+        return true
+    }
+
+    private fun adoptFailoverStreamUrl(uri: String) {
+        val current = mutableState.value
+        val index = current.currentIndex
+        val track = current.queue.getOrNull(index) ?: return
+        if (track.streamUrl == uri) return
+        mutableState.value = current.copy(
+            queue = current.queue.mapIndexed { itemIndex, item ->
+                if (itemIndex == index) item.copy(streamUrl = uri) else item
+            },
         )
     }
 

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
@@ -656,8 +656,10 @@ abstract class SimpleAudioPlayer(
         startIndex: Int,
         track: Track,
         generation: Int = activePlayGeneration,
+        startPositionMs: Long = 0L,
     ) {
         playTrack(track)
+        if (startPositionMs > 0L) seek(startPositionMs)
     }
 
     private fun tracksMatch(left: List<Track>, right: List<Track>): Boolean {
@@ -846,14 +848,22 @@ abstract class SimpleAudioPlayer(
         val current = mutableState.value
         val track = current.currentTrack ?: return false
         val index = current.currentIndex.takeIf { it in current.queue.indices } ?: return false
+        val resumePositionMs = current.positionMs.coerceAtLeast(0L)
         mutableState.value = current.copy(
             isBuffering = true,
             isPlaying = false,
+            positionMs = resumePositionMs,
             playbackErrorMessage = null,
         )
-        PhoebeLog.d("AudioPlayer") { "playback failover uri=$next" }
+        PhoebeLog.d("AudioPlayer") { "playback failover uri=$next positionMs=$resumePositionMs" }
         startPlaybackStartupWatchdog(generation)
-        playQueueOnPlatform(mutableState.value.queue, index, track.copy(streamUrl = next), generation)
+        playQueueOnPlatform(
+            queue = mutableState.value.queue,
+            startIndex = index,
+            track = track.copy(streamUrl = next),
+            generation = generation,
+            startPositionMs = resumePositionMs,
+        )
         return true
     }
 

--- a/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
@@ -1050,7 +1050,13 @@ private open class SlowTestPlayer(
 
     fun playIntentActive(): Boolean = playWhenReady
 
-    override fun playQueueOnPlatform(queue: List<Track>, startIndex: Int, track: Track, generation: Int) {
+    override fun playQueueOnPlatform(
+        queue: List<Track>,
+        startIndex: Int,
+        track: Track,
+        generation: Int,
+        startPositionMs: Long,
+    ) {
         pendingLoads += generation
     }
 
@@ -1086,7 +1092,13 @@ private class QueueAwareTestPlayer : SimpleAudioPlayer() {
 
     override fun playUri(uri: String) = Unit
 
-    override fun playQueueOnPlatform(queue: List<Track>, startIndex: Int, track: Track, generation: Int) {
+    override fun playQueueOnPlatform(
+        queue: List<Track>,
+        startIndex: Int,
+        track: Track,
+        generation: Int,
+        startPositionMs: Long,
+    ) {
         fullLoads++
     }
 
@@ -1120,7 +1132,13 @@ private class EndedReplayTestPlayer : SimpleAudioPlayer() {
 
     override fun playUri(uri: String) = Unit
 
-    override fun playQueueOnPlatform(queue: List<Track>, startIndex: Int, track: Track, generation: Int) {
+    override fun playQueueOnPlatform(
+        queue: List<Track>,
+        startIndex: Int,
+        track: Track,
+        generation: Int,
+        startPositionMs: Long,
+    ) {
         fullLoads++
         markPlaybackReady(generation = generation)
     }
@@ -1160,7 +1178,13 @@ private class PositionTrackingTestPlayer : SimpleAudioPlayer() {
         markPlaybackReady(generation = generation)
     }
 
-    override fun playQueueOnPlatform(queue: List<Track>, startIndex: Int, track: Track, generation: Int) {
+    override fun playQueueOnPlatform(
+        queue: List<Track>,
+        startIndex: Int,
+        track: Track,
+        generation: Int,
+        startPositionMs: Long,
+    ) {
         lastSeekPositionMs = 0L
         markPlaybackReady(generation = generation)
     }

--- a/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -99,6 +100,37 @@ class PlayerStateTest {
             player.state.value.playbackErrorMessage,
         )
         assertFalse(player.playIntentActive())
+    }
+
+    @Test
+    fun stalledPlatformStartupFailsoverToTheNextStreamOrigin() = runTest {
+        val player = TimeoutTestPlayer(this)
+        val liveUri = "https://live.example/library/parts/1/file.mp3"
+        val tracks = listOf(
+            Track(
+                id = "t1",
+                title = "One",
+                artist = "Artist",
+                album = "Album",
+                durationMs = 60_000,
+                streamUrl = "https://dead.example/library/parts/1/file.mp3",
+                downloadUrl = "",
+                playbackFallbackUrls = listOf(liveUri),
+            ),
+        )
+
+        player.play(tracks, 0)
+        advanceTimeBy(player.testStartupTimeoutMs + 1L)
+        runCurrent()
+
+        assertEquals(liveUri, player.state.value.currentTrack?.streamUrl)
+        assertEquals(0, player.state.value.playbackErrorSerial)
+        assertTrue(player.state.value.isBuffering)
+
+        player.finishPendingLoad()
+
+        assertTrue(player.state.value.isPlaying)
+        assertNull(player.state.value.playbackErrorMessage)
     }
 
     @Test

--- a/playback/src/commonTest/kotlin/com/phoebe/app/player/PlaybackUrlOriginsTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/player/PlaybackUrlOriginsTest.kt
@@ -1,0 +1,123 @@
+package com.phoebe.app.player
+
+import com.phoebe.app.domain.PlexServer
+import com.phoebe.app.domain.Track
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PlaybackUrlOriginsTest {
+    @Test
+    fun rebasesStalePlexDirectPartUrlOntoTheLiveRelay() {
+        val stale =
+            "https://23-239-17-63.95629f759c4c47eaaf42abf3d9725767.plex.direct:8443/library/parts/36576/1780447465/file.mp3?X-Plex-Token=old"
+        val live = "https://45-79-210-225.95629f759c4c47eaaf42abf3d9725767.plex.direct:8443"
+
+        assertEquals(
+            "https://45-79-210-225.95629f759c4c47eaaf42abf3d9725767.plex.direct:8443/library/parts/36576/1780447465/file.mp3?X-Plex-Token=old",
+            rebaseHttpUrlOrigin(stale, live),
+        )
+    }
+
+    @Test
+    fun plexPartUrlsAreTreatedAsMusicServerStreamsEvenWhenTheRelayRotated() {
+        assertTrue(
+            isMusicServerStreamUrl(
+                "https://23-239-17-63.abc.plex.direct:8443/library/parts/36576/file.mp3?X-Plex-Token=old",
+            ),
+        )
+        assertFalse(isMusicServerStreamUrl("https://kexp.streamguys1.com/kexp128.mp3"))
+        assertFalse(isMusicServerStreamUrl("file:///music/song.mp3"))
+    }
+
+    @Test
+    fun playbackUrlsForOriginsPutTheLiveHostFirstAndKeepOtherRelaysAsFallbacks() {
+        val stale =
+            "https://23-239-17-63.abc.plex.direct:8443/library/parts/1/file.mp3?X-Plex-Token=token"
+        val urls = playbackUrlsForOrigins(
+            stale,
+            listOf(
+                "https://45-79-210-225.abc.plex.direct:8443",
+                "https://23-239-17-63.abc.plex.direct:8443",
+                "http://192.168.1.9:32400",
+            ),
+        )
+
+        assertEquals(
+            "https://45-79-210-225.abc.plex.direct:8443/library/parts/1/file.mp3?X-Plex-Token=token",
+            urls.first(),
+        )
+        assertTrue(urls.any { it.startsWith("http://192.168.1.9:32400/library/parts/1/file.mp3") })
+        assertTrue(urls.any { it.startsWith("https://23-239-17-63.abc.plex.direct:8443/library/parts/1/file.mp3") })
+    }
+
+    @Test
+    fun trackWithPlaybackOriginsRewritesThePrimaryUrlAndStashesFallbacks() {
+        val track = Track(
+            id = "54588",
+            title = "Souvenir",
+            artist = "Artist",
+            album = "Album",
+            durationMs = 180_000,
+            streamUrl = "https://23-239-17-63.abc.plex.direct:8443/library/parts/36576/file.mp3?X-Plex-Token=old",
+            downloadUrl = "https://23-239-17-63.abc.plex.direct:8443/library/parts/36576/file.mp3?X-Plex-Token=old&download=1",
+        )
+        val server = PlexServer(
+            id = "plex",
+            name = "Plex",
+            uri = "https://23-239-17-63.abc.plex.direct:8443",
+            owned = true,
+            connectionUris = listOf(
+                "https://45-79-210-225.abc.plex.direct:8443",
+                "https://23-239-17-63.abc.plex.direct:8443",
+            ),
+            advertisedConnectionUris = listOf(
+                "https://45-79-210-225.abc.plex.direct:8443",
+                "https://23-239-17-63.abc.plex.direct:8443",
+            ),
+        )
+        val origins = playbackOriginCandidates(
+            server = server,
+            preferredOrigin = "https://45-79-210-225.abc.plex.direct:8443",
+        )
+        val refreshed = track.withPlaybackOrigins(origins.first(), origins.drop(1))
+
+        assertEquals(
+            "https://45-79-210-225.abc.plex.direct:8443/library/parts/36576/file.mp3?X-Plex-Token=old",
+            refreshed.streamUrl,
+        )
+        assertTrue(refreshed.playbackFallbackUrls.any { it.contains("23-239-17-63") })
+        assertEquals(
+            listOf(refreshed.streamUrl) + refreshed.playbackFallbackUrls,
+            refreshed.playbackUriCandidates(),
+        )
+    }
+
+    @Test
+    fun radioAndLocalTracksAreNotRebasedOntoTheMusicServer() {
+        val radio = Track(
+            id = "radio:kexp",
+            title = "KEXP",
+            artist = "Radio",
+            album = "Radio",
+            durationMs = 0,
+            streamUrl = "https://kexp.streamguys1.com/kexp128.mp3",
+            downloadUrl = "",
+        )
+        val local = Track(
+            id = "local:1",
+            title = "Local",
+            artist = "Artist",
+            album = "Album",
+            durationMs = 1_000,
+            streamUrl = "https://23-239-17-63.abc.plex.direct:8443/library/parts/1/file.mp3",
+            downloadUrl = "",
+            localUri = "file:///music/song.mp3",
+        )
+
+        assertEquals(radio, radio.withPlaybackOrigins("https://plex.example:32400"))
+        assertEquals(local, local.withPlaybackOrigins("https://plex.example:32400"))
+        assertEquals(listOf("file:///music/song.mp3"), local.playbackUriCandidates())
+    }
+}

--- a/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
+++ b/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
@@ -273,11 +273,13 @@ class DesktopAudioPlayer(
         startIndex: Int,
         track: Track,
         generation: Int,
+        startPositionMs: Long,
     ) {
         playTrack(
             track = track,
             preferJavaFxForLocalStreaming = shouldPreferJavaFxForCrossfade(queue, startIndex, track),
         )
+        if (startPositionMs > 0L) seek(startPositionMs)
         scheduleCrossfadePrefetchAfterLoad(queue, startIndex, generation)
     }
 

--- a/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
+++ b/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
@@ -1535,6 +1535,10 @@ class DesktopAudioPlayer(
     }
 
     private fun finishPlaybackFailed(failure: PlaybackFailure, generation: Int = activePlayGeneration) {
+        if (failure.shouldRetry && replayWithFailoverUri(generation, failure.streamUri ?: currentStreamUri())) {
+            pendingPlaybackFailure = null
+            return
+        }
         DesktopInlineRadioMapCoordinator.endLiveRadioStartup()
         reloadOnResume = failure.holdsQueue
         publishPlaybackFailure(failure, generation)

--- a/playback/src/iosMain/kotlin/com/phoebe/app/player/IosAudioPlayer.kt
+++ b/playback/src/iosMain/kotlin/com/phoebe/app/player/IosAudioPlayer.kt
@@ -686,6 +686,7 @@ private class IosAudioPlayer(
             retryCount = 0
         }
         if (retryCount >= MaxStreamRetryCount) {
+            if (replayWithFailoverUri(generation, currentUri)) return
             markPlaybackFailed(generation)
             return
         }

--- a/playback/src/wasmJsMain/kotlin/com/phoebe/app/player/WebAudioPlayer.kt
+++ b/playback/src/wasmJsMain/kotlin/com/phoebe/app/player/WebAudioPlayer.kt
@@ -78,6 +78,7 @@ private class WebAudioPlayer(
     }
 
     override fun onPlaybackStartupTimedOut(generation: Int) {
+        if (replayWithFailoverUri(generation, currentUri ?: state.value.currentTrack?.streamUrl)) return
         if (isPlayRequestCurrent(generation) && state.value.isBuffering &&
             shouldSkipToNextWebTrackAfterFailure(generation)
         ) {
@@ -1174,6 +1175,7 @@ private class WebAudioPlayer(
             retryCount = 0
         }
         if (retryCount >= MaxStreamRetryCount) {
+            if (replayWithFailoverUri(generation, currentUri)) return
             failOrAdvanceWebPlayback(generation)
             return
         }


### PR DESCRIPTION
## Summary
- Sentry at 3:38pm CT on Pixel 10 Pro showed `playback timed out while buffering` then `stream retry exhausted kind=Unreachable` for a Plex part URL on dead relay `23-239-17-63.*.plex.direct`, while timeline reports were already succeeding on live relay `45-79-210-225.*.plex.direct`. The song itself was fine; Phoebe kept retrying the catalog-baked host and then held the queue.
- Rebase Plex/Jellyfin/Navidrome stream URLs onto the current reachable server origin at play time, stash remaining connections as failover URLs, and retry those origins after a buffering/unreachable failure on Android, desktop, web, and iOS.
- Android Media3 now follows cross-protocol HTTP redirects (the Emby `302` stalls in the same Sentry window) and reloads the media item instead of seeking on a hung buffer.

## Test plan
- [x] `./gradlew :playback:desktopTest --tests PlaybackUrlOriginsTest --tests PlayerStateTest --tests PlaybackFailureTest`
- [x] `./gradlew :composeApp:desktopTest --tests PlaybackUrlRefreshTest`
- [x] `./gradlew :playback:compileAndroidMain :playback:compileKotlinWasmJs :playback:compileKotlinIosSimulatorArm64`
- [ ] Play a Plex track on Android after remote-access relay rotation; first attempt should use the live `mediaBaseUrl`, and a forced dead host should fail over instead of freezing Now Playing.
- [ ] Confirm Emby/Jellyfin http→https stream redirects start instead of retrying `status=302`.


Made with [Cursor](https://cursor.com)