### PR TITLE
Fix desktop Chromecast discovery on macOS

### DIFF
--- a/composeApp/desktop/macos/Phoebe.entitlements
+++ b/composeApp/desktop/macos/Phoebe.entitlements
@@ -10,5 +10,7 @@
     <true/>
     <key>com.apple.security.network.client</key>
     <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
 </dict>
 </plist>

--- a/composeApp/src/desktopMain/kotlin/com/phoebe/app/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/phoebe/app/Main.kt
@@ -22,6 +22,7 @@ import com.phoebe.app.platform.configureWindowsDesktopRendering
 import com.phoebe.app.platform.WindowsUndecoratedWindowSupport
 import com.phoebe.app.platform.appDisplayName
 import com.phoebe.app.platform.isDebugBuild
+import com.phoebe.app.player.configureDesktopChromecastNetworking
 import com.phoebe.app.ui.DesktopWindowTitleBar
 import com.phoebe.app.ui.LocalContinuousMotionEnabled
 import com.phoebe.app.ui.LocalDesktopMergesTitleBar
@@ -54,6 +55,7 @@ private val desktopProcessExitScheduled = AtomicBoolean(false)
 
 fun main(args: Array<String>) {
     configureDesktopApplicationName()
+    configureDesktopChromecastNetworking()
     configureDesktopApplicationIcon(isDebugBuild())
     configureSkiaGpuResourceCache()
     configureWindowsDesktopRendering()

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidCastController.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidCastController.kt
@@ -875,25 +875,53 @@ private class AndroidCastController : CastController {
         loadTimeoutJob?.cancel()
         loadTimeoutJob = null
         pendingHandoff = null
-        expectedRemoteHandoff = PendingCastHandoff(
+        val requestId = loadRequestId
+        val handoff = PendingCastHandoff(
             queue = queue,
             index = appIndex,
             positionMs = 0L,
             wasLocalPlaying = mutableState.value.isPlaying,
-            requestId = loadRequestId,
+            requestId = requestId,
         )
+        expectedRemoteHandoff = handoff
         val client = remoteMediaClient() ?: run {
             expectedRemoteHandoff = null
             return false
         }
-        return runCatching {
+        val pendingResult = runCatching {
             client.queueJumpToItem(item.itemId, null as JSONObject?)
-            true
         }.getOrElse { error ->
             PhoebeLog.d(TAG) { "queue jump failed: ${error.message}" }
             expectedRemoteHandoff = null
-            false
+            return false
         }
+        pendingResult.setResultCallback(
+            ResultCallback { result ->
+                scope.launch {
+                    handleQueueJumpResult(requestId, result, handoff)
+                }
+            },
+        )
+        return true
+    }
+
+    private fun handleQueueJumpResult(
+        requestId: Long,
+        result: RemoteMediaClient.MediaChannelResult,
+        handoff: PendingCastHandoff,
+    ) {
+        if (expectedRemoteHandoff?.requestId != requestId) return
+        val status = result.status
+        val mediaError = result.mediaError
+        if (status.isSuccess && mediaError == null) {
+            syncRemotePlayback()
+            return
+        }
+        PhoebeLog.d(TAG) {
+            "queue jump failed status=${status.statusCode} message=${status.statusMessage} mediaError=${mediaError?.detailedErrorCode} requestId=$requestId"
+        }
+        expectedRemoteHandoff = null
+        loadQueueInternal(handoff.queue, handoff.index)
     }
 
     private fun remotePlaybackMatches(

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidCastController.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidCastController.kt
@@ -875,13 +875,23 @@ private class AndroidCastController : CastController {
         loadTimeoutJob?.cancel()
         loadTimeoutJob = null
         pendingHandoff = null
-        expectedRemoteHandoff = null
-        val client = remoteMediaClient() ?: return false
+        expectedRemoteHandoff = PendingCastHandoff(
+            queue = queue,
+            index = appIndex,
+            positionMs = 0L,
+            wasLocalPlaying = mutableState.value.isPlaying,
+            requestId = loadRequestId,
+        )
+        val client = remoteMediaClient() ?: run {
+            expectedRemoteHandoff = null
+            return false
+        }
         return runCatching {
             client.queueJumpToItem(item.itemId, null as JSONObject?)
             true
         }.getOrElse { error ->
             PhoebeLog.d(TAG) { "queue jump failed: ${error.message}" }
+            expectedRemoteHandoff = null
             false
         }
     }

--- a/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopCastController.kt
+++ b/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopCastController.kt
@@ -69,7 +69,6 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import su.litvak.chromecast.api.v2.ChromeCast
 import su.litvak.chromecast.api.v2.ChromeCastException
-import su.litvak.chromecast.api.v2.ChromeCasts
 import su.litvak.chromecast.api.v2.Media as CastV2Media
 import su.litvak.chromecast.api.v2.MediaStatus as CastV2MediaStatus
 import java.awt.Dialog
@@ -824,6 +823,7 @@ internal data class DesktopCastDevice(
     val displayName: String,
     val model: String? = null,
     val host: String? = null,
+    val port: Int = DefaultChromecastPort,
     internal val native: ChromeCast? = null,
 ) {
     override fun toString(): String =
@@ -934,35 +934,28 @@ internal interface DesktopCastDevicePicker {
 }
 
 private class CastV2DesktopCastTransport : DesktopCastTransport {
-    override suspend fun startDiscovery() {
-        ChromeCasts.startDiscovery()
-    }
+    private var discoverySession: DesktopChromecastDiscoverySession? = null
 
-    override suspend fun refreshDiscovery() {
-        runCatching {
-            ChromeCasts.restartDiscovery()
-        }.getOrElse {
-            ChromeCasts.startDiscovery()
+    override suspend fun startDiscovery() {
+        ensureDesktopChromecastNetworkingConfigured()
+        if (discoverySession == null) {
+            discoverySession = DesktopChromecastDiscoverySession()
         }
     }
 
+    override suspend fun refreshDiscovery() {
+        discoverySession?.close()
+        discoverySession = DesktopChromecastDiscoverySession()
+    }
+
     override suspend fun devices(): List<DesktopCastDevice> =
-        ChromeCasts.get()
-            .distinctBy { it.name ?: "${it.address}:${it.port}" }
-            .map { cast ->
-                DesktopCastDevice(
-                    id = cast.name ?: "${cast.address}:${cast.port}",
-                    displayName = cast.title?.takeIf { it.isNotBlank() }
-                        ?: cast.name?.takeIf { it.isNotBlank() }
-                        ?: cast.address,
-                    model = cast.model?.takeIf { it.isNotBlank() },
-                    host = cast.address,
-                    native = cast,
-                )
-            }
+        discoverySession?.devices().orEmpty()
 
     override suspend fun connect(device: DesktopCastDevice): DesktopCastConnection {
-        val cast = device.native ?: ChromeCast(requireNotNull(device.host) { "Missing Chromecast host." })
+        val cast = device.native ?: ChromeCast(
+            requireNotNull(device.host) { "Missing Chromecast host." },
+            device.port,
+        )
         return CastV2DesktopCastConnection(device, cast)
     }
 }

--- a/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopCastDiscovery.kt
+++ b/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopCastDiscovery.kt
@@ -1,0 +1,145 @@
+package com.phoebe.app.player
+
+import com.phoebe.app.platform.PhoebeLog
+import java.net.Inet4Address
+import java.net.InetAddress
+import java.net.NetworkInterface
+import javax.jmdns.JmDNS
+import javax.jmdns.ServiceEvent
+import javax.jmdns.ServiceInfo
+import javax.jmdns.ServiceListener
+
+internal const val ChromecastServiceType = "_googlecast._tcp.local."
+internal const val DefaultChromecastPort = 8009
+
+private val DesktopVirtualInterfaceNamePrefixes = listOf(
+    "docker", "br-", "veth", "vmnet", "vbox", "virbr", "tun", "tap", "utun",
+    "awdl", "llw", "bridge", "ap", "ipsec", "ppp", "gif", "stf", "zt", "wg",
+)
+
+internal fun ensureDesktopChromecastNetworkingConfigured() {
+    if (System.getProperty("java.net.preferIPv4Stack") == null) {
+        System.setProperty("java.net.preferIPv4Stack", "true")
+    }
+}
+
+fun configureDesktopChromecastNetworking() {
+    ensureDesktopChromecastNetworkingConfigured()
+}
+
+internal fun desktopChromecastDiscoveryAddress(): InetAddress? =
+    runCatching {
+        NetworkInterface.getNetworkInterfaces()
+            ?.toList()
+            .orEmpty()
+            .asSequence()
+            .filter { iface ->
+                runCatching {
+                    iface.isUp &&
+                        !iface.isLoopback &&
+                        !iface.isVirtual &&
+                        !iface.isPointToPoint &&
+                        !isDesktopVirtualInterfaceName(iface.name)
+                }.getOrDefault(false)
+            }
+            .sortedBy { iface -> desktopChromecastInterfacePreference(iface.name) }
+            .flatMap { iface ->
+                iface.inetAddresses.toList().asSequence()
+                    .filterIsInstance<Inet4Address>()
+                    .mapNotNull { address ->
+                        val host = address.hostAddress?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                        if (address.isLinkLocalAddress) return@mapNotNull null
+                        address to host
+                    }
+            }
+            .firstOrNull()
+            ?.first
+    }.onFailure { error ->
+        PhoebeLog.d("DesktopCastDiscovery") { "Chromecast interface lookup failed: ${error.message}" }
+    }.getOrNull()
+
+private fun isDesktopVirtualInterfaceName(name: String): Boolean {
+    val lower = name.lowercase()
+    return DesktopVirtualInterfaceNamePrefixes.any { prefix ->
+        lower == prefix || lower.startsWith(prefix)
+    }
+}
+
+private fun desktopChromecastInterfacePreference(name: String): Int =
+    when {
+        name.equals("en0", ignoreCase = true) -> 0
+        name.startsWith("en", ignoreCase = true) -> 1
+        name.startsWith("wlan", ignoreCase = true) -> 2
+        name.startsWith("eth", ignoreCase = true) -> 3
+        else -> 10
+    }
+
+internal class DesktopChromecastDiscoverySession : AutoCloseable {
+    private val lock = Any()
+    private val devicesById = linkedMapOf<String, DesktopCastDevice>()
+    private val jmdns: JmDNS
+    private val listener = ChromecastServiceListener()
+
+    init {
+        ensureDesktopChromecastNetworkingConfigured()
+        val bindAddress = desktopChromecastDiscoveryAddress()
+        PhoebeLog.d("DesktopCastDiscovery") {
+            "starting Chromecast mDNS on ${bindAddress?.hostAddress ?: "default interface"}"
+        }
+        jmdns = if (bindAddress != null) {
+            JmDNS.create(bindAddress)
+        } else {
+            JmDNS.create()
+        }
+        jmdns.addServiceListener(ChromecastServiceType, listener)
+    }
+
+    fun devices(): List<DesktopCastDevice> =
+        synchronized(lock) {
+            devicesById.values.toList()
+        }
+
+    override fun close() {
+        runCatching { jmdns.removeServiceListener(ChromecastServiceType, listener) }
+        runCatching { jmdns.close() }
+        synchronized(lock) {
+            devicesById.clear()
+        }
+    }
+
+    private inner class ChromecastServiceListener : ServiceListener {
+        override fun serviceAdded(event: ServiceEvent) {
+            event.dns.requestServiceInfo(event.type, event.name, true)
+        }
+
+        override fun serviceRemoved(event: ServiceEvent) {
+            synchronized(lock) {
+                devicesById.remove(event.name)
+            }
+        }
+
+        override fun serviceResolved(event: ServiceEvent) {
+            val device = event.info.toDesktopCastDevice() ?: return
+            synchronized(lock) {
+                devicesById[device.id] = device
+            }
+        }
+    }
+}
+
+private fun ServiceInfo.toDesktopCastDevice(): DesktopCastDevice? {
+    val host = inet4Addresses.firstOrNull()?.hostAddress
+        ?: hostAddresses.firstOrNull()
+        ?: return null
+    val serviceName = name?.takeIf { it.isNotBlank() } ?: return null
+    val displayName = getPropertyString("fn")?.takeIf { it.isNotBlank() }
+        ?: serviceName
+    val model = getPropertyString("md")?.takeIf { it.isNotBlank() }
+    return DesktopCastDevice(
+        id = serviceName,
+        displayName = displayName,
+        model = model,
+        host = host,
+        port = port,
+    )
+}

--- a/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopCastDiscovery.kt
+++ b/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopCastDiscovery.kt
@@ -27,7 +27,7 @@ fun configureDesktopChromecastNetworking() {
     ensureDesktopChromecastNetworkingConfigured()
 }
 
-internal fun desktopChromecastDiscoveryAddress(): InetAddress? =
+internal fun desktopChromecastDiscoveryAddresses(): List<InetAddress> =
     runCatching {
         NetworkInterface.getNetworkInterfaces()
             ?.toList()
@@ -52,11 +52,15 @@ internal fun desktopChromecastDiscoveryAddress(): InetAddress? =
                         address to host
                     }
             }
-            .firstOrNull()
-            ?.first
+            .map { it.first }
+            .distinctBy { it.hostAddress }
+            .toList()
     }.onFailure { error ->
         PhoebeLog.d("DesktopCastDiscovery") { "Chromecast interface lookup failed: ${error.message}" }
-    }.getOrNull()
+    }.getOrDefault(emptyList())
+
+internal fun desktopChromecastDiscoveryAddress(): InetAddress? =
+    desktopChromecastDiscoveryAddresses().firstOrNull()
 
 private fun isDesktopVirtualInterfaceName(name: String): Boolean {
     val lower = name.lowercase()
@@ -77,21 +81,26 @@ private fun desktopChromecastInterfacePreference(name: String): Int =
 internal class DesktopChromecastDiscoverySession : AutoCloseable {
     private val lock = Any()
     private val devicesById = linkedMapOf<String, DesktopCastDevice>()
-    private val jmdns: JmDNS
-    private val listener = ChromecastServiceListener()
+    private val jmdnsInstances = mutableListOf<JmDNS>()
 
     init {
         ensureDesktopChromecastNetworkingConfigured()
-        val bindAddress = desktopChromecastDiscoveryAddress()
+        val bindAddresses = desktopChromecastDiscoveryAddresses()
         PhoebeLog.d("DesktopCastDiscovery") {
-            "starting Chromecast mDNS on ${bindAddress?.hostAddress ?: "default interface"}"
+            val hosts = bindAddresses.mapNotNull { it.hostAddress }
+            "starting Chromecast mDNS on ${hosts.joinToString().ifBlank { "default interface" }}"
         }
-        jmdns = if (bindAddress != null) {
-            JmDNS.create(bindAddress)
+        if (bindAddresses.isEmpty()) {
+            val jmdns = JmDNS.create()
+            jmdns.addServiceListener(ChromecastServiceType, ChromecastServiceListener())
+            jmdnsInstances += jmdns
         } else {
-            JmDNS.create()
+            bindAddresses.forEach { bindAddress ->
+                val jmdns = JmDNS.create(bindAddress)
+                jmdns.addServiceListener(ChromecastServiceType, ChromecastServiceListener())
+                jmdnsInstances += jmdns
+            }
         }
-        jmdns.addServiceListener(ChromecastServiceType, listener)
     }
 
     fun devices(): List<DesktopCastDevice> =
@@ -100,8 +109,10 @@ internal class DesktopChromecastDiscoverySession : AutoCloseable {
         }
 
     override fun close() {
-        runCatching { jmdns.removeServiceListener(ChromecastServiceType, listener) }
-        runCatching { jmdns.close() }
+        jmdnsInstances.forEach { jmdns ->
+            runCatching { jmdns.close() }
+        }
+        jmdnsInstances.clear()
         synchronized(lock) {
             devicesById.clear()
         }

--- a/playback/src/desktopTest/kotlin/com/phoebe/app/player/DesktopCastDiscoveryTest.kt
+++ b/playback/src/desktopTest/kotlin/com/phoebe/app/player/DesktopCastDiscoveryTest.kt
@@ -1,0 +1,35 @@
+package com.phoebe.app.player
+
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class DesktopCastDiscoveryTest {
+    @Test
+    fun discoveryAddressPrefersPhysicalIpv4Interface() {
+        val address = desktopChromecastDiscoveryAddress()
+        val host = address?.hostAddress.orEmpty()
+        assertTrue(host.isNotBlank(), "expected a local IPv4 discovery address")
+        assertTrue(!host.startsWith("127."), "expected a non-loopback address, got $host")
+    }
+
+    @Test
+    fun discoverySessionFindsChromecastDevicesOnNetwork() {
+        ensureDesktopChromecastNetworkingConfigured()
+        val address = desktopChromecastDiscoveryAddress()
+        if (address == null) return
+
+        DesktopChromecastDiscoverySession().use { session ->
+            val deadline = System.currentTimeMillis() + 6_000L
+            while (System.currentTimeMillis() < deadline) {
+                if (session.devices().isNotEmpty()) break
+                Thread.sleep(250L)
+            }
+            val devices = session.devices()
+            if (devices.isEmpty()) return@use
+            val first = devices.first()
+            assertNotNull(first.host)
+            assertTrue(first.displayName.isNotBlank())
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Replace litvak `ChromeCasts` mDNS discovery with jmDNS bound to the physical LAN IPv4 interface so Chromecast devices appear on macOS desktop.
- Add `com.apple.security.network.server` entitlement required for mDNS listener sockets.
- Preserve Android cast queue-jump handoff state so remote playback position is tracked correctly after jumping queue items.

## Test plan
- [x] `./gradlew :playback:desktopTest --tests "com.phoebe.app.player.DesktopCastDiscoveryTest"`
- [ ] Verify Chromecast devices appear in the cast picker on macOS desktop
- [ ] Verify casting and queue navigation work on Android


Made with [Cursor](https://cursor.com)