### PR TITLE
Stop Popular and Top Tracks mixes from hanging

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
@@ -2211,9 +2211,11 @@ class AppState(
     }
 
     fun playPopularMix() = scope.launch {
+        PhoebeLog.d("AppState") { "popular mix play requested" }
         val seed = popularMixSeedForSession(session.value)
         val popularPool = seed?.tracks.orEmpty()
         if (seed == null || popularPool.isEmpty()) {
+            PhoebeLog.d("AppState") { "popular mix play aborted: no seed tracks" }
             mutableMessage.value = "No popular songs found yet."
             return@launch
         }
@@ -2239,11 +2241,15 @@ class AppState(
     }
 
     fun playTopTracksMix() = scope.launch {
+        PhoebeLog.d("AppState") { "top tracks mix play requested" }
         val currentSession = session.value
-        val cachedPool = dependencies.catalogRepository.cachedPopularTracksForLibrary(currentSession)
+        val cachedPool = withTimeoutOrNull(MixProviderLoadTimeoutMs) {
+            dependencies.catalogRepository.cachedPopularTracksForLibrary(currentSession)
+        }.orEmpty()
         val seed = if (cachedPool.isEmpty()) popularMixSeedForSession(currentSession) else null
         val topTracksPool = cachedPool.takeIf { it.isNotEmpty() } ?: seed?.tracks.orEmpty()
         if (topTracksPool.isEmpty()) {
+            PhoebeLog.d("AppState") { "top tracks mix play aborted: no tracks" }
             mutableMessage.value = "No top tracks found yet."
             return@launch
         }
@@ -2277,12 +2283,21 @@ class AppState(
         val signature = currentSession.topTracksMixSessionSignature() ?: return null
         val cachedTracks = popularMixSeedTracks
             .takeIf { popularMixSeedSignature == signature && it.isNotEmpty() }
-            ?: startPopularMixSeedBuild(plexSession, signature).await()
+            ?: awaitPopularMixSeedBuild(plexSession, signature)
         return PopularMixSeed(
             session = plexSession,
             signature = signature,
             tracks = cachedTracks,
         )
+    }
+
+    private suspend fun awaitPopularMixSeedBuild(session: PlexSession, signature: String): List<Track> {
+        val deferred = startPopularMixSeedBuild(session, signature)
+        val tracks = withTimeoutOrNull(MixProviderLoadTimeoutMs) { deferred.await() }
+        if (tracks == null) {
+            PhoebeLog.d("AppState") { "popular mix seed timed out after ${MixProviderLoadTimeoutMs}ms" }
+        }
+        return tracks.orEmpty()
     }
 
     private fun startPopularMixSeedBuild(session: PlexSession, signature: String): Deferred<List<Track>> {
@@ -2292,17 +2307,15 @@ class AppState(
         }
         val deferred = scope.async {
             val tracks = runCatching {
-                withTimeoutOrNull(MixProviderLoadTimeoutMs) {
-                    dependencies.catalogRepository.popularSongsForLibrary(
-                        session = session,
-                        limit = PopularMixSeedTrackLimit,
-                    )
-                }
+                dependencies.catalogRepository.popularSongsForLibrary(
+                    session = session,
+                    limit = PopularMixSeedTrackLimit,
+                )
             }.getOrElse { error ->
                 if (error is CancellationException) throw error
                 PhoebeLog.d("AppState") { "popular mix seed provider load failed: ${error.message}" }
-                null
-            }.orEmpty()
+                emptyList()
+            }
             if (tracks.isNotEmpty()) {
                 popularMixSeedSignature = signature
                 popularMixSeedTracks = tracks

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeRoot.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeRoot.kt
@@ -1032,9 +1032,14 @@ private fun PhoebeRootStateHolder(
             homePosterActionScope.launch {
                 homePosterLoading = homePosterLoading.copy(popularMix = true)
                 val loadingStartedAtMs = currentTimeMs()
+                val playJob = state.playPopularMix()
                 try {
-                    withTimeoutOrNull(HomePosterMixLoadTimeoutMs) {
-                        state.playPopularMix().join()
+                    val completed = withTimeoutOrNull(HomePosterMixLoadTimeoutMs) {
+                        playJob.join()
+                        true
+                    }
+                    if (completed != true) {
+                        playJob.cancel()
                     }
                 } finally {
                     val remainingLoadingMs = HomePosterLoadingMinDurationMs - (currentTimeMs() - loadingStartedAtMs)
@@ -1052,9 +1057,14 @@ private fun PhoebeRootStateHolder(
             homePosterActionScope.launch {
                 homePosterLoading = homePosterLoading.copy(topTracksMix = true)
                 val loadingStartedAtMs = currentTimeMs()
+                val playJob = state.playTopTracksMix()
                 try {
-                    withTimeoutOrNull(HomePosterMixLoadTimeoutMs) {
-                        state.playTopTracksMix().join()
+                    val completed = withTimeoutOrNull(HomePosterMixLoadTimeoutMs) {
+                        playJob.join()
+                        true
+                    }
+                    if (completed != true) {
+                        playJob.cancel()
                     }
                 } finally {
                     val remainingLoadingMs = HomePosterLoadingMinDurationMs - (currentTimeMs() - loadingStartedAtMs)

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeRoot.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeRoot.kt
@@ -296,6 +296,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import com.phoebe.app.sources.rememberPickLocalFolder
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -1032,7 +1033,9 @@ private fun PhoebeRootStateHolder(
                 homePosterLoading = homePosterLoading.copy(popularMix = true)
                 val loadingStartedAtMs = currentTimeMs()
                 try {
-                    state.playPopularMix().join()
+                    withTimeoutOrNull(HomePosterMixLoadTimeoutMs) {
+                        state.playPopularMix().join()
+                    }
                 } finally {
                     val remainingLoadingMs = HomePosterLoadingMinDurationMs - (currentTimeMs() - loadingStartedAtMs)
                     if (remainingLoadingMs > 0L) {
@@ -1050,7 +1053,9 @@ private fun PhoebeRootStateHolder(
                 homePosterLoading = homePosterLoading.copy(topTracksMix = true)
                 val loadingStartedAtMs = currentTimeMs()
                 try {
-                    state.playTopTracksMix().join()
+                    withTimeoutOrNull(HomePosterMixLoadTimeoutMs) {
+                        state.playTopTracksMix().join()
+                    }
                 } finally {
                     val remainingLoadingMs = HomePosterLoadingMinDurationMs - (currentTimeMs() - loadingStartedAtMs)
                     if (remainingLoadingMs > 0L) {
@@ -3042,6 +3047,7 @@ private fun MobilePlayerHost(
 }
 
 private const val HomePosterLoadingMinDurationMs = 700L
+private const val HomePosterMixLoadTimeoutMs = 25_000L
 
 private fun Track?.withRadioNowPlaying(metadata: RadioNowPlayingMetadata?): Track? {
     val track = this ?: return null

--- a/composeApp/src/desktopTest/kotlin/com/phoebe/app/CatalogRepositoryRefreshDesktopTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/phoebe/app/CatalogRepositoryRefreshDesktopTest.kt
@@ -617,11 +617,13 @@ class CatalogRepositoryRefreshDesktopTest {
         driver = d
         var capturedLimit: String? = null
         var capturedContainerSize: String? = null
+        var capturedGroup: String? = null
         val engine = MockEngine { request ->
             when (request.url.encodedPath) {
                 "/library/sections/1/all" -> {
                     capturedLimit = request.url.parameters["limit"]
                     capturedContainerSize = request.headers["X-Plex-Container-Size"]
+                    capturedGroup = request.url.parameters["group"]
                     respondJson(popularTracksJson("t1" to "Library Top Song"))
                 }
                 else -> respond("", HttpStatusCode.NotFound)
@@ -641,6 +643,7 @@ class CatalogRepositoryRefreshDesktopTest {
 
         assertEquals("500", capturedLimit)
         assertEquals("500", capturedContainerSize)
+        assertEquals(null, capturedGroup)
         assertEquals(listOf("plex:t1"), tracks.map { it.id })
     }
 

--- a/data/catalog/src/commonMain/kotlin/com/phoebe/app/data/CatalogRepository.kt
+++ b/data/catalog/src/commonMain/kotlin/com/phoebe/app/data/CatalogRepository.kt
@@ -3759,9 +3759,20 @@ class CatalogRepository(
         )
             .map { it.withPlexPrefix() }
             .distinctBy { it.id }
+            .distinctBy { track ->
+                "${track.title.trim().lowercase()}|${track.artist.trim().lowercase()}"
+            }
         if (tracks.isNotEmpty()) {
-            publishIndexedPlexTracks(tracks)
-            runCatalogDbWrite { persistTrackBatch(tracks) }
+            persistenceScope.launch {
+                runCatching { publishIndexedPlexTracks(tracks) }
+                    .onFailure { error ->
+                        if (error is CancellationException) throw error
+                        PhoebeLog.d("CatalogRepository") {
+                            "popular songs catalog publish failed: ${error.message}"
+                        }
+                    }
+                enqueueCatalogDbWrite { persistTrackBatch(tracks) }
+            }
         }
         tracks
     }

--- a/data/catalog/src/commonMain/kotlin/com/phoebe/app/data/CatalogRepository.kt
+++ b/data/catalog/src/commonMain/kotlin/com/phoebe/app/data/CatalogRepository.kt
@@ -3763,6 +3763,7 @@ class CatalogRepository(
                 "${track.title.trim().lowercase()}|${track.artist.trim().lowercase()}"
             }
         if (tracks.isNotEmpty()) {
+            enqueueCatalogDbWrite { persistTrackBatch(tracks) }
             persistenceScope.launch {
                 runCatching { publishIndexedPlexTracks(tracks) }
                     .onFailure { error ->
@@ -3771,7 +3772,6 @@ class CatalogRepository(
                             "popular songs catalog publish failed: ${error.message}"
                         }
                     }
-                enqueueCatalogDbWrite { persistTrackBatch(tracks) }
             }
         }
         tracks

--- a/data/catalog/src/commonTest/kotlin/com/phoebe/app/PlexMappingTest.kt
+++ b/data/catalog/src/commonTest/kotlin/com/phoebe/app/PlexMappingTest.kt
@@ -349,7 +349,7 @@ class PlexMappingTest {
         assertEquals("10", capturedType)
         assertEquals(null, capturedArtist)
         assertEquals("Compilation,Live", capturedSubformat)
-        assertEquals("title", capturedGroup)
+        assertEquals(null, capturedGroup)
         assertEquals("0", capturedRatingCount)
         assertEquals("ratingCount:desc", capturedSort)
         assertEquals("25", capturedLimit)

--- a/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexClient.kt
+++ b/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexClient.kt
@@ -352,6 +352,7 @@ class PlexClient(
         if (ratingKey.isBlank() || limit <= 0) return emptyList()
         val response: PlexMediaContainerResponse = withReachableBase(server) { base ->
             val response = httpClient.get("$base/library/sections/${library.key}/all") {
+                timeout { requestTimeoutMillis = PlexPopularTracksRequestTimeoutMs }
                 plexServerAuth(token)
                 header(HttpHeaders.Accept, "application/json")
                 header("X-Plex-Container-Start", "0")
@@ -384,6 +385,7 @@ class PlexClient(
         if (limit <= 0) return emptyList()
         val response: PlexMediaContainerResponse = withReachableBase(server) { base ->
             val response = httpClient.get("$base/library/sections/${library.key}/all") {
+                timeout { requestTimeoutMillis = PlexPopularTracksRequestTimeoutMs }
                 plexServerAuth(token)
                 header(HttpHeaders.Accept, "application/json")
                 header("X-Plex-Container-Start", "0")
@@ -392,7 +394,6 @@ class PlexClient(
                 parameter("X-Plex-Container-Size", limit)
                 parameter("type", PlexTrackType)
                 parameter("album.subformat!", "Compilation,Live")
-                parameter("group", "title")
                 parameter("ratingCount>>", 0)
                 parameter("sort", "ratingCount:desc")
                 parameter("limit", limit)
@@ -1882,34 +1883,33 @@ class PlexClient(
         server: PlexServer,
         block: suspend (base: String) -> T,
     ): T {
-        apiBaseCache[server.id]?.let { cached ->
+        val cached = baseResolveMutex.withLock { apiBaseCache[server.id] }
+        var lastError: Throwable? = null
+        if (cached != null) {
             try {
                 return block(cached)
             } catch (error: Throwable) {
                 if (error is CancellationException) throw error
-            }
-        }
-        return baseResolveMutex.withLock {
-            apiBaseCache[server.id]?.let { cached ->
-                try {
-                    return@withLock block(cached)
-                } catch (error: Throwable) {
-                    if (error is CancellationException) throw error
+                lastError = error
+                baseResolveMutex.withLock {
+                    if (apiBaseCache[server.id] == cached) {
+                        apiBaseCache.remove(server.id)
+                    }
                 }
             }
-            var lastError: Throwable? = null
-            for (base in server.reachableBaseUris(apiBaseCache[server.id])) {
-                try {
-                    val result = block(base)
-                    apiBaseCache[server.id] = base
-                    return@withLock result
-                } catch (error: Throwable) {
-                    if (error is CancellationException) throw error
-                    lastError = error
-                }
-            }
-            throw lastError ?: IllegalStateException("Could not reach Plex server '${server.name}'")
         }
+        for (base in server.reachableBaseUris(cached)) {
+            if (base == cached) continue
+            try {
+                val result = block(base)
+                baseResolveMutex.withLock { apiBaseCache[server.id] = base }
+                return result
+            } catch (error: Throwable) {
+                if (error is CancellationException) throw error
+                lastError = error
+            }
+        }
+        throw lastError ?: IllegalStateException("Could not reach Plex server '${server.name}'")
     }
 
     private suspend inline fun <reified T> plexGet(server: PlexServer, token: String, path: String): T =
@@ -2240,6 +2240,7 @@ class PlexClient(
         private const val PlexTrackType = 10
         private const val PlexLocalSetupRequestTimeoutMs = 800L
         private const val PlexRemoteSetupRequestTimeoutMs = 8_000L
+        private const val PlexPopularTracksRequestTimeoutMs = 15_000L
         private const val MusicStationsHubContext = "hub.music.stations"
         private const val MusicStationsHubIdentifier = "music.stations"
         val PlexJson = Json {


### PR DESCRIPTION
## Summary
- Drop the library-wide Plex `group=title` popular-tracks query (that grouping can stall PMS) and bound those requests to 15s
- Start mix playback from the Plex response without waiting on catalog SQLite writes, and stop holding the Plex base-resolve lock during the request
- Time out mix seed waits and the home-poster spinner so Popular / Top Tracks cannot load forever

## Test plan
- [x] `:data:catalog:desktopTest --tests "com.phoebe.app.PlexMappingTest.popularTracksFor*"`
- [x] `:composeApp:desktopTest --tests "com.phoebe.app.CatalogRepositoryRefreshDesktopTest.popularSongsForLibrary*"`
- [x] `:composeApp:desktopTest --tests "com.phoebe.app.PopularMixQueueTest"`
- [ ] Tap Popular and Top Tracks on a Plex library and confirm playback starts (or a timeout message) instead of an endless spinner


Made with [Cursor](https://cursor.com)