### PR TITLE
Stop Chromecast dual-play after failed queue loads

### DIFF
--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidCastController.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidCastController.kt
@@ -67,12 +67,17 @@ private class AndroidCastController : CastController {
     private val castContext: CastContext? get() = runCatching { CastContext.getSharedInstance(appContext) }.getOrNull()
     private var positionJob: Job? = null
     private var loadTimeoutJob: Job? = null
+    private var reconnectJob: Job? = null
     private var audioPlayer: AudioPlayer? = null
     private var sessionListenerRegistered = false
     private var pendingHandoff: PendingCastHandoff? = null
     private var expectedRemoteHandoff: PendingCastHandoff? = null
     private var appQueueSnapshot: AppQueueSnapshot? = null
     private var loadRequestId = 0L
+    private var lastLoadReceiverQueueSize = 0
+    private var mediaErrorRetryCount = 0
+    private var endingSessionIntentionally = false
+    private var lastLoggedRemoteState: String? = null
 
     private val mutableState = MutableStateFlow(
         CastState(
@@ -99,28 +104,55 @@ private class AndroidCastController : CastController {
     }
 
     private val sessionListener = object : SessionManagerListener<CastSession> {
-        override fun onSessionStarted(session: CastSession, sessionId: String) =
+        override fun onSessionStarted(session: CastSession, sessionId: String) {
+            PhoebeLog.d(TAG) { "session started id=$sessionId device=${session.castDevice?.friendlyName}" }
             connect(session, castLocalQueueIfReceiverEmpty = true)
-
-        override fun onSessionResumed(session: CastSession, wasSuspended: Boolean) =
-            connect(session, castLocalQueueIfReceiverEmpty = false)
-
-        override fun onSessionEnded(session: CastSession, error: Int) = disconnectState()
-        override fun onSessionSuspended(session: CastSession, reason: Int) {
-            mutableState.update { it.copy(isBuffering = true) }
         }
 
-        override fun onSessionResumeFailed(session: CastSession, error: Int) = disconnectState()
+        override fun onSessionResumed(session: CastSession, wasSuspended: Boolean) {
+            PhoebeLog.d(TAG) { "session resumed wasSuspended=$wasSuspended device=${session.castDevice?.friendlyName}" }
+            connect(session, castLocalQueueIfReceiverEmpty = false)
+        }
+
+        override fun onSessionEnded(session: CastSession, error: Int) {
+            val reason = if (endingSessionIntentionally) {
+                CastSessionDisconnectReason.UserRequested
+            } else {
+                CastSessionDisconnectReason.Unexpected
+            }
+            endingSessionIntentionally = false
+            PhoebeLog.d(TAG) { "session ended error=$error reason=$reason device=${session.castDevice?.friendlyName}" }
+            disconnectState(reason)
+        }
+
+        override fun onSessionSuspended(session: CastSession, reason: Int) {
+            PhoebeLog.d(TAG) { "session suspended reason=$reason device=${session.castDevice?.friendlyName}" }
+            suspendLocalPlayback()
+            mutableState.update { it.copy(isBuffering = true, message = "Chromecast connection interrupted...") }
+        }
+
+        override fun onSessionResumeFailed(session: CastSession, error: Int) {
+            PhoebeLog.d(TAG) { "session resume failed error=$error" }
+            disconnectState(CastSessionDisconnectReason.Unexpected)
+        }
+
         override fun onSessionStarting(session: CastSession) {
+            PhoebeLog.d(TAG) { "session starting" }
             mutableState.update { it.copy(isAvailable = true, isBuffering = true, message = null) }
         }
 
         override fun onSessionStartFailed(session: CastSession, error: Int) {
+            PhoebeLog.d(TAG) { "session start failed error=$error" }
             mutableState.update { it.copy(isBuffering = false, message = "Couldn't start Chromecast session.") }
         }
 
-        override fun onSessionEnding(session: CastSession) = Unit
-        override fun onSessionResuming(session: CastSession, sessionId: String) = Unit
+        override fun onSessionEnding(session: CastSession) {
+            PhoebeLog.d(TAG) { "session ending intentional=$endingSessionIntentionally" }
+        }
+
+        override fun onSessionResuming(session: CastSession, sessionId: String) {
+            PhoebeLog.d(TAG) { "session resuming id=$sessionId" }
+        }
     }
 
     init {
@@ -156,15 +188,24 @@ private class AndroidCastController : CastController {
     }
 
     override fun disconnect() {
+        endingSessionIntentionally = true
+        reconnectJob?.cancel()
+        reconnectJob = null
+        PhoebeLog.d(TAG) { "user requested disconnect device=${mutableState.value.deviceName}" }
         castContext?.sessionManager?.endCurrentSession(true)
-        disconnectState()
+        disconnectState(CastSessionDisconnectReason.UserRequested)
     }
 
     override fun loadQueue(queue: List<Track>, startIndex: Int, startPositionMs: Long) {
         loadQueueInternal(queue, startIndex, startPositionMs = startPositionMs)
     }
 
-    private fun loadQueueInternal(queue: List<Track>, startIndex: Int, startPositionMs: Long) {
+    private fun loadQueueInternal(
+        queue: List<Track>,
+        startIndex: Int,
+        startPositionMs: Long = 0L,
+        maxReceiverItems: Int = CAST_MAX_RECEIVER_QUEUE_ITEMS,
+    ) {
         val support = canLoadQueue(queue)
         if (!support.isSupported) {
             mutableState.update { it.copy(message = support.message) }
@@ -183,6 +224,7 @@ private class AndroidCastController : CastController {
         val localState = audioPlayer?.state?.value
         val servicePlaying = AndroidPlaybackBridge.isServicePlaybackActive()
         val wasLocalPlaying = localState?.isPlaying == true || servicePlaying
+        suspendLocalPlayback()
         loadRequestId++
         val requestId = loadRequestId
         rememberAppQueue(queue, index)
@@ -209,15 +251,16 @@ private class AndroidCastController : CastController {
                 message = null,
             )
         }
-        val loadRequest = buildCastLoadRequest(queue, index, positionMs)
-        PhoebeLog.d("AndroidCastController") {
-            "loading cast queue receiverItems=${loadRequest.receiverQueueSize}/${queue.size} bytes=${loadRequest.estimatedBytes}"
+        val loadRequest = buildCastLoadRequest(queue, index, positionMs, maxItems = maxReceiverItems)
+        lastLoadReceiverQueueSize = loadRequest.receiverQueueSize
+        PhoebeLog.d(TAG) {
+            "loading cast queue startId=${track.id} codec=${track.audioCodec} startIndex=$index receiverItems=${loadRequest.receiverQueueSize}/${queue.size} bytes=${loadRequest.estimatedBytes} budget=$CAST_LOAD_MESSAGE_BYTE_BUDGET requestId=$requestId"
         }
         val pendingResult = runCatching {
             client.load(loadRequest.requestData)
         }.getOrElse { error ->
-            PhoebeLog.d("AndroidCastController") { "cast load request rejected: ${error.message}" }
-            onCastLoadFailed(requestId, "Couldn't load this playlist on Chromecast. Playing on this device.")
+            PhoebeLog.d(TAG) { "cast load request rejected: ${error.message}" }
+            onCastLoadFailed(requestId, "Couldn't load this playlist on Chromecast.")
             return
         }
         pendingResult.setResultCallback(
@@ -278,18 +321,44 @@ private class AndroidCastController : CastController {
     }
 
     override fun next() {
-        val current = mutableState.value
-        val target = current.currentIndex + 1
-        if (target in current.queue.indices) {
-            loadQueue(current.queue, target)
-        }
+        skipTo(mutableState.value.currentIndex + 1)
     }
 
     override fun previous() {
+        skipTo((mutableState.value.currentIndex - 1).coerceAtLeast(0))
+    }
+
+    private fun skipTo(targetIndex: Int) {
         val current = mutableState.value
-        val target = (current.currentIndex - 1).coerceAtLeast(0)
-        if (target in current.queue.indices) {
-            loadQueue(current.queue, target)
+        val decision = decideCastSkipAction(
+            targetIndex = targetIndex,
+            queueSize = current.queue.size,
+            targetAlreadyOnReceiver = receiverQueueItem(current.queue.getOrNull(targetIndex)) != null,
+        )
+        PhoebeLog.d(TAG) {
+            "skip to=$targetIndex from=${current.currentIndex} decision=$decision connected=${current.isConnected}"
+        }
+        when (decision) {
+            CastSkipDecision.None -> Unit
+            CastSkipDecision.AdvanceReceiverQueue -> {
+                val target = current.queue[targetIndex]
+                rememberAppQueue(current.queue, targetIndex)
+                mutableState.update {
+                    it.copy(
+                        currentIndex = targetIndex,
+                        isPlaying = true,
+                        isBuffering = true,
+                        positionMs = 0L,
+                        durationMs = target.durationMs,
+                        message = null,
+                    )
+                }
+                suspendLocalPlayback()
+                if (!jumpToReceiverTrack(target)) {
+                    loadQueueInternal(current.queue, targetIndex)
+                }
+            }
+            is CastSkipDecision.LoadWindow -> loadQueueInternal(current.queue, decision.startIndex)
         }
     }
 
@@ -303,10 +372,14 @@ private class AndroidCastController : CastController {
     }
 
     private fun connect(session: CastSession, castLocalQueueIfReceiverEmpty: Boolean) {
+        reconnectJob?.cancel()
+        reconnectJob = null
+        endingSessionIntentionally = false
         ensurePlaybackServiceRunning()
         val client = session.remoteMediaClient
         client?.registerCallback(remoteMediaClientListener)
         client?.requestStatus()
+        suspendLocalPlayback()
         mutableState.update {
             it.copy(
                 isAvailable = true,
@@ -317,41 +390,66 @@ private class AndroidCastController : CastController {
             )
         }
         syncRemotePlayback()
-        if (castLocalQueueIfReceiverEmpty && client?.mediaInfo == null) {
+        val receiverEmpty = client?.mediaInfo == null
+        PhoebeLog.d(TAG) {
+            "session connected device=${session.castDevice?.friendlyName} receiverEmpty=$receiverEmpty recastLocal=$castLocalQueueIfReceiverEmpty"
+        }
+        if (castLocalQueueIfReceiverEmpty && receiverEmpty) {
             castCurrentLocalQueueIfPossible()
         }
         startPositionSync()
     }
 
-    private fun disconnectState() {
+    private fun disconnectState(reason: CastSessionDisconnectReason) {
         loadTimeoutJob?.cancel()
         loadTimeoutJob = null
         val pending = pendingHandoff
         pendingHandoff = null
         expectedRemoteHandoff = null
-        appQueueSnapshot = null
         val previous = mutableState.value
-        val localPlayer = audioPlayer
-        if (pending != null) {
-            restoreLocalPlayback(pending)
-        } else if (previous.isConnected && previous.queue.isNotEmpty() && previous.currentIndex in previous.queue.indices) {
-            localPlayer?.play(previous.queue, previous.currentIndex)
-            if (previous.positionMs > 0L) {
-                localPlayer?.seekTo(previous.positionMs)
-            }
+        val restoreLocal = shouldRestoreLocalAfterCastSessionEnd(reason)
+        PhoebeLog.d(TAG) {
+            "disconnectState reason=$reason restoreLocal=$restoreLocal pending=${pending != null} queue=${previous.queue.size} index=${previous.currentIndex} localPlaying=${audioPlayer?.state?.value?.isPlaying == true}"
         }
+        if (restoreLocal) {
+            reconnectJob?.cancel()
+            reconnectJob = null
+            appQueueSnapshot = null
+            if (pending != null) {
+                restoreLocalPlayback(pending)
+            }             else if (previous.isConnected && previous.queue.isNotEmpty() && previous.currentIndex in previous.queue.indices) {
+                restoreLocalPlayback(
+                    queue = previous.queue,
+                    index = previous.currentIndex,
+                    positionMs = previous.positionMs,
+                    shouldPlay = previous.isPlaying || pending?.wasLocalPlaying == true,
+                )
+            }
+            positionJob?.cancel()
+            positionJob = null
+            mutableState.update {
+                it.copy(
+                    isConnected = false,
+                    deviceName = null,
+                    isPlaying = false,
+                    isBuffering = false,
+                    message = null,
+                )
+            }
+            AndroidPlaybackBridge.onCastMediaSessionState?.invoke(null)
+            return
+        }
+        suspendLocalPlayback()
         positionJob?.cancel()
         positionJob = null
         mutableState.update {
             it.copy(
-                isConnected = false,
-                deviceName = null,
                 isPlaying = false,
-                isBuffering = false,
-                message = null,
+                isBuffering = true,
+                message = "Reconnecting to Chromecast...",
             )
         }
-        AndroidPlaybackBridge.onCastMediaSessionState?.invoke(null)
+        scheduleUnexpectedDisconnectTimeout()
     }
 
     private fun syncRemotePlayback() {
@@ -428,14 +526,57 @@ private class AndroidCastController : CastController {
         } else if (remoteQueue.isNotEmpty() || remoteTrack != null) {
             appQueueSnapshot = null
         }
-        if (status?.playerState == MediaStatus.PLAYER_STATE_IDLE &&
-            status.idleReason == MediaStatus.IDLE_REASON_FINISHED &&
-            pendingHandoff == null &&
-            currentIndex in queue.indices &&
-            currentIndex < queue.lastIndex
-        ) {
-            loadQueue(queue, currentIndex + 1)
-            return
+        val playerState = status?.playerState ?: CAST_PLAYER_STATE_UNKNOWN
+        val idleReason = status?.idleReason ?: CAST_IDLE_REASON_NONE
+        val nextTrack = queue.getOrNull(currentIndex + 1)
+        val idleDecision = decideCastIdleAction(
+            playerState = playerState,
+            idleReason = idleReason,
+            hasPendingHandoff = pendingHandoff != null,
+            currentIndex = currentIndex,
+            lastAppIndex = queue.lastIndex,
+            nextItemAlreadyOnReceiver = receiverQueueItem(nextTrack, queueItems) != null,
+            currentErrorRetryCount = mediaErrorRetryCount,
+        )
+        val remoteState = "player=${castPlayerStateName(playerState)} idle=${castIdleReasonName(idleReason)} index=$currentIndex playing=$isPlaying buffering=$isBuffering localPlaying=${audioPlayer?.state?.value?.isPlaying == true} servicePlaying=${AndroidPlaybackBridge.isServicePlaybackActive()} decision=$idleDecision"
+        if (remoteState != lastLoggedRemoteState) {
+            lastLoggedRemoteState = remoteState
+            PhoebeLog.d(TAG) { "remote $remoteState" }
+        }
+        if (playerState != CAST_PLAYER_STATE_IDLE || idleReason != CAST_IDLE_REASON_ERROR) {
+            mediaErrorRetryCount = 0
+        }
+        when (idleDecision) {
+            CastIdleDecision.Ignore -> Unit
+            CastIdleDecision.AdvanceReceiverQueue -> {
+                if (nextTrack != null && jumpToReceiverTrack(nextTrack, queueItems)) {
+                    rememberAppQueue(queue, currentIndex + 1)
+                    return
+                }
+                if (nextTrack != null) {
+                    loadQueueInternal(queue, currentIndex + 1)
+                    return
+                }
+            }
+            is CastIdleDecision.LoadNextWindow -> {
+                loadQueueInternal(queue, idleDecision.startIndex)
+                return
+            }
+            CastIdleDecision.RetryCurrent -> {
+                mediaErrorRetryCount++
+                val retryIndex = currentIndex.takeIf { it in queue.indices } ?: return
+                PhoebeLog.d(TAG) { "retrying failed cast item index=$retryIndex attempt=$mediaErrorRetryCount" }
+                loadQueueInternal(queue, retryIndex, maxReceiverItems = 1)
+                return
+            }
+            is CastIdleDecision.SkipFailedTrack -> {
+                PhoebeLog.d(TAG) {
+                    "skipping failed cast item index=$currentIndex next=${idleDecision.nextIndex} title=${queue.getOrNull(currentIndex)?.title}"
+                }
+                mediaErrorRetryCount = 0
+                loadQueueInternal(queue, idleDecision.nextIndex)
+                return
+            }
         }
         val positionMs = client.approximateStreamPosition.coerceAtLeast(0L)
         val durationMs = client.streamDuration.coerceAtLeast(0L).takeIf { duration -> duration > 0L }
@@ -460,11 +601,7 @@ private class AndroidCastController : CastController {
             }
         }
         publishCastMediaSessionState()
-        val localPlayer = audioPlayer
-        if (client.isPlaying && localPlayer?.state?.value?.isPlaying == true) {
-            suspendLocalPlayback()
-        }
-        if (AndroidPlaybackBridge.isServicePlaybackActive()) {
+        if (previous.isConnected || mutableState.value.isConnected) {
             suspendLocalPlayback()
         }
     }
@@ -512,13 +649,48 @@ private class AndroidCastController : CastController {
     }
 
     private fun restoreLocalPlayback(handoff: PendingCastHandoff) {
+        restoreLocalPlayback(
+            queue = handoff.queue,
+            index = handoff.index,
+            positionMs = handoff.positionMs,
+            shouldPlay = handoff.wasLocalPlaying,
+        )
+    }
+
+    private fun restoreLocalPlayback(
+        queue: List<Track>,
+        index: Int,
+        positionMs: Long,
+        shouldPlay: Boolean,
+    ) {
         val localPlayer = audioPlayer ?: return
-        localPlayer.play(handoff.queue, handoff.index)
-        if (handoff.positionMs > 0L) {
-            localPlayer.seekTo(handoff.positionMs)
+        PhoebeLog.d(TAG) {
+            "restoring local playback index=$index positionMs=$positionMs shouldPlay=$shouldPlay id=${queue.getOrNull(index)?.id}"
         }
-        if (handoff.wasLocalPlaying && !localPlayer.state.value.isPlaying) {
+        localPlayer.play(queue, index)
+        if (positionMs > 0L) {
+            localPlayer.seekTo(positionMs)
+        }
+        if (shouldPlay && !localPlayer.state.value.isPlaying) {
             localPlayer.togglePlayPause()
+        }
+    }
+
+    private fun scheduleUnexpectedDisconnectTimeout() {
+        reconnectJob?.cancel()
+        reconnectJob = scope.launch {
+            delay(CAST_UNEXPECTED_DISCONNECT_RECONNECT_MS)
+            if (remoteMediaClient() != null) return@launch
+            PhoebeLog.d(TAG) { "cast reconnect timed out; leaving local playback paused" }
+            mutableState.update {
+                it.copy(
+                    isConnected = false,
+                    isPlaying = false,
+                    isBuffering = false,
+                    message = "Lost Chromecast connection. The speaker may still be playing.",
+                )
+            }
+            AndroidPlaybackBridge.onCastMediaSessionState?.invoke(null)
         }
     }
 
@@ -527,7 +699,7 @@ private class AndroidCastController : CastController {
         loadTimeoutJob = scope.launch {
             delay(LOAD_TIMEOUT_MS)
             if (pendingHandoff?.requestId == requestId) {
-                onCastLoadFailed(requestId, "Chromecast didn't respond in time. Playing on this device.")
+                onCastLoadFailed(requestId, "Chromecast didn't respond in time.")
             }
         }
     }
@@ -540,12 +712,12 @@ private class AndroidCastController : CastController {
         if (status.isSuccess && mediaError == null) {
             onCastLoadSucceeded(requestId)
         } else {
-            PhoebeLog.d("AndroidCastController") {
-                "cast load failed status=${status.statusCode} mediaError=${mediaError?.detailedErrorCode}"
+            PhoebeLog.d(TAG) {
+                "cast load failed status=${status.statusCode} statusMessage=${status.statusMessage} mediaError=${mediaError?.detailedErrorCode} items=$lastLoadReceiverQueueSize requestId=$requestId"
             }
             val message = mediaError?.detailedErrorCode?.let { code ->
-                "Couldn't load on Chromecast (error $code). Playing on this device."
-            } ?: "Couldn't load on Chromecast. Playing on this device."
+                "Couldn't load on Chromecast (error $code)."
+            } ?: "Couldn't load this playlist on Chromecast."
             onCastLoadFailed(requestId, message)
         }
     }
@@ -559,22 +731,63 @@ private class AndroidCastController : CastController {
 
     private fun onCastLoadFailed(requestId: Long, message: String) {
         val handoff = pendingHandoff?.takeIf { it.requestId == requestId } ?: return
+        val sessionConnected = remoteMediaClient() != null
+        val action = decideCastLoadFailureAction(sessionConnected, lastLoadReceiverQueueSize)
+        val retryItemCount = nextCastLoadRetryItemCount(lastLoadReceiverQueueSize)
+        PhoebeLog.d(TAG) {
+            "cast load failure action=$action retryItems=$retryItemCount sessionConnected=$sessionConnected message=$message"
+        }
+        when (action) {
+            CastLoadFailureAction.RetrySmallerQueue -> {
+                if (retryItemCount != null) {
+                    loadQueueInternal(
+                        queue = handoff.queue,
+                        startIndex = handoff.index,
+                        startPositionMs = handoff.positionMs,
+                        maxReceiverItems = retryItemCount,
+                    )
+                    return
+                }
+                holdFailedCastLoad(handoff, message)
+            }
+            CastLoadFailureAction.HoldOnReceiver -> holdFailedCastLoad(handoff, message)
+            CastLoadFailureAction.RestoreLocal -> {
+                pendingHandoff = null
+                if (expectedRemoteHandoff?.requestId == requestId) {
+                    expectedRemoteHandoff = null
+                }
+                restoreLocalPlayback(handoff)
+                mutableState.update {
+                    it.copy(
+                        isConnected = false,
+                        isPlaying = false,
+                        isBuffering = false,
+                        message = "$message Playing on this device.",
+                    )
+                }
+            }
+        }
+    }
+
+    private fun holdFailedCastLoad(handoff: PendingCastHandoff, message: String) {
         pendingHandoff = null
-        if (expectedRemoteHandoff?.requestId == requestId) {
+        if (expectedRemoteHandoff?.requestId == handoff.requestId) {
             expectedRemoteHandoff = null
         }
-        appQueueSnapshot = null
-        restoreLocalPlayback(handoff)
+        rememberAppQueue(handoff.queue, handoff.index)
+        suspendLocalPlayback()
         mutableState.update {
             it.copy(
-                queue = emptyList(),
-                currentIndex = -1,
+                queue = handoff.queue,
+                currentIndex = handoff.index,
                 isPlaying = false,
                 isBuffering = false,
-                positionMs = 0L,
-                message = message,
+                positionMs = handoff.positionMs,
+                durationMs = handoff.queue.getOrNull(handoff.index)?.durationMs ?: it.durationMs,
+                message = "$message Playback stays on Chromecast.",
             )
         }
+        syncRemotePlayback()
     }
 
     private fun ensurePlaybackServiceRunning() {
@@ -582,16 +795,61 @@ private class AndroidCastController : CastController {
     }
 
     private fun castCurrentLocalQueueIfPossible() {
-        val localPlayer = audioPlayer ?: return
-        val current = localPlayer.state.value
-        val index = current.currentIndex
-        if (index !in current.queue.indices) return
-        val support = canLoadQueue(current.queue)
+        val snapshot = appQueueSnapshot
+        val castState = mutableState.value
+        val rememberedQueue = snapshot?.queue?.takeIf { it.isNotEmpty() } ?: castState.queue
+        val rememberedIndex = snapshot?.currentIndex ?: castState.currentIndex
+        val local = audioPlayer?.state?.value
+        val queue: List<Track>
+        val index: Int
+        val positionMs: Long
+        if (rememberedQueue.isNotEmpty() && rememberedIndex in rememberedQueue.indices) {
+            queue = rememberedQueue
+            index = rememberedIndex
+            positionMs = castState.positionMs
+        } else {
+            if (local == null || local.currentIndex !in local.queue.indices) return
+            queue = local.queue
+            index = local.currentIndex
+            positionMs = local.positionMs
+        }
+        val support = canLoadQueue(queue)
         if (!support.isSupported) {
             mutableState.update { it.copy(message = support.message) }
             return
         }
-        loadQueue(current.queue, index, current.positionMs)
+        loadQueueInternal(queue, index, positionMs)
+    }
+
+    private fun receiverQueueItem(
+        track: Track?,
+        queueItems: List<MediaQueueItem>? = remoteMediaClient()?.mediaStatus?.queueItems,
+    ): MediaQueueItem? {
+        if (track == null) return null
+        return queueItems.orEmpty().firstOrNull { item ->
+            val media = item.media ?: return@firstOrNull false
+            track.matchesCastMedia(media.toTrack(), media.contentId)
+        }
+    }
+
+    private fun jumpToReceiverTrack(
+        track: Track,
+        queueItems: List<MediaQueueItem>? = remoteMediaClient()?.mediaStatus?.queueItems,
+    ): Boolean {
+        val client = remoteMediaClient() ?: return false
+        val item = receiverQueueItem(track, queueItems) ?: return false
+        PhoebeLog.d(TAG) { "jumping receiver queue itemId=${item.itemId} id=${track.id}" }
+        loadTimeoutJob?.cancel()
+        loadTimeoutJob = null
+        pendingHandoff = null
+        expectedRemoteHandoff = null
+        return runCatching {
+            client.queueJumpToItem(item.itemId, null as JSONObject?)
+            true
+        }.getOrElse { error ->
+            PhoebeLog.d(TAG) { "queue jump failed: ${error.message}" }
+            false
+        }
     }
 
     private fun remotePlaybackMatches(
@@ -621,9 +879,6 @@ private class AndroidCastController : CastController {
             putString(MediaMetadata.KEY_ALBUM_TITLE, descriptor.album)
             descriptor.thumbUrl?.let { addImage(com.google.android.gms.common.images.WebImage(android.net.Uri.parse(it))) }
         }
-        PhoebeLog.d("AndroidCastController") {
-            "loading cast media id=${descriptor.trackId} codec=${descriptor.audioCodec} contentType=${descriptor.contentType} transcode=${descriptor.transcodesOriginal}"
-        }
         return MediaInfo.Builder(descriptor.castUrl)
             .setStreamType(MediaInfo.STREAM_TYPE_BUFFERED)
             .setContentType(descriptor.contentType)
@@ -643,26 +898,27 @@ private class AndroidCastController : CastController {
             }
             .build()
 
-    private fun buildCastLoadRequest(queue: List<Track>, startIndex: Int, startPositionMs: Long): CastLoadRequest {
+    private fun buildCastLoadRequest(
+        queue: List<Track>,
+        startIndex: Int,
+        startPositionMs: Long,
+        maxItems: Int = CAST_MAX_RECEIVER_QUEUE_ITEMS,
+    ): CastLoadRequest {
         val tail = queue.drop(startIndex)
-        var itemCount = tail.size.coerceAtMost(MaxCastReceiverQueueItems)
-        var best: CastLoadRequest? = null
-        while (itemCount >= 1) {
-            val request = buildMediaLoadRequest(
-                queue = tail.take(itemCount),
-                startPositionMs = startPositionMs,
-            )
-            val bytes = request.estimatedByteSize()
-            val castRequest = CastLoadRequest(
-                requestData = request,
-                receiverQueueSize = itemCount,
-                estimatedBytes = bytes,
-            )
-            best = castRequest
-            if (bytes <= MaxCastLoadMessageBytes || itemCount == 1) return castRequest
-            itemCount = (itemCount / 2).coerceAtLeast(1)
-        }
-        return requireNotNull(best)
+        val itemCount = shrinkCastReceiverQueueItemCount(
+            tailSize = tail.size,
+            maxItems = maxItems,
+            maxBytes = CAST_LOAD_MESSAGE_BYTE_BUDGET,
+            estimatedBytesForCount = { count ->
+                buildMediaLoadRequest(tail.take(count), startPositionMs).estimatedByteSize()
+            },
+        ).coerceAtLeast(1)
+        val request = buildMediaLoadRequest(tail.take(itemCount), startPositionMs)
+        return CastLoadRequest(
+            requestData = request,
+            receiverQueueSize = itemCount,
+            estimatedBytes = request.estimatedByteSize(),
+        )
     }
 
     private fun buildMediaLoadRequest(queue: List<Track>, startPositionMs: Long): MediaLoadRequestData {
@@ -731,8 +987,7 @@ private class AndroidCastController : CastController {
     }
 
     private companion object {
+        const val TAG = "AndroidCastController"
         const val LOAD_TIMEOUT_MS = 30_000L
-        const val MaxCastLoadMessageBytes = 450_000
-        const val MaxCastReceiverQueueItems = 80
     }
 }

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidCastController.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidCastController.kt
@@ -76,6 +76,7 @@ private class AndroidCastController : CastController {
     private var loadRequestId = 0L
     private var lastLoadReceiverQueueSize = 0
     private var mediaErrorRetryCount = 0
+    private var mediaErrorTrackId: String? = null
     private var endingSessionIntentionally = false
     private var lastLoggedRemoteState: String? = null
 
@@ -333,7 +334,7 @@ private class AndroidCastController : CastController {
         val decision = decideCastSkipAction(
             targetIndex = targetIndex,
             queueSize = current.queue.size,
-            targetAlreadyOnReceiver = receiverQueueItem(current.queue.getOrNull(targetIndex)) != null,
+            targetAlreadyOnReceiver = receiverQueueItemForAppIndex(current.queue, targetIndex) != null,
         )
         PhoebeLog.d(TAG) {
             "skip to=$targetIndex from=${current.currentIndex} decision=$decision connected=${current.isConnected}"
@@ -354,7 +355,7 @@ private class AndroidCastController : CastController {
                     )
                 }
                 suspendLocalPlayback()
-                if (!jumpToReceiverTrack(target)) {
+                if (!jumpToReceiverAppIndex(current.queue, targetIndex)) {
                     loadQueueInternal(current.queue, targetIndex)
                 }
             }
@@ -528,14 +529,20 @@ private class AndroidCastController : CastController {
         }
         val playerState = status?.playerState ?: CAST_PLAYER_STATE_UNKNOWN
         val idleReason = status?.idleReason ?: CAST_IDLE_REASON_NONE
-        val nextTrack = queue.getOrNull(currentIndex + 1)
+        val currentTrackId = queue.getOrNull(currentIndex)?.id
+        mediaErrorRetryCount = mediaErrorRetryCountFor(
+            currentTrackId = currentTrackId,
+            previousTrackId = mediaErrorTrackId,
+            previousCount = mediaErrorRetryCount,
+        )
+        mediaErrorTrackId = currentTrackId
         val idleDecision = decideCastIdleAction(
             playerState = playerState,
             idleReason = idleReason,
             hasPendingHandoff = pendingHandoff != null,
             currentIndex = currentIndex,
             lastAppIndex = queue.lastIndex,
-            nextItemAlreadyOnReceiver = receiverQueueItem(nextTrack, queueItems) != null,
+            nextItemAlreadyOnReceiver = receiverQueueItemForAppIndex(queue, currentIndex + 1, queueItems) != null,
             currentErrorRetryCount = mediaErrorRetryCount,
         )
         val remoteState = "player=${castPlayerStateName(playerState)} idle=${castIdleReasonName(idleReason)} index=$currentIndex playing=$isPlaying buffering=$isBuffering localPlaying=${audioPlayer?.state?.value?.isPlaying == true} servicePlaying=${AndroidPlaybackBridge.isServicePlaybackActive()} decision=$idleDecision"
@@ -543,20 +550,20 @@ private class AndroidCastController : CastController {
             lastLoggedRemoteState = remoteState
             PhoebeLog.d(TAG) { "remote $remoteState" }
         }
-        if (playerState != CAST_PLAYER_STATE_IDLE || idleReason != CAST_IDLE_REASON_ERROR) {
+        if (playerState == CAST_PLAYER_STATE_PLAYING &&
+            client.approximateStreamPosition > 2_000L
+        ) {
             mediaErrorRetryCount = 0
         }
         when (idleDecision) {
             CastIdleDecision.Ignore -> Unit
             CastIdleDecision.AdvanceReceiverQueue -> {
-                if (nextTrack != null && jumpToReceiverTrack(nextTrack, queueItems)) {
+                if (jumpToReceiverAppIndex(queue, currentIndex + 1, queueItems)) {
                     rememberAppQueue(queue, currentIndex + 1)
                     return
                 }
-                if (nextTrack != null) {
-                    loadQueueInternal(queue, currentIndex + 1)
-                    return
-                }
+                loadQueueInternal(queue, currentIndex + 1)
+                return
             }
             is CastIdleDecision.LoadNextWindow -> {
                 loadQueueInternal(queue, idleDecision.startIndex)
@@ -671,7 +678,7 @@ private class AndroidCastController : CastController {
         if (positionMs > 0L) {
             localPlayer.seekTo(positionMs)
         }
-        if (shouldPlay && !localPlayer.state.value.isPlaying) {
+        if (!shouldPlay && (localPlayer.state.value.isPlaying || localPlayer.state.value.isBuffering)) {
             localPlayer.togglePlayPause()
         }
     }
@@ -682,11 +689,16 @@ private class AndroidCastController : CastController {
             delay(CAST_UNEXPECTED_DISCONNECT_RECONNECT_MS)
             if (remoteMediaClient() != null) return@launch
             PhoebeLog.d(TAG) { "cast reconnect timed out; leaving local playback paused" }
+            appQueueSnapshot = null
             mutableState.update {
                 it.copy(
                     isConnected = false,
+                    queue = emptyList(),
+                    currentIndex = -1,
                     isPlaying = false,
                     isBuffering = false,
+                    positionMs = 0L,
+                    durationMs = 0L,
                     message = "Lost Chromecast connection. The speaker may still be playing.",
                 )
             }
@@ -821,28 +833,50 @@ private class AndroidCastController : CastController {
         loadQueueInternal(queue, index, positionMs)
     }
 
-    private fun receiverQueueItem(
-        track: Track?,
+    private fun receiverQueueItemForAppIndex(
+        queue: List<Track>,
+        appIndex: Int,
         queueItems: List<MediaQueueItem>? = remoteMediaClient()?.mediaStatus?.queueItems,
     ): MediaQueueItem? {
-        if (track == null) return null
-        return queueItems.orEmpty().firstOrNull { item ->
-            val media = item.media ?: return@firstOrNull false
-            track.matchesCastMedia(media.toTrack(), media.contentId)
+        val target = queue.getOrNull(appIndex) ?: return null
+        val items = queueItems.orEmpty()
+        if (items.isEmpty()) return null
+        val firstMedia = items.first().media ?: return null
+        val windowStart = queue.indexOfFirst { track ->
+            track.matchesCastMedia(firstMedia.toTrack(), firstMedia.contentId)
         }
+        if (windowStart >= 0) {
+            val receiverIndex = appIndex - windowStart
+            items.getOrNull(receiverIndex)?.let { item ->
+                val media = item.media ?: return@let null
+                if (target.matchesCastMedia(media.toTrack(), media.contentId)) return item
+            }
+        }
+        val matchingAppIndexes = queue.indices.filter { index ->
+            queue[index].matchesCastMedia(target, target.toCastMediaDescriptor().castUrl)
+        }
+        if (matchingAppIndexes.size == 1) {
+            return items.firstOrNull { item ->
+                val media = item.media ?: return@firstOrNull false
+                target.matchesCastMedia(media.toTrack(), media.contentId)
+            }
+        }
+        return null
     }
 
-    private fun jumpToReceiverTrack(
-        track: Track,
+    private fun jumpToReceiverAppIndex(
+        queue: List<Track>,
+        appIndex: Int,
         queueItems: List<MediaQueueItem>? = remoteMediaClient()?.mediaStatus?.queueItems,
     ): Boolean {
-        val client = remoteMediaClient() ?: return false
-        val item = receiverQueueItem(track, queueItems) ?: return false
-        PhoebeLog.d(TAG) { "jumping receiver queue itemId=${item.itemId} id=${track.id}" }
+        val item = receiverQueueItemForAppIndex(queue, appIndex, queueItems) ?: return false
+        val track = queue.getOrNull(appIndex) ?: return false
+        PhoebeLog.d(TAG) { "jumping receiver queue itemId=${item.itemId} appIndex=$appIndex id=${track.id}" }
         loadTimeoutJob?.cancel()
         loadTimeoutJob = null
         pendingHandoff = null
         expectedRemoteHandoff = null
+        val client = remoteMediaClient() ?: return false
         return runCatching {
             client.queueJumpToItem(item.itemId, null as JSONObject?)
             true

--- a/playback/src/androidUnitTest/kotlin/com/phoebe/app/player/CastPlaybackPolicyAndroidTest.kt
+++ b/playback/src/androidUnitTest/kotlin/com/phoebe/app/player/CastPlaybackPolicyAndroidTest.kt
@@ -1,0 +1,31 @@
+package com.phoebe.app.player
+
+import android.app.Application
+import com.google.android.gms.cast.MediaStatus
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35], application = Application::class)
+class CastPlaybackPolicyAndroidTest {
+    @Test
+    fun mirroredCastPlayerStatesMatchGoogleCastSdk() {
+        assertEquals(MediaStatus.PLAYER_STATE_UNKNOWN, CAST_PLAYER_STATE_UNKNOWN)
+        assertEquals(MediaStatus.PLAYER_STATE_IDLE, CAST_PLAYER_STATE_IDLE)
+        assertEquals(MediaStatus.PLAYER_STATE_PLAYING, CAST_PLAYER_STATE_PLAYING)
+        assertEquals(MediaStatus.PLAYER_STATE_PAUSED, CAST_PLAYER_STATE_PAUSED)
+        assertEquals(MediaStatus.PLAYER_STATE_BUFFERING, CAST_PLAYER_STATE_BUFFERING)
+    }
+
+    @Test
+    fun mirroredCastIdleReasonsMatchGoogleCastSdk() {
+        assertEquals(MediaStatus.IDLE_REASON_NONE, CAST_IDLE_REASON_NONE)
+        assertEquals(MediaStatus.IDLE_REASON_FINISHED, CAST_IDLE_REASON_FINISHED)
+        assertEquals(MediaStatus.IDLE_REASON_CANCELED, CAST_IDLE_REASON_CANCELED)
+        assertEquals(MediaStatus.IDLE_REASON_INTERRUPTED, CAST_IDLE_REASON_INTERRUPTED)
+        assertEquals(MediaStatus.IDLE_REASON_ERROR, CAST_IDLE_REASON_ERROR)
+    }
+}

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/CastPlaybackPolicy.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/CastPlaybackPolicy.kt
@@ -1,0 +1,141 @@
+package com.phoebe.app.player
+
+/**
+ * Cast protocol messages are capped at 64 KiB. Yesterday's Pixel 10 Pro session loaded
+ * 80 queue items at ~122 KiB (`cast load failed status=13`) and then started local
+ * playback while the receiver kept going.
+ */
+const val CAST_PROTOCOL_MAX_MESSAGE_BYTES = 64 * 1024
+const val CAST_LOAD_MESSAGE_BYTE_BUDGET = 56 * 1024
+const val CAST_MAX_RECEIVER_QUEUE_ITEMS = 80
+const val CAST_MEDIA_ERROR_MAX_RETRIES = 2
+const val CAST_UNEXPECTED_DISCONNECT_RECONNECT_MS = 15_000L
+
+/** [com.google.android.gms.cast.MediaStatus] player states, mirrored for common tests. */
+const val CAST_PLAYER_STATE_UNKNOWN = 0
+const val CAST_PLAYER_STATE_IDLE = 1
+const val CAST_PLAYER_STATE_PLAYING = 2
+const val CAST_PLAYER_STATE_PAUSED = 3
+const val CAST_PLAYER_STATE_BUFFERING = 4
+
+/** [com.google.android.gms.cast.MediaStatus] idle reasons, mirrored for common tests. */
+const val CAST_IDLE_REASON_NONE = 0
+const val CAST_IDLE_REASON_FINISHED = 1
+const val CAST_IDLE_REASON_CANCELED = 2
+const val CAST_IDLE_REASON_INTERRUPTED = 3
+const val CAST_IDLE_REASON_ERROR = 4
+
+enum class CastSessionDisconnectReason {
+    UserRequested,
+    Unexpected,
+}
+
+fun shouldRestoreLocalAfterCastSessionEnd(reason: CastSessionDisconnectReason): Boolean =
+    reason == CastSessionDisconnectReason.UserRequested
+
+enum class CastLoadFailureAction {
+    RetrySmallerQueue,
+    HoldOnReceiver,
+    RestoreLocal,
+}
+
+fun decideCastLoadFailureAction(
+    sessionConnected: Boolean,
+    failedReceiverItemCount: Int,
+): CastLoadFailureAction = when {
+    sessionConnected && failedReceiverItemCount > 1 -> CastLoadFailureAction.RetrySmallerQueue
+    sessionConnected -> CastLoadFailureAction.HoldOnReceiver
+    else -> CastLoadFailureAction.RestoreLocal
+}
+
+fun nextCastLoadRetryItemCount(failedReceiverItemCount: Int): Int? {
+    if (failedReceiverItemCount <= 1) return null
+    return (failedReceiverItemCount / 2).coerceAtLeast(1)
+}
+
+fun shrinkCastReceiverQueueItemCount(
+    tailSize: Int,
+    maxItems: Int = CAST_MAX_RECEIVER_QUEUE_ITEMS,
+    maxBytes: Int = CAST_LOAD_MESSAGE_BYTE_BUDGET,
+    estimatedBytesForCount: (Int) -> Int,
+): Int {
+    if (tailSize <= 0) return 0
+    var itemCount = tailSize.coerceAtMost(maxItems).coerceAtLeast(1)
+    while (itemCount > 1) {
+        if (estimatedBytesForCount(itemCount) <= maxBytes) return itemCount
+        itemCount = (itemCount / 2).coerceAtLeast(1)
+    }
+    return 1
+}
+
+sealed interface CastIdleDecision {
+    data object Ignore : CastIdleDecision
+    data object AdvanceReceiverQueue : CastIdleDecision
+    data class LoadNextWindow(val startIndex: Int) : CastIdleDecision
+    data object RetryCurrent : CastIdleDecision
+    data class SkipFailedTrack(val nextIndex: Int) : CastIdleDecision
+}
+
+fun decideCastIdleAction(
+    playerState: Int,
+    idleReason: Int,
+    hasPendingHandoff: Boolean,
+    currentIndex: Int,
+    lastAppIndex: Int,
+    nextItemAlreadyOnReceiver: Boolean,
+    currentErrorRetryCount: Int,
+    maxErrorRetries: Int = CAST_MEDIA_ERROR_MAX_RETRIES,
+): CastIdleDecision {
+    if (hasPendingHandoff || playerState != CAST_PLAYER_STATE_IDLE) return CastIdleDecision.Ignore
+    if (currentIndex < 0 || lastAppIndex < 0) return CastIdleDecision.Ignore
+    return when (idleReason) {
+        CAST_IDLE_REASON_FINISHED -> when {
+            currentIndex >= lastAppIndex -> CastIdleDecision.Ignore
+            nextItemAlreadyOnReceiver -> CastIdleDecision.AdvanceReceiverQueue
+            else -> CastIdleDecision.LoadNextWindow(currentIndex + 1)
+        }
+        CAST_IDLE_REASON_ERROR -> when {
+            currentErrorRetryCount < maxErrorRetries -> CastIdleDecision.RetryCurrent
+            currentIndex < lastAppIndex -> CastIdleDecision.SkipFailedTrack(currentIndex + 1)
+            else -> CastIdleDecision.Ignore
+        }
+        else -> CastIdleDecision.Ignore
+    }
+}
+
+sealed interface CastSkipDecision {
+    data object None : CastSkipDecision
+    data object AdvanceReceiverQueue : CastSkipDecision
+    data class LoadWindow(val startIndex: Int) : CastSkipDecision
+}
+
+fun decideCastSkipAction(
+    targetIndex: Int,
+    queueSize: Int,
+    targetAlreadyOnReceiver: Boolean,
+): CastSkipDecision {
+    if (queueSize <= 0 || targetIndex !in 0 until queueSize) return CastSkipDecision.None
+    return if (targetAlreadyOnReceiver) {
+        CastSkipDecision.AdvanceReceiverQueue
+    } else {
+        CastSkipDecision.LoadWindow(targetIndex)
+    }
+}
+
+fun castIdleReasonName(idleReason: Int): String = when (idleReason) {
+    CAST_IDLE_REASON_NONE -> "NONE"
+    CAST_IDLE_REASON_FINISHED -> "FINISHED"
+    CAST_IDLE_REASON_CANCELED -> "CANCELED"
+    CAST_IDLE_REASON_INTERRUPTED -> "INTERRUPTED"
+    CAST_IDLE_REASON_ERROR -> "ERROR"
+    else -> "UNKNOWN($idleReason)"
+}
+
+fun castPlayerStateName(playerState: Int): String = when (playerState) {
+    CAST_PLAYER_STATE_UNKNOWN -> "UNKNOWN"
+    CAST_PLAYER_STATE_IDLE -> "IDLE"
+    CAST_PLAYER_STATE_PLAYING -> "PLAYING"
+    CAST_PLAYER_STATE_PAUSED -> "PAUSED"
+    CAST_PLAYER_STATE_BUFFERING -> "BUFFERING"
+    else -> "UNKNOWN($playerState)"
+}

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/CastPlaybackPolicy.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/CastPlaybackPolicy.kt
@@ -53,6 +53,12 @@ fun nextCastLoadRetryItemCount(failedReceiverItemCount: Int): Int? {
     return (failedReceiverItemCount / 2).coerceAtLeast(1)
 }
 
+fun mediaErrorRetryCountFor(
+    currentTrackId: String?,
+    previousTrackId: String?,
+    previousCount: Int,
+): Int = if (currentTrackId != null && currentTrackId == previousTrackId) previousCount else 0
+
 fun shrinkCastReceiverQueueItemCount(
     tailSize: Int,
     maxItems: Int = CAST_MAX_RECEIVER_QUEUE_ITEMS,

--- a/playback/src/commonTest/kotlin/com/phoebe/app/player/CastPlaybackPolicyTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/player/CastPlaybackPolicyTest.kt
@@ -1,0 +1,167 @@
+package com.phoebe.app.player
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class CastPlaybackPolicyTest {
+    @Test
+    fun loadMessageBudgetStaysUnderCastProtocolLimit() {
+        assertTrue(CAST_LOAD_MESSAGE_BYTE_BUDGET < CAST_PROTOCOL_MAX_MESSAGE_BYTES)
+        assertEquals(64 * 1024, CAST_PROTOCOL_MAX_MESSAGE_BYTES)
+        assertEquals(56 * 1024, CAST_LOAD_MESSAGE_BYTE_BUDGET)
+    }
+
+    @Test
+    fun yesterdayOversizedQueueShrinksUnderByteBudget() {
+        val itemCount = shrinkCastReceiverQueueItemCount(
+            tailSize = 157,
+            maxItems = 80,
+            maxBytes = CAST_LOAD_MESSAGE_BYTE_BUDGET,
+            estimatedBytesForCount = { count -> (121_698 * count) / 80 },
+        )
+
+        assertEquals(20, itemCount)
+        assertTrue((121_698 * itemCount) / 80 <= CAST_LOAD_MESSAGE_BYTE_BUDGET)
+    }
+
+    @Test
+    fun singleItemQueueIsKeptEvenWhenOverBudget() {
+        assertEquals(
+            1,
+            shrinkCastReceiverQueueItemCount(
+                tailSize = 1,
+                estimatedBytesForCount = { 200_000 },
+            ),
+        )
+    }
+
+    @Test
+    fun emptyTailProducesNoReceiverItems() {
+        assertEquals(
+            0,
+            shrinkCastReceiverQueueItemCount(
+                tailSize = 0,
+                estimatedBytesForCount = { 0 },
+            ),
+        )
+    }
+
+    @Test
+    fun unexpectedSessionEndDoesNotRestoreLocalPlayback() {
+        assertFalse(shouldRestoreLocalAfterCastSessionEnd(CastSessionDisconnectReason.Unexpected))
+        assertTrue(shouldRestoreLocalAfterCastSessionEnd(CastSessionDisconnectReason.UserRequested))
+    }
+
+    @Test
+    fun loadFailureRetriesSmallerQueueWhileSessionStaysConnected() {
+        assertEquals(
+            CastLoadFailureAction.RetrySmallerQueue,
+            decideCastLoadFailureAction(sessionConnected = true, failedReceiverItemCount = 80),
+        )
+        assertEquals(40, nextCastLoadRetryItemCount(80))
+        assertEquals(
+            CastLoadFailureAction.HoldOnReceiver,
+            decideCastLoadFailureAction(sessionConnected = true, failedReceiverItemCount = 1),
+        )
+        assertNull(nextCastLoadRetryItemCount(1))
+        assertEquals(
+            CastLoadFailureAction.RestoreLocal,
+            decideCastLoadFailureAction(sessionConnected = false, failedReceiverItemCount = 1),
+        )
+    }
+
+    @Test
+    fun finishedTrackAdvancesReceiverInsteadOfReloadingWholeQueue() {
+        assertEquals(
+            CastIdleDecision.AdvanceReceiverQueue,
+            decideCastIdleAction(
+                playerState = CAST_PLAYER_STATE_IDLE,
+                idleReason = CAST_IDLE_REASON_FINISHED,
+                hasPendingHandoff = false,
+                currentIndex = 4,
+                lastAppIndex = 156,
+                nextItemAlreadyOnReceiver = true,
+                currentErrorRetryCount = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun finishedTrackLoadsNextWindowWhenReceiverQueueIsExhausted() {
+        assertEquals(
+            CastIdleDecision.LoadNextWindow(5),
+            decideCastIdleAction(
+                playerState = CAST_PLAYER_STATE_IDLE,
+                idleReason = CAST_IDLE_REASON_FINISHED,
+                hasPendingHandoff = false,
+                currentIndex = 4,
+                lastAppIndex = 156,
+                nextItemAlreadyOnReceiver = false,
+                currentErrorRetryCount = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun idleErrorRetriesThenSkipsInsteadOfSilentlyStopping() {
+        assertEquals(
+            CastIdleDecision.RetryCurrent,
+            decideCastIdleAction(
+                playerState = CAST_PLAYER_STATE_IDLE,
+                idleReason = CAST_IDLE_REASON_ERROR,
+                hasPendingHandoff = false,
+                currentIndex = 4,
+                lastAppIndex = 156,
+                nextItemAlreadyOnReceiver = true,
+                currentErrorRetryCount = 0,
+            ),
+        )
+        assertEquals(
+            CastIdleDecision.SkipFailedTrack(5),
+            decideCastIdleAction(
+                playerState = CAST_PLAYER_STATE_IDLE,
+                idleReason = CAST_IDLE_REASON_ERROR,
+                hasPendingHandoff = false,
+                currentIndex = 4,
+                lastAppIndex = 156,
+                nextItemAlreadyOnReceiver = true,
+                currentErrorRetryCount = CAST_MEDIA_ERROR_MAX_RETRIES,
+            ),
+        )
+    }
+
+    @Test
+    fun pendingHandoffIgnoresIdleFinishedSoAutoplayDoesNotRaceAReload() {
+        assertEquals(
+            CastIdleDecision.Ignore,
+            decideCastIdleAction(
+                playerState = CAST_PLAYER_STATE_IDLE,
+                idleReason = CAST_IDLE_REASON_FINISHED,
+                hasPendingHandoff = true,
+                currentIndex = 4,
+                lastAppIndex = 156,
+                nextItemAlreadyOnReceiver = false,
+                currentErrorRetryCount = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun skipUsesReceiverQueueWhenTheTargetIsAlreadyLoaded() {
+        assertEquals(
+            CastSkipDecision.AdvanceReceiverQueue,
+            decideCastSkipAction(targetIndex = 5, queueSize = 157, targetAlreadyOnReceiver = true),
+        )
+        assertEquals(
+            CastSkipDecision.LoadWindow(5),
+            decideCastSkipAction(targetIndex = 5, queueSize = 157, targetAlreadyOnReceiver = false),
+        )
+        assertEquals(
+            CastSkipDecision.None,
+            decideCastSkipAction(targetIndex = 157, queueSize = 157, targetAlreadyOnReceiver = false),
+        )
+    }
+}

--- a/playback/src/commonTest/kotlin/com/phoebe/app/player/CastPlaybackPolicyTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/player/CastPlaybackPolicyTest.kt
@@ -106,6 +106,26 @@ class CastPlaybackPolicyTest {
     }
 
     @Test
+    fun mediaErrorRetriesSurviveBufferingAndPlayingOnTheSameTrack() {
+        assertEquals(
+            1,
+            mediaErrorRetryCountFor(
+                currentTrackId = "plex:1",
+                previousTrackId = "plex:1",
+                previousCount = 1,
+            ),
+        )
+        assertEquals(
+            0,
+            mediaErrorRetryCountFor(
+                currentTrackId = "plex:2",
+                previousTrackId = "plex:1",
+                previousCount = 1,
+            ),
+        )
+    }
+
+    @Test
     fun idleErrorRetriesThenSkipsInsteadOfSilentlyStopping() {
         assertEquals(
             CastIdleDecision.RetryCurrent,


### PR DESCRIPTION
## Summary
- Yesterday's Pixel 10 Pro Chromecast session in Sentry failed a 80-item / 122KB queue load (`cast load failed status=13`), then started local playback while the speaker kept playing — so the same song (and a second Plex track) ran in two places.
- Cap Android Cast loads under the 64KB protocol limit, jump the already-loaded receiver queue on skip/track-end instead of reloading 80 items, retry/hold on the speaker when a load fails, and only restore phone playback after an explicit disconnect.
- Add session/idle/load diagnostic logs (without one line per queue item) so the next incident is traceable.

## Test plan
- [ ] Cast a long Plex playlist from Android and let several tracks auto-advance on the speaker without the phone starting audio
- [ ] Skip next/previous while casting; playback should stay on Chromecast only
- [ ] Toggle Wi-Fi or briefly lose the Cast session; phone should not start playing while the speaker continues
- [ ] Disconnect from the Cast picker; speaker should stop and playback can continue on the phone
- [ ] Confirm Sentry shows `loading cast queue ... bytes=` under the 56KiB budget and session ended/resume logs


Made with [Cursor](https://cursor.com)