### PR TITLE
Stop Linux package smoke from dying on JavaFX startup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
   version:
     name: Validate and bump version
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     outputs:
       version: ${{ steps.version.outputs.version }}
       version_code: ${{ steps.version.outputs.version_code }}
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Validate and bump version
         id: version

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackUrlOrigins.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackUrlOrigins.kt
@@ -167,8 +167,12 @@ internal fun Track.preferPlaybackUri(uri: String): Track {
 }
 
 /** JavaFX/player-engine timeouts on LAN hosts will hang the same way on every engine. */
-internal fun shouldSkipAlternateEngineAfterPlayerTimeout(uri: String): Boolean =
-    uri.isNotBlank() && isLocalOnlyPlaybackOrigin(uri)
+internal fun shouldSkipAlternateEngineAfterPlayerTimeout(uri: String): Boolean {
+    if (uri.isBlank()) return false
+    val isHttp = uri.startsWith("http://", ignoreCase = true) ||
+        uri.startsWith("https://", ignoreCase = true)
+    return isHttp && isLocalOnlyPlaybackOrigin(uri)
+}
 
 fun Track.withPlaybackOrigins(
     preferredOrigin: String?,

--- a/playback/src/commonTest/kotlin/com/phoebe/app/player/PlaybackFailureTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/player/PlaybackFailureTest.kt
@@ -195,6 +195,10 @@ class PlaybackFailureTest {
             "JavaFX media ready but never started playing",
             streamUri = "http://10.10.0.1:8096/emby/Audio/1/stream",
         )
+        val runtimeTimeout = PlaybackFailureClassifier.fromMessage(
+            "JavaFX runtime did not become ready in 15000ms",
+            streamUri = "file:///music/song.mp3",
+        )
 
         assertEquals(PlaybackFailureKind.Unreachable, timeout.kind)
         assertEquals(PlaybackFailureKind.Unreachable, playingTimeout.kind)
@@ -203,6 +207,8 @@ class PlaybackFailureTest {
         assertTrue(playingTimeout.shouldTryAlternateEngine)
         assertTrue(timeout.isPlayerEngineTimeout)
         assertTrue(timeout.isInfrastructureFailure)
+        assertTrue(runtimeTimeout.isPlayerEngineTimeout)
+        assertTrue(runtimeTimeout.shouldTryAlternateEngine)
     }
 
     @Test

--- a/playback/src/commonTest/kotlin/com/phoebe/app/player/PlaybackUrlOriginsTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/player/PlaybackUrlOriginsTest.kt
@@ -210,6 +210,16 @@ class PlaybackUrlOriginsTest {
                 "https://173-230-133-75.abc.plex.direct:8443/library/parts/1/file.mp3",
             ),
         )
+        assertFalse(
+            shouldSkipAlternateEngineAfterPlayerTimeout(
+                "file:///home/runner/Downloads/phoebe-smoke/wikimedia-example.mp3",
+            ),
+        )
+        assertFalse(
+            shouldSkipAlternateEngineAfterPlayerTimeout(
+                "file:/home/runner/Downloads/phoebe-smoke/wikimedia-example.mp3",
+            ),
+        )
     }
 
     @Test

--- a/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
+++ b/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
@@ -1706,7 +1706,7 @@ class DesktopAudioPlayer(
                 if (mediaReady.get() || !isPlayRequestCurrent(generation)) return@execute
                 stop.set(true)
                 playbackExecutor.execute {
-                    if (!isPlayRequestCurrent(generation)) return@execute
+                    if (stop.get() || mediaReady.get() || !isPlayRequestCurrent(generation)) return@execute
                     disposeJavaFxBlocking()
                     onStartupFailed()
                 }
@@ -1753,28 +1753,43 @@ class DesktopAudioPlayer(
             }
         }
         val readyTimeoutMs = DesktopPlaybackStartupPolicy.javaFxMediaReadyTimeoutMs(uri)
+        scheduleJavaFxStartupWatchdog(
+            stop = watchdogStop,
+            generation = generation,
+            mediaReady = mediaReady,
+            timeoutMs = JavaFxRuntimeStartupTimeoutMs,
+            onStartupFailed = {
+                failStartup(
+                    PlaybackFailureClassifier.fromMessage(
+                        "JavaFX runtime did not become ready in ${JavaFxRuntimeStartupTimeoutMs}ms",
+                        uri,
+                    ),
+                )
+            },
+        )
         JavaFxRuntime.runLater(
             block = {
                 runCatching {
+                    if (startupFailed.get() || !isPlayRequestCurrent(generation)) return@runCatching
                     diagnostics.playbackStartupEvent(PlaybackEnginePath.JavaFxMediaPlayer, "javafx-thread")
                     diagnostics.engineSelected(PlaybackEnginePath.JavaFxMediaPlayer)
-                    // Ready timeout starts here so Platform.startup does not consume it.
-                    if (!watchdogStop.get() && isPlayRequestCurrent(generation)) {
-                        scheduleJavaFxStartupWatchdog(
-                            stop = watchdogStop,
-                            generation = generation,
-                            mediaReady = mediaReady,
-                            timeoutMs = readyTimeoutMs,
-                            onStartupFailed = {
-                                failStartup(
-                                    PlaybackFailureClassifier.fromMessage(
-                                        "JavaFX media did not become ready in ${readyTimeoutMs}ms",
-                                        uri,
-                                    ),
-                                )
-                            },
-                        )
-                    }
+                    cancelJavaFxStartupWatchdog()
+                    val mediaWatchdogStop = AtomicBoolean(false)
+                    javaFxStartupWatchdogStop = mediaWatchdogStop
+                    scheduleJavaFxStartupWatchdog(
+                        stop = mediaWatchdogStop,
+                        generation = generation,
+                        mediaReady = mediaReady,
+                        timeoutMs = readyTimeoutMs,
+                        onStartupFailed = {
+                            failStartup(
+                                PlaybackFailureClassifier.fromMessage(
+                                    "JavaFX media did not become ready in ${readyTimeoutMs}ms",
+                                    uri,
+                                ),
+                            )
+                        },
+                    )
                     val media = Media(uri)
                     diagnostics.playbackStartupEvent(PlaybackEnginePath.JavaFxMediaPlayer, "media-created")
                     val mediaPlayer = MediaPlayer(media)
@@ -3518,6 +3533,7 @@ class DesktopAudioPlayer(
 
     private companion object {
         const val JavaFxEqualizerBandMatchTolerance = 0.045f
+        const val JavaFxRuntimeStartupTimeoutMs = 15_000L
         const val JavaFxMediaPlayingTimeoutMs = 8_000L
         const val JavaFxCrossfadeReadyTimeoutMs = 3_000L
         const val JavaFxGaplessHotStartLeadMs = 180L

--- a/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
+++ b/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
@@ -1753,25 +1753,28 @@ class DesktopAudioPlayer(
             }
         }
         val readyTimeoutMs = DesktopPlaybackStartupPolicy.javaFxMediaReadyTimeoutMs(uri)
-        scheduleJavaFxStartupWatchdog(
-            stop = watchdogStop,
-            generation = generation,
-            mediaReady = mediaReady,
-            timeoutMs = readyTimeoutMs,
-            onStartupFailed = {
-                failStartup(
-                    PlaybackFailureClassifier.fromMessage(
-                        "JavaFX media did not become ready in ${readyTimeoutMs}ms",
-                        uri,
-                    ),
-                )
-            },
-        )
         JavaFxRuntime.runLater(
             block = {
                 runCatching {
                     diagnostics.playbackStartupEvent(PlaybackEnginePath.JavaFxMediaPlayer, "javafx-thread")
                     diagnostics.engineSelected(PlaybackEnginePath.JavaFxMediaPlayer)
+                    // Ready timeout starts here so Platform.startup does not consume it.
+                    if (!watchdogStop.get() && isPlayRequestCurrent(generation)) {
+                        scheduleJavaFxStartupWatchdog(
+                            stop = watchdogStop,
+                            generation = generation,
+                            mediaReady = mediaReady,
+                            timeoutMs = readyTimeoutMs,
+                            onStartupFailed = {
+                                failStartup(
+                                    PlaybackFailureClassifier.fromMessage(
+                                        "JavaFX media did not become ready in ${readyTimeoutMs}ms",
+                                        uri,
+                                    ),
+                                )
+                            },
+                        )
+                    }
                     val media = Media(uri)
                     diagnostics.playbackStartupEvent(PlaybackEnginePath.JavaFxMediaPlayer, "media-created")
                     val mediaPlayer = MediaPlayer(media)


### PR DESCRIPTION
## Summary
- Linux Package Smoke failed after #173 because the 3s JavaFX ready watchdog started before `Platform.startup` finished (3.2s on the runner), so packaged MP3 playback never reached `MediaPlayer`.
- Start that watchdog on the JavaFX thread, keep engine fallback available for `file://` URIs, and give the Release version job a shallow checkout plus a 15-minute timeout so a slow full-history fetch cannot cancel the release.

## Test plan
- [x] `./gradlew :playback:desktopTest --tests PlaybackUrlOriginsTest --tests DesktopPlaybackStartupPolicyTest --tests PlaybackFailureTest`
- [ ] PR Checks green
- [ ] Package Smoke Linux playback green (label `smoke`)
- [ ] Merge to main kicks off Release and creates a GitHub release


Made with [Cursor](https://cursor.com)