### PR TITLE
Add a Linux media session via MPRIS

### DIFF
--- a/feature/playback/build.gradle.kts
+++ b/feature/playback/build.gradle.kts
@@ -25,6 +25,8 @@ kotlin {
             dependsOn(filamentMain)
             dependencies {
                 implementation(libs.jnativehook)
+                implementation(libs.dbus.java.core)
+                implementation(libs.dbus.java.transport.native.unixsocket)
             }
         }
         androidMain {

--- a/feature/playback/src/desktopMain/kotlin/com/phoebe/app/feature/playback/GlobalMediaKeysEffect.desktop.kt
+++ b/feature/playback/src/desktopMain/kotlin/com/phoebe/app/feature/playback/GlobalMediaKeysEffect.desktop.kt
@@ -110,9 +110,9 @@ actual fun GlobalMediaKeysEffect(
 
             try {
                 playerFlow
-                    .map { it.toNowPlayingSnapshot() }
+                    .map { it.toNowPlayingSnapshot() to it.volume }
                     .distinctUntilChanged()
-                    .collectLatest { snapshot -> MprisMediaSession.update(snapshot) }
+                    .collectLatest { (snapshot, volume) -> MprisMediaSession.update(snapshot, volume) }
             } finally {
                 MprisMediaSession.shutdown()
             }

--- a/feature/playback/src/desktopMain/kotlin/com/phoebe/app/feature/playback/GlobalMediaKeysEffect.desktop.kt
+++ b/feature/playback/src/desktopMain/kotlin/com/phoebe/app/feature/playback/GlobalMediaKeysEffect.desktop.kt
@@ -3,13 +3,18 @@ package com.phoebe.app.feature.playback
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import com.github.kwhat.jnativehook.GlobalScreen
 import com.github.kwhat.jnativehook.dispatcher.SwingDispatchService
 import com.github.kwhat.jnativehook.keyboard.NativeKeyEvent
 import com.github.kwhat.jnativehook.keyboard.NativeKeyListener
 import com.phoebe.app.domain.PlayerState
 import com.phoebe.app.media.MacMediaSession
+import com.phoebe.app.media.MprisMediaSession
 import com.phoebe.app.media.NowPlayingSnapshot
 import com.phoebe.app.media.loadMacMediaDylib
 import com.phoebe.app.platform.PhoebeLog
@@ -23,6 +28,9 @@ import kotlinx.coroutines.flow.StateFlow
 
 private val isMacOs: Boolean
     get() = System.getProperty("os.name").orEmpty().lowercase().contains("mac")
+
+private val isLinux: Boolean
+    get() = System.getProperty("os.name").orEmpty().lowercase().contains("linux")
 
 @Composable
 actual fun GlobalMediaKeysEffect(
@@ -40,6 +48,10 @@ actual fun GlobalMediaKeysEffect(
     val next = rememberUpdatedState(onNext)
     val previous = rememberUpdatedState(onPrevious)
     val seek = rememberUpdatedState(onSeek)
+
+    // Set when MPRIS cannot register, so the composable falls through to the key hook.
+    // Exactly one path is ever live, so a key press can never be handled twice.
+    var mprisUnavailable by remember { mutableStateOf(false) }
 
     if (isMacOs) {
         LaunchedEffect(playerFlow) {
@@ -79,6 +91,30 @@ actual fun GlobalMediaKeysEffect(
                     }
             } finally {
                 runCatching { MacMediaSession.nativeShutdown() }
+            }
+        }
+    } else if (isLinux && !mprisUnavailable) {
+        LaunchedEffect(playerFlow) {
+            MprisMediaSession.onToggle = { toggle.value.invoke() }
+            MprisMediaSession.onPlay = { play.value.invoke() }
+            MprisMediaSession.onPause = { pause.value.invoke() }
+            MprisMediaSession.onNext = { next.value.invoke() }
+            MprisMediaSession.onPrevious = { previous.value.invoke() }
+            MprisMediaSession.onStop = { pause.value.invoke() }
+            MprisMediaSession.onSeek = { positionMs -> seek.value.invoke(positionMs) }
+
+            if (!MprisMediaSession.connect()) {
+                mprisUnavailable = true
+                return@LaunchedEffect
+            }
+
+            try {
+                playerFlow
+                    .map { it.toNowPlayingSnapshot() }
+                    .distinctUntilChanged()
+                    .collectLatest { snapshot -> MprisMediaSession.update(snapshot) }
+            } finally {
+                MprisMediaSession.shutdown()
             }
         }
     } else {

--- a/feature/playback/src/desktopMain/kotlin/com/phoebe/app/feature/playback/GlobalMediaKeysEffect.desktop.kt
+++ b/feature/playback/src/desktopMain/kotlin/com/phoebe/app/feature/playback/GlobalMediaKeysEffect.desktop.kt
@@ -10,6 +10,7 @@ import com.github.kwhat.jnativehook.keyboard.NativeKeyEvent
 import com.github.kwhat.jnativehook.keyboard.NativeKeyListener
 import com.phoebe.app.domain.PlayerState
 import com.phoebe.app.media.MacMediaSession
+import com.phoebe.app.media.NowPlayingSnapshot
 import com.phoebe.app.media.loadMacMediaDylib
 import com.phoebe.app.platform.PhoebeLog
 import java.util.function.LongConsumer
@@ -22,17 +23,6 @@ import kotlinx.coroutines.flow.StateFlow
 
 private val isMacOs: Boolean
     get() = System.getProperty("os.name").orEmpty().lowercase().contains("mac")
-
-private data class MacNowPlayingSnapshot(
-    val trackId: String,
-    val title: String,
-    val artist: String,
-    val album: String,
-    val artworkUrl: String,
-    val positionBucketMs: Long,
-    val durationMs: Long,
-    val playing: Boolean,
-)
 
 @Composable
 actual fun GlobalMediaKeysEffect(
@@ -74,7 +64,7 @@ actual fun GlobalMediaKeysEffect(
             }
             try {
                 playerFlow
-                    .map { it.toMacNowPlayingSnapshot() }
+                    .map { it.toNowPlayingSnapshot() }
                     .distinctUntilChanged()
                     .collectLatest { snapshot ->
                         MacMediaSession.nativeUpdateNowPlaying(
@@ -149,14 +139,14 @@ actual fun GlobalMediaKeysEffect(
     }
 }
 
-private fun PlayerState.toMacNowPlayingSnapshot(): MacNowPlayingSnapshot {
+internal fun PlayerState.toNowPlayingSnapshot(): NowPlayingSnapshot {
     val track = currentTrack
     val durationMs = when {
         this.durationMs > 0L -> this.durationMs
         track != null && track.durationMs > 0L -> track.durationMs
         else -> 0L
     }
-    return MacNowPlayingSnapshot(
+    return NowPlayingSnapshot(
         trackId = track?.id.orEmpty(),
         title = track?.title.orEmpty(),
         artist = track?.artist.orEmpty(),

--- a/feature/playback/src/desktopMain/kotlin/com/phoebe/app/media/MprisMediaSession.kt
+++ b/feature/playback/src/desktopMain/kotlin/com/phoebe/app/media/MprisMediaSession.kt
@@ -178,9 +178,20 @@ internal object MprisMediaSession : MediaPlayer2, MediaPlayer2Player, Properties
 
     // --- org.freedesktop.DBus.Properties ---
 
+    /**
+     * Returns the Variant itself rather than its value. Unwrapping here looks harmless
+     * but breaks Metadata: dbus-java would have to re-wrap a plain Map for the reply,
+     * cannot infer a signature for one, and fails with "Can't wrap class
+     * java.util.LinkedHashMap in an unqualified Variant". The Variants built in
+     * [GetAll] already carry their signatures, so passing them through preserves it.
+     *
+     * Clients differ in which they call, so this is easy to miss: playerctl reads
+     * GetAll and works either way, while swayosd reads Get and silently falls back to
+     * an icon with no track information.
+     */
     @Suppress("UNCHECKED_CAST")
     override fun <A : Any?> Get(interfaceName: String, propertyName: String): A =
-        GetAll(interfaceName)[propertyName]?.value as A
+        GetAll(interfaceName)[propertyName] as A
 
     override fun <A : Any?> Set(interfaceName: String, propertyName: String, value: A) {
         // Volume is the only writable property MPRIS defines on Player, and it is

--- a/feature/playback/src/desktopMain/kotlin/com/phoebe/app/media/MprisMediaSession.kt
+++ b/feature/playback/src/desktopMain/kotlin/com/phoebe/app/media/MprisMediaSession.kt
@@ -65,6 +65,13 @@ internal object MprisMediaSession : MediaPlayer2, MediaPlayer2Player, Properties
 
     @Volatile private var snapshot: NowPlayingSnapshot? = null
 
+    /**
+     * Reported through the Volume property. Kept separate from [NowPlayingSnapshot] so
+     * the macOS session, which shares that type and has no notion of volume, does not
+     * start emitting updates every time the volume changes.
+     */
+    @Volatile private var volume: Double = 1.0
+
     override fun getObjectPath(): String = OBJECT_PATH
 
     override fun isRemote(): Boolean = false
@@ -96,9 +103,10 @@ internal object MprisMediaSession : MediaPlayer2, MediaPlayer2Player, Properties
         }
     }
 
-    fun update(newSnapshot: NowPlayingSnapshot) {
+    fun update(newSnapshot: NowPlayingSnapshot, newVolume: Float) {
         val previous = snapshot
         snapshot = newSnapshot
+        volume = newVolume.toDouble().coerceIn(0.0, 1.0)
         val conn = connection ?: return
 
         // Everything here runs inside the guard, including building the Variants:
@@ -108,6 +116,7 @@ internal object MprisMediaSession : MediaPlayer2, MediaPlayer2Player, Properties
             val changed: Map<String, Variant<*>> = mapOf(
                 "Metadata" to metadataVariant(newSnapshot),
                 "PlaybackStatus" to Variant(MprisMetadata.playbackStatus(newSnapshot.playing)),
+                "Volume" to Variant(volume),
             )
             conn.sendMessage(Properties.PropertiesChanged(OBJECT_PATH, PLAYER_IFACE, changed, emptyList()))
         }.onFailure { e ->
@@ -174,8 +183,14 @@ internal object MprisMediaSession : MediaPlayer2, MediaPlayer2Player, Properties
         GetAll(interfaceName)[propertyName]?.value as A
 
     override fun <A : Any?> Set(interfaceName: String, propertyName: String, value: A) {
-        // Volume is the only writable property advertised and Phoebe's volume is not
-        // wired through here, so accept and ignore rather than raising an error.
+        // Volume is the only writable property MPRIS defines on Player, and it is
+        // reported accurately above but not settable: routing a write back into
+        // playback would mean threading a volume callback through
+        // GlobalMediaKeysEffect, whose signature is expect/actual across four
+        // platforms. In practice compositors bind the volume keys to the system mixer
+        // rather than to a player, so this path is rarely exercised. Accepted and
+        // ignored rather than raising an error; see the PR discussion for whether it
+        // is worth wiring.
     }
 
     override fun GetAll(interfaceName: String): MutableMap<String, Variant<*>> {
@@ -195,7 +210,7 @@ internal object MprisMediaSession : MediaPlayer2, MediaPlayer2Player, Properties
                 "PlaybackStatus" to Variant(MprisMetadata.playbackStatus(current?.playing == true)),
                 "Metadata" to metadataVariant(current),
                 "Position" to Variant(MprisMetadata.positionMicros(current?.positionBucketMs ?: 0L)),
-                "Volume" to Variant(1.0),
+                "Volume" to Variant(volume),
                 "Rate" to Variant(1.0),
                 "MinimumRate" to Variant(1.0),
                 "MaximumRate" to Variant(1.0),

--- a/feature/playback/src/desktopMain/kotlin/com/phoebe/app/media/MprisMediaSession.kt
+++ b/feature/playback/src/desktopMain/kotlin/com/phoebe/app/media/MprisMediaSession.kt
@@ -101,12 +101,14 @@ internal object MprisMediaSession : MediaPlayer2, MediaPlayer2Player, Properties
         snapshot = newSnapshot
         val conn = connection ?: return
 
-        val changed: Map<String, Variant<*>> = mapOf(
-            "Metadata" to Variant(MprisMetadata.metadata(newSnapshot).toVariantMap()),
-            "PlaybackStatus" to Variant(MprisMetadata.playbackStatus(newSnapshot.playing)),
-        )
-
+        // Everything here runs inside the guard, including building the Variants:
+        // constructing one can throw, and this is called from a flow collector, so an
+        // escaping exception would surface to the user as a failed playback update.
         runCatching {
+            val changed: Map<String, Variant<*>> = mapOf(
+                "Metadata" to metadataVariant(newSnapshot),
+                "PlaybackStatus" to Variant(MprisMetadata.playbackStatus(newSnapshot.playing)),
+            )
             conn.sendMessage(Properties.PropertiesChanged(OBJECT_PATH, PLAYER_IFACE, changed, emptyList()))
         }.onFailure { e ->
             PhoebeLog.d("Phoebe") { "MPRIS property signal failed: ${e.message}" }
@@ -185,15 +187,13 @@ internal object MprisMediaSession : MediaPlayer2, MediaPlayer2Player, Properties
                 "CanRaise" to Variant(true),
                 "CanQuit" to Variant(true),
                 "HasTrackList" to Variant(false),
-                "SupportedUriSchemes" to Variant(arrayOf<String>()),
-                "SupportedMimeTypes" to Variant(arrayOf<String>()),
+                "SupportedUriSchemes" to Variant(arrayOf<String>(), "as"),
+                "SupportedMimeTypes" to Variant(arrayOf<String>(), "as"),
             )
 
             PLAYER_IFACE -> mutableMapOf(
                 "PlaybackStatus" to Variant(MprisMetadata.playbackStatus(current?.playing == true)),
-                "Metadata" to Variant(
-                    (current?.let { MprisMetadata.metadata(it) } ?: emptyMap()).toVariantMap(),
-                ),
+                "Metadata" to metadataVariant(current),
                 "Position" to Variant(MprisMetadata.positionMicros(current?.positionBucketMs ?: 0L)),
                 "Volume" to Variant(1.0),
                 "Rate" to Variant(1.0),
@@ -212,5 +212,24 @@ internal object MprisMediaSession : MediaPlayer2, MediaPlayer2Player, Properties
     }
 }
 
+/**
+ * A Map carries no signature dbus-java can infer, so it has to be spelled out. An
+ * unqualified `Variant(map)` throws "Can't wrap class java.util.LinkedHashMap in an
+ * unqualified Variant".
+ */
+private fun metadataVariant(snapshot: NowPlayingSnapshot?): Variant<*> =
+    Variant((snapshot?.let { MprisMetadata.metadata(it) } ?: emptyMap()).toVariantMap(), "a{sv}")
+
+/**
+ * Wraps metadata values as Variants, spelling out the signature wherever dbus-java
+ * cannot infer one. Plain strings, longs and booleans infer fine; collections do not,
+ * and mpris:trackid is an object path rather than a string per the MPRIS spec.
+ */
 private fun Map<String, Any>.toVariantMap(): MutableMap<String, Variant<*>> =
-    entries.associateTo(mutableMapOf()) { (k, v) -> k to Variant(v) }
+    entries.associateTo(mutableMapOf()) { (key, value) ->
+        key to when {
+            key == "mpris:trackid" -> Variant(DBusPath(value as String), "o")
+            value is List<*> -> Variant(value.map(Any?::toString).toTypedArray(), "as")
+            else -> Variant(value)
+        }
+    }

--- a/feature/playback/src/desktopMain/kotlin/com/phoebe/app/media/MprisMediaSession.kt
+++ b/feature/playback/src/desktopMain/kotlin/com/phoebe/app/media/MprisMediaSession.kt
@@ -1,0 +1,216 @@
+package com.phoebe.app.media
+
+import com.phoebe.app.platform.PhoebeLog
+import org.freedesktop.dbus.DBusPath
+import org.freedesktop.dbus.annotations.DBusInterfaceName
+import org.freedesktop.dbus.connections.impl.DBusConnection
+import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder
+import org.freedesktop.dbus.interfaces.DBusInterface
+import org.freedesktop.dbus.interfaces.Properties
+import org.freedesktop.dbus.messages.DBusSignal
+import org.freedesktop.dbus.types.Variant
+import kotlin.math.abs
+
+private const val OBJECT_PATH = "/org/mpris/MediaPlayer2"
+private const val ROOT_IFACE = "org.mpris.MediaPlayer2"
+private const val PLAYER_IFACE = "org.mpris.MediaPlayer2.Player"
+
+@DBusInterfaceName(ROOT_IFACE)
+internal interface MediaPlayer2 : DBusInterface {
+    fun Raise()
+    fun Quit()
+}
+
+@DBusInterfaceName(PLAYER_IFACE)
+internal interface MediaPlayer2Player : DBusInterface {
+    fun Next()
+    fun Previous()
+    fun Pause()
+    fun PlayPause()
+    fun Stop()
+    fun Play()
+    fun Seek(offsetMicros: Long)
+    fun SetPosition(trackId: DBusPath, positionMicros: Long)
+
+    /**
+     * org.mpris.MediaPlayer2.Player.Seeked, emitted only on a position discontinuity.
+     *
+     * Nested inside the interface deliberately: dbus-java derives a signal's D-Bus
+     * interface name from its enclosing type, so a top-level class would be advertised
+     * under the wrong interface and clients would never see it.
+     */
+    class Seeked(path: String, val positionMicros: Long) : DBusSignal(path, positionMicros)
+}
+
+/**
+ * Linux media session over MPRIS.
+ *
+ * Compositors route XF86Audio* keys to the MPRIS bus name rather than delivering them
+ * to the focused window, which is why a raw X11 key hook cannot work on Wayland.
+ * Mirrors [MacMediaSession]'s handler-property shape.
+ */
+internal object MprisMediaSession : MediaPlayer2, MediaPlayer2Player, Properties {
+
+    @Volatile var onToggle: () -> Unit = {}
+    @Volatile var onPlay: () -> Unit = {}
+    @Volatile var onPause: () -> Unit = {}
+    @Volatile var onNext: () -> Unit = {}
+    @Volatile var onPrevious: () -> Unit = {}
+    @Volatile var onStop: () -> Unit = {}
+    @Volatile var onSeek: (Long) -> Unit = {}
+    @Volatile var onRaise: () -> Unit = {}
+    @Volatile var onQuit: () -> Unit = {}
+
+    private var connection: DBusConnection? = null
+
+    @Volatile private var snapshot: NowPlayingSnapshot? = null
+
+    override fun getObjectPath(): String = OBJECT_PATH
+
+    override fun isRemote(): Boolean = false
+
+    /**
+     * Attempts to own the MPRIS bus name. Returns false when there is no session bus to
+     * connect to, which is expected on headless machines and inside sandboxes; the
+     * caller falls back to the global key hook in that case.
+     */
+    fun connect(): Boolean {
+        if (connection != null) return true
+        return runCatching {
+            val conn = DBusConnectionBuilder.forSessionBus().build()
+            conn.exportObject(OBJECT_PATH, this)
+
+            runCatching {
+                conn.requestBusName("org.mpris.MediaPlayer2.phoebe")
+            }.onFailure {
+                // Another Phoebe already owns the well-known name. The spec allows a
+                // per-instance name, so a second window stays controllable.
+                conn.requestBusName("org.mpris.MediaPlayer2.phoebe.instance${ProcessHandle.current().pid()}")
+            }
+
+            connection = conn
+            true
+        }.getOrElse { e ->
+            PhoebeLog.d("Phoebe") { "MPRIS unavailable, falling back to key hook: ${e.message}" }
+            false
+        }
+    }
+
+    fun update(newSnapshot: NowPlayingSnapshot) {
+        val previous = snapshot
+        snapshot = newSnapshot
+        val conn = connection ?: return
+
+        val changed: Map<String, Variant<*>> = mapOf(
+            "Metadata" to Variant(MprisMetadata.metadata(newSnapshot).toVariantMap()),
+            "PlaybackStatus" to Variant(MprisMetadata.playbackStatus(newSnapshot.playing)),
+        )
+
+        runCatching {
+            conn.sendMessage(Properties.PropertiesChanged(OBJECT_PATH, PLAYER_IFACE, changed, emptyList()))
+        }.onFailure { e ->
+            PhoebeLog.d("Phoebe") { "MPRIS property signal failed: ${e.message}" }
+        }
+
+        // Seeked announces a discontinuity, not smooth progress, so only emit when the
+        // position jumps within the same track.
+        val jumped = previous != null &&
+            previous.trackId == newSnapshot.trackId &&
+            abs(newSnapshot.positionBucketMs - previous.positionBucketMs) > 2L
+        if (jumped) {
+            runCatching {
+                conn.sendMessage(
+                    MediaPlayer2Player.Seeked(
+                        OBJECT_PATH,
+                        MprisMetadata.positionMicros(newSnapshot.positionBucketMs),
+                    ),
+                )
+            }
+        }
+    }
+
+    fun shutdown() {
+        runCatching { connection?.disconnect() }
+        connection = null
+        snapshot = null
+    }
+
+    // --- org.mpris.MediaPlayer2 ---
+
+    override fun Raise() = onRaise()
+
+    override fun Quit() = onQuit()
+
+    // --- org.mpris.MediaPlayer2.Player ---
+
+    override fun Next() = onNext()
+
+    override fun Previous() = onPrevious()
+
+    override fun Pause() = onPause()
+
+    override fun PlayPause() = onToggle()
+
+    override fun Stop() = onStop()
+
+    override fun Play() = onPlay()
+
+    override fun Seek(offsetMicros: Long) {
+        val current = snapshot ?: return
+        val target = MprisMetadata.positionMicros(current.positionBucketMs) + offsetMicros
+        onSeek(target.coerceAtLeast(0L) / 1_000L)
+    }
+
+    override fun SetPosition(trackId: DBusPath, positionMicros: Long) {
+        onSeek(positionMicros.coerceAtLeast(0L) / 1_000L)
+    }
+
+    // --- org.freedesktop.DBus.Properties ---
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <A : Any?> Get(interfaceName: String, propertyName: String): A =
+        GetAll(interfaceName)[propertyName]?.value as A
+
+    override fun <A : Any?> Set(interfaceName: String, propertyName: String, value: A) {
+        // Volume is the only writable property advertised and Phoebe's volume is not
+        // wired through here, so accept and ignore rather than raising an error.
+    }
+
+    override fun GetAll(interfaceName: String): MutableMap<String, Variant<*>> {
+        val current = snapshot
+        return when (interfaceName) {
+            ROOT_IFACE -> mutableMapOf(
+                "Identity" to Variant("Phoebe"),
+                "DesktopEntry" to Variant("phoebe"),
+                "CanRaise" to Variant(true),
+                "CanQuit" to Variant(true),
+                "HasTrackList" to Variant(false),
+                "SupportedUriSchemes" to Variant(arrayOf<String>()),
+                "SupportedMimeTypes" to Variant(arrayOf<String>()),
+            )
+
+            PLAYER_IFACE -> mutableMapOf(
+                "PlaybackStatus" to Variant(MprisMetadata.playbackStatus(current?.playing == true)),
+                "Metadata" to Variant(
+                    (current?.let { MprisMetadata.metadata(it) } ?: emptyMap()).toVariantMap(),
+                ),
+                "Position" to Variant(MprisMetadata.positionMicros(current?.positionBucketMs ?: 0L)),
+                "Volume" to Variant(1.0),
+                "Rate" to Variant(1.0),
+                "MinimumRate" to Variant(1.0),
+                "MaximumRate" to Variant(1.0),
+                "CanGoNext" to Variant(true),
+                "CanGoPrevious" to Variant(true),
+                "CanPlay" to Variant(true),
+                "CanPause" to Variant(true),
+                "CanSeek" to Variant(true),
+                "CanControl" to Variant(true),
+            )
+
+            else -> mutableMapOf()
+        }
+    }
+}
+
+private fun Map<String, Any>.toVariantMap(): MutableMap<String, Variant<*>> =
+    entries.associateTo(mutableMapOf()) { (k, v) -> k to Variant(v) }

--- a/feature/playback/src/desktopMain/kotlin/com/phoebe/app/media/MprisMetadata.kt
+++ b/feature/playback/src/desktopMain/kotlin/com/phoebe/app/media/MprisMetadata.kt
@@ -1,0 +1,39 @@
+package com.phoebe.app.media
+
+/**
+ * Pure mapping from [NowPlayingSnapshot] to MPRIS metadata values.
+ *
+ * Deliberately free of dbus-java types so it can be unit tested without a session bus;
+ * [MprisMediaSession] wraps these values in Variants at the boundary.
+ */
+internal object MprisMetadata {
+    private const val TRACK_PATH_PREFIX = "/com/phoebe/app/track/"
+
+    /** MPRIS PlaybackStatus. The spec defines exactly "Playing", "Paused", "Stopped". */
+    fun playbackStatus(playing: Boolean): String = if (playing) "Playing" else "Paused"
+
+    /** mpris:length is microseconds; [durationMs] is milliseconds. */
+    fun lengthMicros(durationMs: Long): Long = durationMs * 1_000L
+
+    /** Position is microseconds; [positionBucketMs] is seconds despite its name. */
+    fun positionMicros(positionBucketMs: Long): Long = positionBucketMs * 1_000_000L
+
+    /**
+     * D-Bus object paths accept only [A-Za-z0-9_] between slashes, so provider ids such
+     * as "plex://library/metadata/1234" cannot be used verbatim.
+     */
+    fun trackIdPath(trackId: String): String {
+        if (trackId.isBlank()) return "${TRACK_PATH_PREFIX}NoTrack"
+        val sanitized = trackId.map { if (it.isLetterOrDigit()) it else '_' }.joinToString("")
+        return "$TRACK_PATH_PREFIX$sanitized"
+    }
+
+    fun metadata(snapshot: NowPlayingSnapshot): Map<String, Any> = buildMap {
+        put("mpris:trackid", trackIdPath(snapshot.trackId))
+        put("xesam:title", snapshot.title)
+        if (snapshot.durationMs > 0L) put("mpris:length", lengthMicros(snapshot.durationMs))
+        if (snapshot.artworkUrl.isNotBlank()) put("mpris:artUrl", snapshot.artworkUrl)
+        if (snapshot.artist.isNotBlank()) put("xesam:artist", listOf(snapshot.artist))
+        if (snapshot.album.isNotBlank()) put("xesam:album", snapshot.album)
+    }
+}

--- a/feature/playback/src/desktopMain/kotlin/com/phoebe/app/media/NowPlayingSnapshot.kt
+++ b/feature/playback/src/desktopMain/kotlin/com/phoebe/app/media/NowPlayingSnapshot.kt
@@ -1,0 +1,20 @@
+package com.phoebe.app.media
+
+/**
+ * Platform-neutral now-playing state, shared by the macOS media session and the Linux
+ * MPRIS session.
+ *
+ * Note that the units are not uniform: [positionBucketMs] holds **seconds**, quantised
+ * from milliseconds so repeated position updates do not defeat `distinctUntilChanged`,
+ * while [durationMs] holds milliseconds.
+ */
+internal data class NowPlayingSnapshot(
+    val trackId: String,
+    val title: String,
+    val artist: String,
+    val album: String,
+    val artworkUrl: String,
+    val positionBucketMs: Long,
+    val durationMs: Long,
+    val playing: Boolean,
+)

--- a/feature/playback/src/desktopTest/kotlin/com/phoebe/app/media/MprisMetadataTest.kt
+++ b/feature/playback/src/desktopTest/kotlin/com/phoebe/app/media/MprisMetadataTest.kt
@@ -1,0 +1,95 @@
+package com.phoebe.app.media
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MprisMetadataTest {
+    private fun snapshot(
+        trackId: String = "track-42",
+        title: String = "Blue Monday",
+        artist: String = "New Order",
+        album: String = "Power, Corruption & Lies",
+        artworkUrl: String = "https://plex.example/art.jpg",
+        positionBucketMs: Long = 90L,
+        durationMs: Long = 450_000L,
+        playing: Boolean = true,
+    ) = NowPlayingSnapshot(
+        trackId = trackId,
+        title = title,
+        artist = artist,
+        album = album,
+        artworkUrl = artworkUrl,
+        positionBucketMs = positionBucketMs,
+        durationMs = durationMs,
+        playing = playing,
+    )
+
+    @Test
+    fun playbackStatusUsesSpecCasing() {
+        assertEquals("Playing", MprisMetadata.playbackStatus(playing = true))
+        assertEquals("Paused", MprisMetadata.playbackStatus(playing = false))
+    }
+
+    @Test
+    fun lengthConvertsMillisecondsToMicroseconds() {
+        assertEquals(450_000_000L, MprisMetadata.lengthMicros(450_000L))
+        assertEquals(0L, MprisMetadata.lengthMicros(0L))
+    }
+
+    @Test
+    fun positionConvertsSecondsToMicroseconds() {
+        // positionBucketMs holds seconds despite its name.
+        assertEquals(90_000_000L, MprisMetadata.positionMicros(90L))
+        assertEquals(0L, MprisMetadata.positionMicros(0L))
+    }
+
+    @Test
+    fun trackIdPathIsAValidObjectPath() {
+        val path = MprisMetadata.trackIdPath("track-42")
+        assertTrue(path.startsWith("/com/phoebe/app/track/"))
+        assertTrue(path.all { it.isLetterOrDigit() || it == '/' || it == '_' })
+    }
+
+    @Test
+    fun trackIdPathSanitizesCharactersIllegalInObjectPaths() {
+        val path = MprisMetadata.trackIdPath("plex://library/metadata/1234")
+        assertFalse(path.contains(':'))
+        assertFalse(path.contains('-'))
+        assertTrue(path.all { it.isLetterOrDigit() || it == '/' || it == '_' })
+    }
+
+    @Test
+    fun trackIdPathFallsBackWhenTrackIdIsBlank() {
+        assertEquals("/com/phoebe/app/track/NoTrack", MprisMetadata.trackIdPath(""))
+    }
+
+    @Test
+    fun metadataMapsEveryPopulatedField() {
+        val m = MprisMetadata.metadata(snapshot())
+        assertEquals("/com/phoebe/app/track/track_42", m["mpris:trackid"])
+        assertEquals(450_000_000L, m["mpris:length"])
+        assertEquals("https://plex.example/art.jpg", m["mpris:artUrl"])
+        assertEquals("Blue Monday", m["xesam:title"])
+        assertEquals(listOf("New Order"), m["xesam:artist"])
+        assertEquals("Power, Corruption & Lies", m["xesam:album"])
+    }
+
+    @Test
+    fun metadataOmitsBlankOptionalFields() {
+        val m = MprisMetadata.metadata(snapshot(artworkUrl = "", album = "", artist = ""))
+        assertFalse(m.containsKey("mpris:artUrl"))
+        assertFalse(m.containsKey("xesam:album"))
+        assertFalse(m.containsKey("xesam:artist"))
+        // trackid and title are always present so clients always have something to show.
+        assertTrue(m.containsKey("mpris:trackid"))
+        assertTrue(m.containsKey("xesam:title"))
+    }
+
+    @Test
+    fun metadataOmitsLengthWhenDurationUnknown() {
+        val m = MprisMetadata.metadata(snapshot(durationMs = 0L))
+        assertFalse(m.containsKey("mpris:length"))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ junit = "4.13.2"
 javafx = "21.0.11"
 jaudiotagger = "3.0.1"
 jnativehook = "2.2.2"
+dbus-java = "5.1.1"
 filamentKmp = "0.1.3-beta02"
 jna = "5.18.1"
 soundlibs-mp3spi = "1.9.5.4"
@@ -109,6 +110,8 @@ serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-jso
 junit = { module = "junit:junit", version.ref = "junit" }
 jaudiotagger = { module = "net.jthink:jaudiotagger", version.ref = "jaudiotagger" }
 jnativehook = { module = "com.github.kwhat:jnativehook", version.ref = "jnativehook" }
+dbus-java-core = { module = "com.github.hypfvieh:dbus-java-core", version.ref = "dbus-java" }
+dbus-java-transport-native-unixsocket = { module = "com.github.hypfvieh:dbus-java-transport-native-unixsocket", version.ref = "dbus-java" }
 filament-compose = { module = "io.github.erkko68.filament:filament-compose", version.ref = "filamentKmp" }
 jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 jna-platform = { module = "net.java.dev.jna:jna-platform", version.ref = "jna" }


### PR DESCRIPTION
## Problem

Phoebe has no Linux media session. `GlobalMediaKeysEffect.desktop.kt` branches on `isMacOs`: macOS gets a real OS-level session via `MacMediaSession`, and every other desktop platform falls back to `DesktopGlobalMediaKeyHook`, a JNativeHook global key hook reading raw X11 key events.

**That fallback cannot work on Wayland.** The compositor binds `XF86Audio*` itself and never delivers those keys to XWayland clients, so JNativeHook never sees them. On Hyprland it fails loudly at startup:

```
SEVERE: load_input_helper [1827]: XkbGetKeyboard failed to locate a valid keyboard!
```

The mechanism Linux desktops actually use is MPRIS — the `org.mpris.MediaPlayer2` D-Bus interfaces. It's how compositors route media keys, how `playerctl` works, and how status bars show now-playing.

## Approach

A Linux branch mirroring the existing macOS one, in the same directory and with the same shape.

- `MprisMediaSession` owns the D-Bus connection and exports `org.mpris.MediaPlayer2` and `.Player`, using the same assignable-handler pattern as `MacMediaSession`.
- `MprisMetadata` holds the snapshot → metadata mapping as **pure functions**, deliberately free of dbus-java types so it can be tested without a session bus.
- `MacNowPlayingSnapshot` is lifted to `NowPlayingSnapshot`, since MPRIS needs exactly the fields the macOS path already produces.

Inbound D-Bus calls invoke the callbacks the existing paths already use, so **no playback logic changes**.

### Fallback

MPRIS is attempted first on Linux; if `connect()` fails — no session bus, headless, sandbox — it falls through to the JNativeHook hook. Exactly one path is ever live, so a key press can never be handled twice, and behavior is unchanged anywhere MPRIS can't work. macOS and Windows are untouched.

### Dependency

`dbus-java-core` + `dbus-java-transport-native-unixsocket`.

The transport choice is deliberate: it uses the JEP 380 Unix domain socket API from `java.base`, so it adds **no native libraries**. The `jnr-unixsocket` alternative ships JNI objects inside a jar, which then have to be extracted and resolved at runtime — worth avoiding in a jpackage'd app.

## Testing

`MprisMetadataTest` — 9 tests covering the unit conversions that are easy to get wrong (`mpris:length` and `Position` are microseconds, while the snapshot holds milliseconds and *seconds* respectively) and D-Bus object-path sanitisation, since provider ids like `plex://library/metadata/1234` can't be used verbatim.

Verified manually against a real Plex server on Hyprland:

| Check | Result |
| --- | --- |
| `playerctl -l` | `phoebe` |
| `playerctl -p phoebe status` | `Paused` / `Playing` |
| `playerctl -p phoebe metadata` | title, artist, album, artUrl correct; `mpris:length` `201848000`µs = 3m21s matches the track |
| `playerctl -p phoebe volume` | `0.700000`, matching the real setting |
| `playerctl -p phoebe play-pause` / `next` / `previous` | work |
| **Hardware media keys with the window unfocused** | **work** |
| Same keys with the window focused | no double-toggle |

`:feature:playback:desktopTest` passes.

`:composeApp:desktopTest` has one failure, `MobileSignInWelcomeScreenTest > expandingProvidersScrollsProviderChoicesIntoView`. It **also fails on unmodified `main`** in a separate clean checkout on the same machine, so it looks environment-specific (a layout-sensitive scroll assertion) rather than related to this change.

## Open question: writable Volume

`Volume` is **reported** accurately rather than hardcoded, so a status bar reading the property shows the true value.

It is not **settable**. MPRIS defines `Volume` as read/write, but routing a write back into playback would mean threading a volume callback through `GlobalMediaKeysEffect`, whose signature is `expect`/`actual` across Android, iOS, web and desktop — well beyond the scope of media keys. In practice compositors bind the volume keys to the system mixer rather than to a player, so this path is rarely exercised.

Flagged rather than decided — happy to wire it here if you'd prefer, or leave it for a follow-up.

Worth noting this isn't a regression relative to macOS, which has no volume support at all. The difference is that `MPRemoteCommandCenter` lets you register only the commands you support, whereas MPRIS makes `Volume` a mandatory property, so something has to be reported.

## Not included

**Desktop notifications on track change.** A separate gap, mentioned only because it's adjacent: the only desktop notification code is `DownloadNotifier`, which fires on finished downloads and uses AWT `SystemTray` — X11-only, so it silently no-ops on Wayland. Nothing notifies on track change on any desktop platform. Happy to look at that separately if it's of interest.
