### PR TITLE
Limit Plex playlist fetching to audio playlists

### DIFF
--- a/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexClient.kt
+++ b/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexClient.kt
@@ -275,7 +275,8 @@ class PlexClient(
     }
 
     suspend fun playlists(server: PlexServer, token: String): List<Playlist> {
-        val response = plexGet<PlexMediaContainerResponse>(server, token, "/playlists")
+        // Without playlistType, Plex also returns video and photo playlists.
+        val response = plexGet<PlexMediaContainerResponse>(server, token, "/playlists?playlistType=audio")
         return response.mediaContainer.metadata.map {
             val thumb = it.thumb ?: it.composite
             Playlist(

--- a/data/providers/plex/src/commonTest/kotlin/com/phoebe/app/PlexClientPlaylistEndToEndTest.kt
+++ b/data/providers/plex/src/commonTest/kotlin/com/phoebe/app/PlexClientPlaylistEndToEndTest.kt
@@ -187,6 +187,29 @@ class PlexClientPlaylistEndToEndTest {
     }
 
     @Test
+    fun playlistsRequestsAudioPlaylistsOnly() = runTest {
+        var capturedPlaylistType: String? = null
+        val engine = MockEngine { request ->
+            when (request.url.encodedPath) {
+                "/playlists" -> {
+                    capturedPlaylistType = request.url.parameters["playlistType"]
+                    respond(
+                        content = playlistsJson(trackCount = 2),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
+                else -> respond("", HttpStatusCode.NotFound)
+            }
+        }
+        val client = PlexClient(testHttpClient(engine))
+        val server = PlexServer("server", "Plex", "https://plex.example:32400", owned = true)
+        client.playlists(server, "token")
+
+        assertEquals("audio", capturedPlaylistType)
+    }
+
+    @Test
     fun rateItemUsesPutWithDoubledRating() = runTest {
         var capturedMethod: String? = null
         var capturedIdentifier: String? = null


### PR DESCRIPTION
## Problem

`PlexClient.playlists()` requests `GET /playlists` with no `playlistType`, so Plex returns **every** playlist on the server — video and photo playlists included.

Since Phoebe is a music player, those are never useful:

- their items aren't tracks, so they appear as empty playlists in the library
- a catalog sync fetches the contents of each one for nothing

## Fix

Pass `playlistType=audio` and let Plex filter server-side.

```diff
-        val response = plexGet<PlexMediaContainerResponse>(server, token, "/playlists")
+        // Without playlistType, Plex also returns video and photo playlists.
+        val response = plexGet<PlexMediaContainerResponse>(server, token, "/playlists?playlistType=audio")
```

## Testing

Added `playlistsRequestsAudioPlaylistsOnly` to `PlexClientPlaylistEndToEndTest`, asserting the request carries `playlistType=audio`.

Written test-first: it failed with `expected:<audio> but was:<null>` before the change, confirming the parameter was genuinely absent rather than the assertion being wrong.

Existing mocks all match on `request.url.encodedPath`, which excludes the query string, so none of them needed updating.

`:data:providers:plex:desktopTest` and `:data:catalog:desktopTest` pass. Also verified manually against a real Plex server — video playlists no longer appear in the library.

## Deliberately not included

Scoping playlists to a single library. That would mean also passing `sectionID` (note: `sectionID`, not `librarySectionID`), but playlists spanning libraries may well be intentional, so that felt like a separate behavior change rather than part of this fix.
