### PR TITLE
Stop playlist songs from dying on a dead LAN origin

### DIFF
--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackUrlOrigins.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackUrlOrigins.kt
@@ -115,6 +115,61 @@ internal fun nextPlaybackFailoverCandidate(
 
 internal fun isLocalOnlyPlaybackOrigin(url: String): Boolean = isLocalOnlyServerOrigin(url)
 
+internal fun playbackOriginOf(url: String): String? {
+    if (url.isBlank()) return null
+    val parsed = runCatching { Url(url) }.getOrNull() ?: return null
+    if (parsed.protocol.name != "http" && parsed.protocol.name != "https") return null
+    if (parsed.host.isBlank()) return null
+    return "${parsed.protocol.name}://${parsed.host}:${parsed.port}"
+}
+
+/**
+ * Put URLs on [origin] first without inventing hosts. Playlist tracks are stamped with a
+ * LAN-first URL at queue start; after a relay actually works, later songs must not go back
+ * to the dead private address.
+ */
+internal fun Track.preferPlaybackOrigin(origin: String): Track {
+    val preferred = origin.trimEnd('/').takeIf { it.isNotBlank() } ?: return this
+    val candidates = playbackUriCandidates()
+    if (candidates.size <= 1) return this
+    val matching = candidates.filter { candidate ->
+        playbackOriginOf(candidate)?.equals(preferred, ignoreCase = true) == true
+    }
+    if (matching.isEmpty()) return this
+    val rest = candidates.filter { candidate ->
+        playbackOriginOf(candidate)?.equals(preferred, ignoreCase = true) != true
+    }
+    val ordered = matching + rest
+    val nextStream = ordered.first()
+    val nextFallbacks = ordered.drop(1)
+    if (nextStream == streamUrl && nextFallbacks == playbackFallbackUrls) return this
+    return copy(
+        streamUrl = nextStream,
+        playbackFallbackUrls = nextFallbacks,
+    )
+}
+
+internal fun Track.preferPlaybackUri(uri: String): Track {
+    if (uri.isBlank()) return this
+    val origin = playbackOriginOf(uri) ?: return copy(
+        streamUrl = uri,
+        playbackFallbackUrls = playbackUriCandidates().filter { it != uri },
+    )
+    val rest = playbackUriCandidates().filter { it != uri }
+    val sameOrigin = rest.filter { playbackOriginOf(it)?.equals(origin, ignoreCase = true) == true }
+    val others = rest.filter { playbackOriginOf(it)?.equals(origin, ignoreCase = true) != true }
+    val ordered = listOf(uri) + sameOrigin + others
+    if (ordered.first() == streamUrl && ordered.drop(1) == playbackFallbackUrls) return this
+    return copy(
+        streamUrl = ordered.first(),
+        playbackFallbackUrls = ordered.drop(1),
+    )
+}
+
+/** JavaFX/player-engine timeouts on LAN hosts will hang the same way on every engine. */
+internal fun shouldSkipAlternateEngineAfterPlayerTimeout(uri: String): Boolean =
+    uri.isNotBlank() && isLocalOnlyPlaybackOrigin(uri)
+
 fun Track.withPlaybackOrigins(
     preferredOrigin: String?,
     fallbackOrigins: List<String> = emptyList(),

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
@@ -252,6 +252,7 @@ abstract class SimpleAudioPlayer(
     override fun stopPlayback() {
         playGeneration++
         playWhenReady = false
+        stickyPlaybackOrigin = null
         clearCrossfadeRequestState()
         cancelGaplessPrepare()
         resetAudioAnalysis()
@@ -575,6 +576,11 @@ abstract class SimpleAudioPlayer(
         rememberStickyPlaybackOrigin(readyUri)
         val playbackQueue = current.queue.preferStickyPlaybackOrigin()
         val effectivePlaying = isPlaying && playWhenReady
+        if (playbackQueue !== current.queue) {
+            PhoebeLog.d("AudioPlayer") {
+                "playback origin sticky=$stickyPlaybackOrigin rebasedQueue=${playbackQueue.size}"
+            }
+        }
         mutableState.value = current.copy(
             queue = playbackQueue,
             isBuffering = false,
@@ -893,20 +899,16 @@ abstract class SimpleAudioPlayer(
     }
 
     private fun adoptFailoverStreamUrl(uri: String) {
-        rememberStickyPlaybackOrigin(uri)
         val current = mutableState.value
         val index = current.currentIndex
-        val origin = playbackOriginOf(uri)
-        val nextQueue = current.queue.mapIndexed { itemIndex, item ->
-            if (itemIndex == index) item.preferPlaybackUri(uri)
-            else if (origin != null) item.preferPlaybackOrigin(origin)
-            else item
-        }
-        if (nextQueue == current.queue) return
-        PhoebeLog.d("AudioPlayer") {
-            "playback origin sticky=${origin ?: uri} rebasedQueue=${nextQueue.size}"
-        }
-        mutableState.value = current.copy(queue = nextQueue)
+        val track = current.queue.getOrNull(index) ?: return
+        val nextTrack = track.preferPlaybackUri(uri)
+        if (nextTrack === track) return
+        mutableState.value = current.copy(
+            queue = current.queue.mapIndexed { itemIndex, item ->
+                if (itemIndex == index) nextTrack else item
+            },
+        )
     }
 
     private fun rememberStickyPlaybackOrigin(uri: String?) {

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
@@ -46,6 +46,7 @@ abstract class SimpleAudioPlayer(
     private var playGeneration = 0
     private var failoverGeneration = -1
     private val triedPlaybackUris = linkedSetOf<String>()
+    private var stickyPlaybackOrigin: String? = null
     private var crossfadeDurationMs = 0L
     private var crossfadeRequestKey: String? = null
     private var manualSeekCrossfadeSuppression: ManualSeekCrossfadeSuppression? = null
@@ -78,9 +79,10 @@ abstract class SimpleAudioPlayer(
 
     override fun play(queue: List<Track>, startIndex: Int) {
         val previous = mutableState.value
-        val index = startIndex.coerceIn(queue.indices)
-        val track = queue.getOrNull(index)
-        val sameQueue = tracksMatch(previous.queue, queue)
+        val playbackQueue = queue.preferStickyPlaybackOrigin()
+        val index = startIndex.coerceIn(playbackQueue.indices)
+        val track = playbackQueue.getOrNull(index)
+        val sameQueue = tracksMatch(previous.queue, playbackQueue)
 
         val sameCurrentTrack = sameQueue && track != null &&
             previous.currentIndex == index &&
@@ -117,7 +119,7 @@ abstract class SimpleAudioPlayer(
             stopCurrentPlaybackImmediately()
         }
         mutableState.value = previous.copy(
-            queue = queue,
+            queue = playbackQueue,
             currentIndex = if (track == null) -1 else index,
             isPlaying = false,
             isBuffering = track != null,
@@ -134,9 +136,9 @@ abstract class SimpleAudioPlayer(
             if (initialUri.isNotBlank()) notePlaybackUri(initialUri, generation)
             startPlaybackStartupWatchdog(generation)
             if (sameQueue) {
-                skipToInQueueOnPlatform(queue, index, track, generation)
+                skipToInQueueOnPlatform(playbackQueue, index, track, generation)
             } else {
-                playQueueOnPlatform(queue, index, track, generation)
+                playQueueOnPlatform(playbackQueue, index, track, generation)
             }
         }
     }
@@ -262,9 +264,10 @@ abstract class SimpleAudioPlayer(
 
     override fun addToUpNext(track: Track) {
         val state = mutableState.value
-        val deduped = state.queue.filterNot { it.id == track.id }
+        val preferred = listOf(track).preferStickyPlaybackOrigin().first()
+        val deduped = state.queue.filterNot { it.id == preferred.id }
         val insertAt = (state.currentIndex + 1).coerceIn(0, deduped.size)
-        val newQueue = deduped.toMutableList().also { it.add(insertAt, track) }
+        val newQueue = deduped.toMutableList().also { it.add(insertAt, preferred) }
         val newCurrent = if (state.currentIndex < 0) state.currentIndex
         else newQueue.indexOfFirst { it.id == state.currentTrack?.id }.takeIf { it >= 0 } ?: state.currentIndex
         mutableState.value = state.copy(queue = newQueue, currentIndex = newCurrent)
@@ -276,7 +279,7 @@ abstract class SimpleAudioPlayer(
         if (tracks.isEmpty()) return
         val state = mutableState.value
         val existingIds = state.queue.map { it.id }.toMutableSet()
-        val additions = tracks.filter { existingIds.add(it.id) }
+        val additions = tracks.filter { existingIds.add(it.id) }.preferStickyPlaybackOrigin()
         if (additions.isEmpty()) return
         val nextQueue = state.queue + additions
         mutableState.value = state.copy(queue = nextQueue)
@@ -566,8 +569,14 @@ abstract class SimpleAudioPlayer(
         if (!isPlayRequestCurrent(generation)) return
         stopPlaybackStartupWatchdog()
         val current = mutableState.value
+        val readyUri = current.currentTrack?.let { track ->
+            StreamingPlaybackPolicyHolder.resolvePlaybackUri(track).ifBlank { track.streamUrl }
+        }
+        rememberStickyPlaybackOrigin(readyUri)
+        val playbackQueue = current.queue.preferStickyPlaybackOrigin()
         val effectivePlaying = isPlaying && playWhenReady
         mutableState.value = current.copy(
+            queue = playbackQueue,
             isBuffering = false,
             isPlaying = effectivePlaying,
             bufferedPositionMs = current.bufferedPositionMs.coerceAtLeast(current.positionMs),
@@ -884,15 +893,36 @@ abstract class SimpleAudioPlayer(
     }
 
     private fun adoptFailoverStreamUrl(uri: String) {
+        rememberStickyPlaybackOrigin(uri)
         val current = mutableState.value
         val index = current.currentIndex
-        val track = current.queue.getOrNull(index) ?: return
-        if (track.streamUrl == uri) return
-        mutableState.value = current.copy(
-            queue = current.queue.mapIndexed { itemIndex, item ->
-                if (itemIndex == index) item.copy(streamUrl = uri) else item
-            },
-        )
+        val origin = playbackOriginOf(uri)
+        val nextQueue = current.queue.mapIndexed { itemIndex, item ->
+            if (itemIndex == index) item.preferPlaybackUri(uri)
+            else if (origin != null) item.preferPlaybackOrigin(origin)
+            else item
+        }
+        if (nextQueue == current.queue) return
+        PhoebeLog.d("AudioPlayer") {
+            "playback origin sticky=${origin ?: uri} rebasedQueue=${nextQueue.size}"
+        }
+        mutableState.value = current.copy(queue = nextQueue)
+    }
+
+    private fun rememberStickyPlaybackOrigin(uri: String?) {
+        val origin = uri?.let(::playbackOriginOf)?.takeIf { it.isNotBlank() } ?: return
+        stickyPlaybackOrigin = origin
+    }
+
+    private fun List<Track>.preferStickyPlaybackOrigin(): List<Track> {
+        val origin = stickyPlaybackOrigin ?: return this
+        var changed = false
+        val next = map { track ->
+            val preferred = track.preferPlaybackOrigin(origin)
+            if (preferred !== track) changed = true
+            preferred
+        }
+        return if (changed) next else this
     }
 
     protected open val playbackStartupTimeoutMs: Long

--- a/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
@@ -134,6 +134,96 @@ class PlayerStateTest {
     }
 
     @Test
+    fun failoverRebasesLaterQueueTracksOntoTheWorkingOrigin() = runTest {
+        val player = TimeoutTestPlayer(this)
+        val lanOne = "https://172-16-1-2.abc.plex.direct:32400/library/parts/1/file.mp3"
+        val remoteOne = "https://173-230-133-75.abc.plex.direct:8443/library/parts/1/file.mp3"
+        val lanTwo = "https://172-16-1-2.abc.plex.direct:32400/library/parts/2/file.mp3"
+        val remoteTwo = "https://173-230-133-75.abc.plex.direct:8443/library/parts/2/file.mp3"
+        val tracks = listOf(
+            Track(
+                id = "t1",
+                title = "One",
+                artist = "Artist",
+                album = "Album",
+                durationMs = 60_000,
+                streamUrl = lanOne,
+                downloadUrl = "",
+                playbackFallbackUrls = listOf(remoteOne),
+            ),
+            Track(
+                id = "t2",
+                title = "Two",
+                artist = "Artist",
+                album = "Album",
+                durationMs = 60_000,
+                streamUrl = lanTwo,
+                downloadUrl = "",
+                playbackFallbackUrls = listOf(remoteTwo),
+            ),
+        )
+
+        player.play(tracks, 0)
+        advanceTimeBy(player.testStartupTimeoutMs + 1L)
+        runCurrent()
+
+        assertEquals(remoteOne, player.state.value.queue[0].streamUrl)
+        assertEquals(remoteTwo, player.state.value.queue[1].streamUrl)
+
+        player.finishPendingLoad()
+        player.next()
+
+        assertEquals(remoteTwo, player.state.value.currentTrack?.streamUrl)
+        assertEquals(1, player.state.value.currentIndex)
+    }
+
+    @Test
+    fun newPlayRequestsReuseTheOriginThatAlreadyWorked() = runTest {
+        val player = TimeoutTestPlayer(this)
+        val lanOne = "https://172-16-1-2.abc.plex.direct:32400/library/parts/1/file.mp3"
+        val remoteOne = "https://173-230-133-75.abc.plex.direct:8443/library/parts/1/file.mp3"
+        val lanTwo = "https://172-16-1-2.abc.plex.direct:32400/library/parts/2/file.mp3"
+        val remoteTwo = "https://173-230-133-75.abc.plex.direct:8443/library/parts/2/file.mp3"
+
+        player.play(
+            listOf(
+                Track(
+                    id = "t1",
+                    title = "One",
+                    artist = "Artist",
+                    album = "Album",
+                    durationMs = 60_000,
+                    streamUrl = lanOne,
+                    downloadUrl = "",
+                    playbackFallbackUrls = listOf(remoteOne),
+                ),
+            ),
+            0,
+        )
+        advanceTimeBy(player.testStartupTimeoutMs + 1L)
+        runCurrent()
+        player.finishPendingLoad()
+
+        player.play(
+            listOf(
+                Track(
+                    id = "t2",
+                    title = "Two",
+                    artist = "Artist",
+                    album = "Album",
+                    durationMs = 60_000,
+                    streamUrl = lanTwo,
+                    downloadUrl = "",
+                    playbackFallbackUrls = listOf(remoteTwo),
+                ),
+            ),
+            0,
+        )
+
+        assertEquals(remoteTwo, player.state.value.currentTrack?.streamUrl)
+    }
+
+    @Test
     fun startupWatchdogIgnoresSupersededPlayRequests() = runTest {
         val player = TimeoutTestPlayer(this)
         val tracks = listOf(

--- a/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
@@ -168,9 +168,11 @@ class PlayerStateTest {
         runCurrent()
 
         assertEquals(remoteOne, player.state.value.queue[0].streamUrl)
-        assertEquals(remoteTwo, player.state.value.queue[1].streamUrl)
+        assertEquals(lanTwo, player.state.value.queue[1].streamUrl)
 
         player.finishPendingLoad()
+        assertEquals(remoteTwo, player.state.value.queue[1].streamUrl)
+
         player.next()
 
         assertEquals(remoteTwo, player.state.value.currentTrack?.streamUrl)
@@ -221,6 +223,53 @@ class PlayerStateTest {
         )
 
         assertEquals(remoteTwo, player.state.value.currentTrack?.streamUrl)
+    }
+
+    @Test
+    fun stopPlaybackClearsTheStickyOriginSoLanCanBeRediscovered() = runTest {
+        val player = TimeoutTestPlayer(this)
+        val lanOne = "https://172-16-1-2.abc.plex.direct:32400/library/parts/1/file.mp3"
+        val remoteOne = "https://173-230-133-75.abc.plex.direct:8443/library/parts/1/file.mp3"
+        val lanTwo = "https://172-16-1-2.abc.plex.direct:32400/library/parts/2/file.mp3"
+        val remoteTwo = "https://173-230-133-75.abc.plex.direct:8443/library/parts/2/file.mp3"
+
+        player.play(
+            listOf(
+                Track(
+                    id = "t1",
+                    title = "One",
+                    artist = "Artist",
+                    album = "Album",
+                    durationMs = 60_000,
+                    streamUrl = lanOne,
+                    downloadUrl = "",
+                    playbackFallbackUrls = listOf(remoteOne),
+                ),
+            ),
+            0,
+        )
+        advanceTimeBy(player.testStartupTimeoutMs + 1L)
+        runCurrent()
+        player.finishPendingLoad()
+        player.stopPlayback()
+
+        player.play(
+            listOf(
+                Track(
+                    id = "t2",
+                    title = "Two",
+                    artist = "Artist",
+                    album = "Album",
+                    durationMs = 60_000,
+                    streamUrl = lanTwo,
+                    downloadUrl = "",
+                    playbackFallbackUrls = listOf(remoteTwo),
+                ),
+            ),
+            0,
+        )
+
+        assertEquals(lanTwo, player.state.value.currentTrack?.streamUrl)
     }
 
     @Test

--- a/playback/src/commonTest/kotlin/com/phoebe/app/player/PlaybackUrlOriginsTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/player/PlaybackUrlOriginsTest.kt
@@ -166,6 +166,53 @@ class PlaybackUrlOriginsTest {
     }
 
     @Test
+    fun preferPlaybackOriginMovesMatchingRelayFirstWithoutDroppingLanFallback() {
+        val lan = "https://172-16-1-2.abc.plex.direct:32400/library/parts/1/file.mp3"
+        val remote = "https://173-230-133-75.abc.plex.direct:8443/library/parts/1/file.mp3"
+        val track = Track(
+            id = "1",
+            title = "Song",
+            artist = "Artist",
+            album = "Album",
+            durationMs = 180_000,
+            streamUrl = lan,
+            downloadUrl = "",
+            playbackFallbackUrls = listOf(remote),
+        ).preferPlaybackOrigin("https://173-230-133-75.abc.plex.direct:8443")
+
+        assertEquals(remote, track.streamUrl)
+        assertEquals(listOf(lan), track.playbackFallbackUrls)
+    }
+
+    @Test
+    fun preferPlaybackOriginLeavesUnrelatedTracksAlone() {
+        val radio = Track(
+            id = "radio:kexp",
+            title = "KEXP",
+            artist = "Radio",
+            album = "Radio",
+            durationMs = 0,
+            streamUrl = "https://kexp.streamguys1.com/kexp128.mp3",
+            downloadUrl = "",
+        )
+        assertEquals(radio, radio.preferPlaybackOrigin("https://173-230-133-75.abc.plex.direct:8443"))
+    }
+
+    @Test
+    fun playerEngineTimeoutsSkipAlternateEngineOnlyOnLanOrigins() {
+        assertTrue(
+            shouldSkipAlternateEngineAfterPlayerTimeout(
+                "https://172-16-1-2.abc.plex.direct:32400/library/parts/1/file.mp3",
+            ),
+        )
+        assertFalse(
+            shouldSkipAlternateEngineAfterPlayerTimeout(
+                "https://173-230-133-75.abc.plex.direct:8443/library/parts/1/file.mp3",
+            ),
+        )
+    }
+
+    @Test
     fun failoverAfterLanFailureStillTriesRemoteRelays() {
         val lan = "http://192.168.1.9:32400/library/parts/1/file.mp3"
         val remote = "https://45-79-210-225.abc.plex.direct:8443/library/parts/1/file.mp3"

--- a/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
+++ b/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
@@ -1592,6 +1592,14 @@ class DesktopAudioPlayer(
             finishPlaybackFailed(failure, generation)
             return
         }
+        if (failure.isPlayerEngineTimeout && shouldSkipAlternateEngineAfterPlayerTimeout(activeUri)) {
+            PhoebeLog.d("DesktopAudioPlayer") {
+                "skipping alternate engine after JavaFX timeout on local-only origin"
+            }
+            disposeJavaFxBlocking()
+            finishPlaybackFailed(failure, generation)
+            return
+        }
         disposeJavaFxBlocking()
         if (failure.shouldTryAlternateEngine) {
             PhoebeLog.d("DesktopAudioPlayer") {
@@ -1689,9 +1697,10 @@ class DesktopAudioPlayer(
         stop: AtomicBoolean,
         generation: Int,
         mediaReady: AtomicBoolean,
+        timeoutMs: Long,
         onStartupFailed: () -> Unit,
     ) {
-        CompletableFuture.delayedExecutor(JavaFxMediaReadyTimeoutMs, TimeUnit.MILLISECONDS)
+        CompletableFuture.delayedExecutor(timeoutMs, TimeUnit.MILLISECONDS)
             .execute {
                 if (stop.get()) return@execute
                 if (mediaReady.get() || !isPlayRequestCurrent(generation)) return@execute
@@ -1743,14 +1752,16 @@ class DesktopAudioPlayer(
                 }
             }
         }
+        val readyTimeoutMs = DesktopPlaybackStartupPolicy.javaFxMediaReadyTimeoutMs(uri)
         scheduleJavaFxStartupWatchdog(
             stop = watchdogStop,
             generation = generation,
             mediaReady = mediaReady,
+            timeoutMs = readyTimeoutMs,
             onStartupFailed = {
                 failStartup(
                     PlaybackFailureClassifier.fromMessage(
-                        "JavaFX media did not become ready in ${JavaFxMediaReadyTimeoutMs}ms",
+                        "JavaFX media did not become ready in ${readyTimeoutMs}ms",
                         uri,
                     ),
                 )
@@ -3504,7 +3515,6 @@ class DesktopAudioPlayer(
 
     private companion object {
         const val JavaFxEqualizerBandMatchTolerance = 0.045f
-        const val JavaFxMediaReadyTimeoutMs = DesktopPlaybackStartupPolicy.JavaFxFailureFallbackDelayMs
         const val JavaFxMediaPlayingTimeoutMs = 8_000L
         const val JavaFxCrossfadeReadyTimeoutMs = 3_000L
         const val JavaFxGaplessHotStartLeadMs = 180L
@@ -3708,6 +3718,13 @@ private fun normalizedPcmSample(bytes: ByteArray, offset: Int, sampleBytes: Int,
 
 internal object DesktopPlaybackStartupPolicy {
     const val JavaFxFailureFallbackDelayMs = 3_000L
+    const val JavaFxRemoteReadyTimeoutMs = 10_000L
+
+    fun javaFxMediaReadyTimeoutMs(uri: String): Long = when {
+        !isRemoteUri(uri) -> JavaFxFailureFallbackDelayMs
+        isLocalOnlyPlaybackOrigin(uri) -> JavaFxFailureFallbackDelayMs
+        else -> JavaFxRemoteReadyTimeoutMs
+    }
 
     fun isRemoteUri(uri: String): Boolean =
         uri.startsWith("http://", ignoreCase = true) || uri.startsWith("https://", ignoreCase = true)

--- a/playback/src/desktopTest/kotlin/com/phoebe/app/player/DesktopPlaybackStartupPolicyTest.kt
+++ b/playback/src/desktopTest/kotlin/com/phoebe/app/player/DesktopPlaybackStartupPolicyTest.kt
@@ -105,6 +105,26 @@ class DesktopPlaybackStartupPolicyTest {
     }
 
     @Test
+    fun javaFxReadyTimeoutStaysShortOnLanAndLocalFiles() {
+        assertEquals(
+            DesktopPlaybackStartupPolicy.JavaFxFailureFallbackDelayMs,
+            DesktopPlaybackStartupPolicy.javaFxMediaReadyTimeoutMs(
+                "https://172-16-1-2.abc.plex.direct:32400/library/parts/1/file.mp3",
+            ),
+        )
+        assertEquals(
+            DesktopPlaybackStartupPolicy.JavaFxFailureFallbackDelayMs,
+            DesktopPlaybackStartupPolicy.javaFxMediaReadyTimeoutMs("file:///music/song.mp3"),
+        )
+        assertEquals(
+            DesktopPlaybackStartupPolicy.JavaFxRemoteReadyTimeoutMs,
+            DesktopPlaybackStartupPolicy.javaFxMediaReadyTimeoutMs(
+                "https://173-230-133-75.abc.plex.direct:8443/library/parts/1/file.mp3",
+            ),
+        )
+    }
+
+    @Test
     fun knownRemoteFormatsHaveDeterministicInstantStartupPlans() {
         val cases = listOf(
             RemoteStartupCase(


### PR DESCRIPTION
## Summary
- Windows Sentry logs from this afternoon showed every playlist track restarting on `172.16.1.2` even after the previous song had already failed over to a working Plex relay. JavaFX then died at 3s, and the sampled/HTTP fallback burned another ~15s connect timeout before the next origin. After the last origin failed, the queue held — which is why playback just stopped.
- Remember the working relay across the queue and later play requests, fail LAN JavaFX timeouts over immediately instead of trying another engine, and give remote JavaFX 10s to become ready on Windows TLS.

## Test plan
- [ ] Play a Plex playlist from Windows off the server LAN and confirm the first song may pause briefly, then later songs start on the working relay without a long silent gap
- [ ] Skip to the next track after a successful failover and confirm it does not retry `172.16.1.2` / other private plex.direct hosts first
- [ ] On the server LAN, confirm local playback still starts quickly and is not forced through a remote relay
- [ ] `./gradlew :playback:desktopTest --tests com.phoebe.app.player.PlaybackUrlOriginsTest --tests com.phoebe.app.PlayerStateTest --tests com.phoebe.app.player.DesktopPlaybackStartupPolicyTest --tests com.phoebe.app.player.PlaybackFailureTest`


Made with [Cursor](https://cursor.com)