### PR TITLE
Improve library loading resilience and Android Cast disconnect handling

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/phoebe/app/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/phoebe/app/MainActivity.kt
@@ -126,7 +126,9 @@ class MainActivity : FragmentActivity(), AndroidCastRoutePickerHost {
     private fun showCastChooserDialog(): Boolean =
         runCatching {
             dismissCastDialog(CAST_CHOOSER_DIALOG_TAG)
-            MediaRouteChooserDialogFragment().show(supportFragmentManager, CAST_CHOOSER_DIALOG_TAG)
+            val fragment = MediaRouteChooserDialogFragment()
+            castRouteButton?.routeSelector?.let { fragment.routeSelector = it }
+            fragment.show(supportFragmentManager, CAST_CHOOSER_DIALOG_TAG)
             true
         }.getOrDefault(false)
 

--- a/composeApp/src/androidMain/kotlin/com/phoebe/app/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/phoebe/app/MainActivity.kt
@@ -16,9 +16,15 @@ import android.widget.FrameLayout
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.core.app.ActivityCompat
+import android.app.AlertDialog
+import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentActivity
 import androidx.mediarouter.app.MediaRouteButton
+import androidx.mediarouter.app.MediaRouteChooserDialogFragment
+import androidx.mediarouter.app.MediaRouteControllerDialogFragment
 import com.google.android.gms.cast.framework.CastButtonFactory
+import com.google.android.gms.cast.framework.CastContext
+import com.google.android.gms.cast.framework.CastState
 import com.phoebe.app.platform.PhoebeAppLifecycle
 import com.phoebe.app.player.AndroidPlaybackBridge
 
@@ -75,11 +81,58 @@ class MainActivity : FragmentActivity(), AndroidCastRoutePickerHost {
     }
 
     override fun showCastRoutePicker(): Boolean {
+        if (isCastConnected()) {
+            return showCastControllerDialog()
+        }
         val button = castRouteButton ?: return false
         button.post {
             button.showDialog()
         }
         return true
+    }
+
+    private fun isCastConnected(): Boolean =
+        runCatching {
+            CastContext.getSharedInstance(this).castState == CastState.CONNECTED
+        }.getOrDefault(false)
+
+    private fun showCastControllerDialog(): Boolean {
+        val shown = runCatching {
+            dismissCastDialog(CAST_CONTROLLER_DIALOG_TAG)
+            MediaRouteControllerDialogFragment().show(supportFragmentManager, CAST_CONTROLLER_DIALOG_TAG)
+            true
+        }.getOrDefault(false)
+        return shown || showFallbackConnectedCastDialog()
+    }
+
+    private fun showFallbackConnectedCastDialog(): Boolean {
+        val castContext = runCatching { CastContext.getSharedInstance(this) }.getOrNull() ?: return false
+        val deviceName = castContext.sessionManager.currentCastSession?.castDevice?.friendlyName ?: "Chromecast"
+        AlertDialog.Builder(this)
+            .setTitle("Connected to $deviceName")
+            .setMessage("Playback is on your Chromecast.")
+            .setPositiveButton("Disconnect") { _, _ ->
+                AndroidPlaybackBridge.onCastDisconnect?.invoke()
+                    ?: castContext.sessionManager.endCurrentSession(true)
+            }
+            .setNeutralButton("Change device") { _, _ ->
+                showCastChooserDialog()
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+        return true
+    }
+
+    private fun showCastChooserDialog(): Boolean =
+        runCatching {
+            dismissCastDialog(CAST_CHOOSER_DIALOG_TAG)
+            MediaRouteChooserDialogFragment().show(supportFragmentManager, CAST_CHOOSER_DIALOG_TAG)
+            true
+        }.getOrDefault(false)
+
+    private fun dismissCastDialog(tag: String) {
+        (supportFragmentManager.findFragmentByTag(tag) as? DialogFragment)
+            ?.dismissAllowingStateLoss()
     }
 
     private fun installCastRouteButton() {
@@ -127,5 +180,7 @@ class MainActivity : FragmentActivity(), AndroidCastRoutePickerHost {
     private companion object {
         private const val REQUEST_POST_NOTIFICATIONS = 1001
         private const val AssistantSearchQueryExtra = "phoebe.assistant.SEARCH_QUERY"
+        private const val CAST_CONTROLLER_DIALOG_TAG = "cast_controller"
+        private const val CAST_CHOOSER_DIALOG_TAG = "cast_chooser"
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
@@ -324,6 +324,11 @@ class AppState(
     private val mutableLibrariesLoading = MutableStateFlow(false)
     val librariesLoading: StateFlow<Boolean> = mutableLibrariesLoading
 
+    private val mutableLibrariesLoadError = MutableStateFlow<String?>(null)
+    val librariesLoadError: StateFlow<String?> = mutableLibrariesLoadError
+
+    private var librariesLoadJob: Job? = null
+
     private val mutableAuthInProgress = MutableStateFlow(false)
     val authInProgress: StateFlow<Boolean> = mutableAuthInProgress
 
@@ -418,6 +423,7 @@ class AppState(
             downloadedArtworkCacheJob,
             artistDetailPreloadJob,
             keepPlayingJob,
+            librariesLoadJob,
             popularMixSeedBuildDeferred,
             topTracksMixBuildDeferred,
         ).forEach { it.cancel() }
@@ -433,6 +439,7 @@ class AppState(
         downloadedArtworkCacheJob = null
         artistDetailPreloadJob = null
         keepPlayingJob = null
+        librariesLoadJob = null
         popularMixSeedBuildDeferred = null
         popularMixSeedBuildSignature = null
         popularMixSeedSignature = null
@@ -533,6 +540,9 @@ class AppState(
             requestNavigation(defaultBrowseRequest(session.value))
             if (session.value?.token?.isNotBlank() == true && session.value?.selectedServer == null) {
                 refreshServers()
+            }
+            if (session.value?.selectedServer != null && session.value?.selectedLibrary == null) {
+                ensureLibrariesLoaded()
             }
             dependencies.catalogRepository.restoreCachedCatalog()
             refreshInternetRadio()
@@ -1467,6 +1477,7 @@ class AppState(
 
     fun returnToServerPicker() = scope.launch {
         mutableLibrariesLoading.value = false
+        mutableLibrariesLoadError.value = null
         requestNavigation(AppNavigationRequest.ServerPicker)
         refreshServers()
     }
@@ -1484,31 +1495,79 @@ class AppState(
     }
 
     fun selectServer(server: PlexServer) = scope.launch {
-        mutableBusy.value = true
         cancelRemotePlayHistorySync()
         cancelLightweightRemoteSync()
         mutableLibraries.value = emptyList()
-        mutableLibrariesLoading.value = true
-        val resolved = runCatching {
-            dependencies.sessionRepository.selectServer(server, refreshConnections = false)
-        }.onFailure {
+        mutableLibrariesLoadError.value = null
+        mutableBusy.value = true
+        try {
+            runCatching {
+                dependencies.sessionRepository.selectServer(server, refreshConnections = false)
+            }.onFailure {
+                mutableMessage.value = it.message ?: "Couldn't select ${session.value.providerLabel()} server."
+            }.getOrNull() ?: return@launch
+            requestNavigation(AppNavigationRequest.LibraryPicker)
+            loadLibrariesForSelectedServer(force = true)
+        } finally {
             mutableBusy.value = false
-            mutableLibrariesLoading.value = false
-            mutableMessage.value = it.message ?: "Couldn't select ${session.value.providerLabel()} server."
-        }.getOrNull()
-        if (resolved == null) {
-            mutableBusy.value = false
-            return@launch
         }
-        requestNavigation(AppNavigationRequest.LibraryPicker)
-        runCatching {
-            mutableLibraries.value = dependencies.sessionRepository.libraries(resolved)
-        }.onFailure {
-            mutableMessage.value = it.message ?: "Couldn't load ${session.value.providerLabel()} libraries."
-        }
-        mutableLibrariesLoading.value = false
-        mutableBusy.value = false
     }
+
+    fun ensureLibrariesLoaded() {
+        loadLibrariesForSelectedServer(force = false)
+    }
+
+    fun retryLibraries() {
+        loadLibrariesForSelectedServer(force = true)
+    }
+
+    private fun loadLibrariesForSelectedServer(force: Boolean) {
+        librariesLoadJob?.cancel()
+        librariesLoadJob = scope.launch {
+            if (!force) {
+                if (mutableLibrariesLoading.value) return@launch
+                if (mutableLibraries.value.isNotEmpty()) return@launch
+            }
+            val server = session.value?.selectedServer ?: return@launch
+            if (session.value?.selectedLibrary != null) return@launch
+
+            mutableLibrariesLoadError.value = null
+            if (force) {
+                mutableLibraries.value = emptyList()
+            }
+            mutableLibrariesLoading.value = true
+            try {
+                prepareSelectedServerForLibraryRequests()
+                val serverForLibraries = session.value?.selectedServer ?: server
+                val loaded = dependencies.sessionRepository.libraries(serverForLibraries)
+                mutableLibraries.value = loaded
+                if (loaded.isEmpty()) {
+                    val error = librariesEmptyMessage(serverForLibraries.name, session.value.providerLabel())
+                    mutableLibrariesLoadError.value = error
+                    mutableMessage.value = error
+                }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                val message = error.message ?: "Couldn't load ${session.value.providerLabel()} libraries."
+                mutableLibrariesLoadError.value = message
+                mutableMessage.value = message
+                mutableLibraries.value = emptyList()
+            } finally {
+                mutableLibrariesLoading.value = false
+            }
+        }
+    }
+
+    private suspend fun prepareSelectedServerForLibraryRequests() {
+        if (!session.value.isPlex()) return
+        runCatching { dependencies.sessionRepository.refreshSelectedServerConnections() }
+        runCatching { dependencies.sessionRepository.warmServerConnection() }
+    }
+
+    private fun librariesEmptyMessage(serverName: String, providerLabel: String): String =
+        "Couldn't reach music libraries on $serverName. Check your network connection and try again, " +
+            "or turn on Prefer home network in streaming settings if you're on the same LAN as your $providerLabel server."
 
     fun selectLibrary(library: MusicLibrary, jellyfinSyncMode: JellyfinSyncMode? = null) = scope.launch {
         cancelRemotePlayHistorySync()
@@ -3972,6 +4031,9 @@ class AppState(
         mutablePin.value = null
         mutableLibraries.value = emptyList()
         mutableLibrariesLoading.value = false
+        mutableLibrariesLoadError.value = null
+        librariesLoadJob?.cancel()
+        librariesLoadJob = null
         mutableAuthInProgress.value = false
         requestNavigation(AppNavigationRequest.SignIn)
         mutableMessage.value = "Signing out…"

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
@@ -1522,12 +1522,12 @@ class AppState(
     }
 
     private fun loadLibrariesForSelectedServer(force: Boolean) {
+        if (!force) {
+            if (mutableLibrariesLoading.value) return
+            if (mutableLibraries.value.isNotEmpty()) return
+        }
         librariesLoadJob?.cancel()
         librariesLoadJob = scope.launch {
-            if (!force) {
-                if (mutableLibrariesLoading.value) return@launch
-                if (mutableLibraries.value.isNotEmpty()) return@launch
-            }
             val server = session.value?.selectedServer ?: return@launch
             if (session.value?.selectedLibrary != null) return@launch
 

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeDesktopContracts.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeDesktopContracts.kt
@@ -233,6 +233,7 @@ internal data class AuthSetupState(
     val servers: List<PlexServer>,
     val libraries: List<MusicLibrary>,
     val librariesLoading: Boolean = false,
+    val librariesLoadError: String? = null,
 )
 
 internal data class AuthSetupActions(
@@ -255,6 +256,7 @@ internal data class AuthSetupActions(
     val onCancelPlexSetup: () -> Unit,
     val onBackToServerPicker: () -> Unit,
     val onRetryServers: () -> Unit,
+    val onRetryLibraries: () -> Unit,
 )
 
 internal data class SettingsUiState(

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeDesktopPlayer.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeDesktopPlayer.kt
@@ -199,6 +199,7 @@ internal fun DesktopPlayer(
     val servers = authSetupState.servers
     val libraries = authSetupState.libraries
     val librariesLoading = authSetupState.librariesLoading
+    val librariesLoadError = authSetupState.librariesLoadError
     val appSettings = settingsState.appSettings
     val downloadDirectory = settingsState.downloadDirectory
     val downloadCount = settingsState.downloadCount
@@ -317,6 +318,7 @@ internal fun DesktopPlayer(
     val onCancelPlexSetup = authSetupActions.onCancelPlexSetup
     val onBackToServerPicker = authSetupActions.onBackToServerPicker
     val onRetryServers = authSetupActions.onRetryServers
+    val onRetryLibraries = authSetupActions.onRetryLibraries
     val onHomeSections = settingsActions.onHomeSections
     val onMobileBottomTabs = settingsActions.onMobileBottomTabs
     val onPersonalMix = settingsActions.onPersonalMix
@@ -477,12 +479,14 @@ internal fun DesktopPlayer(
                                         providerType = session?.providerType ?: MediaProviderType.Plex,
                                         busy = busy,
                                         librariesLoading = librariesLoading,
+                                        librariesLoadError = librariesLoadError,
                                         isJellyfin = session.isEmbyFamily(),
                                     ),
                                     actions = PlexLibraryPickerRouteActions(
                                         onSelectLibrary = onSelectLibrary,
                                         onBack = onBackToServerPicker,
                                         onCancel = onCancelPlexSetup,
+                                        onRetry = onRetryLibraries,
                                     ),
                                     modifier = Modifier.fillMaxSize(),
                                 )

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeRoot.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeRoot.kt
@@ -401,6 +401,7 @@ private fun PhoebeRootStateHolder(
     val authInProgress by state.authInProgress.collectAsState()
     val serversLoading by state.serversLoading.collectAsState()
     val librariesLoading by state.librariesLoading.collectAsState()
+    val librariesLoadError by state.librariesLoadError.collectAsState()
     val message by state.message.collectAsState()
     val pendingDuplicatePlaylistAdd by state.pendingDuplicatePlaylistAdd.collectAsState()
     val playbackSnackbar by state.playbackSnackbar.collectAsState()
@@ -480,6 +481,12 @@ private fun PhoebeRootStateHolder(
     val missingRoute = routeResolution as? PhoebeRouteResolution.Missing
     val screen = (routeResolution as? PhoebeRouteResolution.Resolved)?.screen ?: AppScreen.Home
     val currentRoutes = navigator.routes
+    LaunchedEffect(session?.selectedServer?.id, session?.selectedLibrary?.key, screen) {
+        if (screen != AppScreen.LibraryPicker) return@LaunchedEffect
+        val currentSession = session ?: return@LaunchedEffect
+        if (currentSession.selectedServer == null || currentSession.selectedLibrary != null) return@LaunchedEffect
+        state.ensureLibrariesLoaded()
+    }
     val browseSection = currentRoutes.filterIsInstance<PhoebeRoute.Browse>().lastOrNull()?.section ?: BrowseSection.Home
     val radioPlayingFromSignIn = currentTrack?.id?.startsWith("radio:") == true &&
         currentRoutes.firstOrNull() == PhoebeRoute.SignIn
@@ -1498,12 +1505,14 @@ private fun PhoebeRootStateHolder(
                             providerType = session?.providerType ?: com.phoebe.app.domain.MediaProviderType.Plex,
                             busy = busy,
                             librariesLoading = librariesLoading,
+                            librariesLoadError = librariesLoadError,
                             isJellyfin = session.isEmbyFamily(),
                         ),
                         actions = PlexLibraryPickerRouteActions(
                             onSelectLibrary = { library, mode -> state.selectLibrary(library, mode) },
                             onBack = state::returnToServerPicker,
                             onCancel = state::signOut,
+                            onRetry = state::retryLibraries,
                         ),
                         modifier = Modifier.fillMaxSize(),
                     )
@@ -2477,6 +2486,7 @@ private fun PhoebeRootStateHolder(
                         servers = servers,
                         libraries = libraries,
                         librariesLoading = librariesLoading,
+                        librariesLoadError = librariesLoadError,
                     ),
                     authSetupActions = AuthSetupActions(
                         onStartSignIn = state::startPlexSignIn,
@@ -2498,6 +2508,7 @@ private fun PhoebeRootStateHolder(
                         onCancelPlexSetup = { state.signOut() },
                         onBackToServerPicker = { state.returnToServerPicker() },
                         onRetryServers = { state.loadServers() },
+                        onRetryLibraries = { state.retryLibraries() },
                     ),
                     settingsState = SettingsUiState(
                         appSettings = appSettings,

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeScreenshotApp.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeScreenshotApp.kt
@@ -604,6 +604,7 @@ internal fun PhoebeDesktopScreenshotScenario(
             onCancelPlexSetup = {},
             onBackToServerPicker = {},
             onRetryServers = {},
+            onRetryLibraries = {},
         ),
         settingsState = SettingsUiState(
             appSettings = AppSettings.Default.copy(

--- a/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexClient.kt
+++ b/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexClient.kt
@@ -169,7 +169,7 @@ class PlexClient private constructor(
             baseTimeoutMs = baseTimeoutMs,
         )
         return response.mediaContainer.directories
-            .filter { it.type == "artist" }
+            .filter { it.type.equals("artist", ignoreCase = true) }
             .map { MusicLibrary(key = it.key, title = it.title) }
     }
 

--- a/feature/auth/src/commonMain/kotlin/com/phoebe/app/feature/auth/AuthFeature.kt
+++ b/feature/auth/src/commonMain/kotlin/com/phoebe/app/feature/auth/AuthFeature.kt
@@ -53,6 +53,7 @@ data class PlexLibraryPickerRouteState(
     val providerType: MediaProviderType = MediaProviderType.Plex,
     val busy: Boolean,
     val librariesLoading: Boolean = false,
+    val librariesLoadError: String? = null,
     val isJellyfin: Boolean = false,
 )
 
@@ -60,6 +61,7 @@ class PlexLibraryPickerRouteActions(
     val onSelectLibrary: (MusicLibrary, JellyfinSyncMode?) -> Unit,
     val onBack: () -> Unit,
     val onCancel: () -> Unit,
+    val onRetry: () -> Unit,
 )
 
 @Composable
@@ -144,10 +146,12 @@ fun PlexLibraryPickerRoute(
         providerType = state.providerType,
         busy = state.busy,
         librariesLoading = state.librariesLoading,
+        librariesLoadError = state.librariesLoadError,
         isJellyfin = state.isJellyfin,
         onSelectLibrary = actions.onSelectLibrary,
         onBack = actions.onBack,
         onCancel = actions.onCancel,
+        onRetry = actions.onRetry,
         modifier = modifier,
     )
 }

--- a/feature/auth/src/commonMain/kotlin/com/phoebe/app/feature/auth/PhoebeAuthScreens.kt
+++ b/feature/auth/src/commonMain/kotlin/com/phoebe/app/feature/auth/PhoebeAuthScreens.kt
@@ -1178,10 +1178,12 @@ fun PlexLibraryPickerPanel(
     providerType: MediaProviderType = MediaProviderType.Plex,
     busy: Boolean,
     librariesLoading: Boolean = false,
+    librariesLoadError: String? = null,
     isJellyfin: Boolean = false,
     onSelectLibrary: (MusicLibrary, JellyfinSyncMode?) -> Unit,
     onBack: () -> Unit,
     onCancel: () -> Unit,
+    onRetry: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var pendingJellyfinLibrary by remember { mutableStateOf<MusicLibrary?>(null) }
@@ -1237,7 +1239,20 @@ fun PlexLibraryPickerPanel(
                 Text("Finding $pickerKindPlural...", color = PhoebeUi.secondaryText, fontSize = 14.sp)
             }
         } else if (libraries.isEmpty()) {
-            Text("No $pickerKindPlural found on this server.", color = PhoebeUi.secondaryText, fontSize = 14.sp)
+            Text(
+                librariesLoadError ?: "No $pickerKindPlural found on this server.",
+                color = PhoebeUi.secondaryText,
+                fontSize = 14.sp,
+                lineHeight = 20.sp,
+            )
+            FilledTonalButton(
+                onClick = onRetry,
+                enabled = !busy && !librariesLoading,
+                colors = ButtonDefaults.filledTonalButtonColors(
+                    containerColor = PhoebeUi.accent.copy(alpha = 0.22f),
+                    contentColor = PhoebeUi.primaryText,
+                ),
+            ) { Text("Retry") }
         } else {
             LazyColumn(
                 verticalArrangement = Arrangement.spacedBy(8.dp),

--- a/feature/playback/src/commonMain/kotlin/com/phoebe/app/feature/playback/MobilePlayer.kt
+++ b/feature/playback/src/commonMain/kotlin/com/phoebe/app/feature/playback/MobilePlayer.kt
@@ -542,6 +542,13 @@ fun MobilePlayer(
             }
         }
 
+        fun skipStepsForSwipe(releaseOffset: Float, artworkSizePx: Float): Int {
+            val rawSteps = (abs(releaseOffset) / artworkSizePx).toInt().coerceIn(1, 5)
+            // Collapsed tray swipes span the full bar while artwork is only 44dp, so distance-based
+            // multi-skip would advance several tracks from a normal gesture.
+            return if (clampedExpansionFraction < 0.1f) 1 else rawSteps
+        }
+
         fun animateSwipeCommit(releaseOffset: Float) {
             horizontalSettleJob?.cancel()
             horizontalSettleJob = scope.launch {
@@ -554,8 +561,7 @@ fun MobilePlayer(
                             targetValue = -artworkSizePx,
                             animationSpec = tween(durationMillis = 240, easing = FastOutSlowInEasing),
                         )
-                        val steps = (abs(releaseOffset) / artworkSizePx).toInt().coerceIn(1, 5)
-                        onSkipQueueBy(steps)
+                        onSkipQueueBy(skipStepsForSwipe(releaseOffset, artworkSizePx))
                         delay(600L)
                         horizontalSettleOffset.animateTo(
                             0f,
@@ -570,8 +576,7 @@ fun MobilePlayer(
                             targetValue = artworkSizePx,
                             animationSpec = tween(durationMillis = 240, easing = FastOutSlowInEasing),
                         )
-                        val steps = -(abs(releaseOffset) / artworkSizePx).toInt().coerceIn(1, 5)
-                        onSkipQueueBy(steps)
+                        onSkipQueueBy(-skipStepsForSwipe(releaseOffset, artworkSizePx))
                         delay(600L)
                         horizontalSettleOffset.animateTo(
                             0f,

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidCastController.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidCastController.kt
@@ -116,11 +116,10 @@ private class AndroidCastController : CastController {
         }
 
         override fun onSessionEnded(session: CastSession, error: Int) {
-            val reason = if (endingSessionIntentionally) {
-                CastSessionDisconnectReason.UserRequested
-            } else {
-                CastSessionDisconnectReason.Unexpected
-            }
+            val reason = castSessionDisconnectReason(
+                endingSessionIntentionally = endingSessionIntentionally,
+                sessionEndError = error,
+            )
             endingSessionIntentionally = false
             PhoebeLog.d(TAG) { "session ended error=$error reason=$reason device=${session.castDevice?.friendlyName}" }
             disconnectState(reason)
@@ -167,6 +166,7 @@ private class AndroidCastController : CastController {
         AndroidPlaybackBridge.readCastVolume = { readCastVolumeNormalized() }
         AndroidPlaybackBridge.applyCastVolume = { volume -> applyCastVolume(volume) }
         AndroidPlaybackBridge.adjustCastVolumeStep = { up -> adjustCastVolumeStep(up) }
+        AndroidPlaybackBridge.onCastDisconnect = { disconnect() }
         ensureCastSessionListener()
     }
 

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidPlaybackBridge.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidPlaybackBridge.kt
@@ -36,6 +36,7 @@ object AndroidPlaybackBridge {
     var applyCastVolume: ((Float) -> Unit)? = null
     var adjustCastVolumeStep: ((up: Boolean) -> Boolean)? = null
     var onCastVolumeChanged: ((Float) -> Unit)? = null
+    var onCastDisconnect: (() -> Unit)? = null
     var onCastMediaSessionState: ((CastMediaSessionState?) -> Unit)? = null
     var onLocalMediaSessionState: ((LocalMediaSessionState?) -> Unit)? = null
 

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/CastPlaybackPolicy.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/CastPlaybackPolicy.kt
@@ -30,6 +30,18 @@ enum class CastSessionDisconnectReason {
     Unexpected,
 }
 
+/** Google Cast reports [CAST_SESSION_END_SUCCESS] for normal app/user teardown. */
+const val CAST_SESSION_END_SUCCESS = 0
+
+fun castSessionDisconnectReason(
+    endingSessionIntentionally: Boolean,
+    sessionEndError: Int,
+): CastSessionDisconnectReason = when {
+    endingSessionIntentionally -> CastSessionDisconnectReason.UserRequested
+    sessionEndError == CAST_SESSION_END_SUCCESS -> CastSessionDisconnectReason.UserRequested
+    else -> CastSessionDisconnectReason.Unexpected
+}
+
 fun shouldRestoreLocalAfterCastSessionEnd(reason: CastSessionDisconnectReason): Boolean =
     reason == CastSessionDisconnectReason.UserRequested
 

--- a/playback/src/commonTest/kotlin/com/phoebe/app/player/CastPlaybackPolicyTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/player/CastPlaybackPolicyTest.kt
@@ -56,6 +56,31 @@ class CastPlaybackPolicyTest {
     }
 
     @Test
+    fun normalCastSessionEndIsTreatedAsUserDisconnect() {
+        assertEquals(
+            CastSessionDisconnectReason.UserRequested,
+            castSessionDisconnectReason(
+                endingSessionIntentionally = false,
+                sessionEndError = CAST_SESSION_END_SUCCESS,
+            ),
+        )
+        assertEquals(
+            CastSessionDisconnectReason.UserRequested,
+            castSessionDisconnectReason(
+                endingSessionIntentionally = true,
+                sessionEndError = 42,
+            ),
+        )
+        assertEquals(
+            CastSessionDisconnectReason.Unexpected,
+            castSessionDisconnectReason(
+                endingSessionIntentionally = false,
+                sessionEndError = 42,
+            ),
+        )
+    }
+
+    @Test
     fun loadFailureRetriesSmallerQueueWhileSessionStaysConnected() {
         assertEquals(
             CastLoadFailureAction.RetrySmallerQueue,


### PR DESCRIPTION
## Summary
- Warm Plex server connections before library fetches, add retry UI when libraries fail or appear empty, and match artist library types case-insensitively.
- On Android, open the Cast controller when already connected (with disconnect/change-device fallback), wire disconnect through the playback bridge, and treat normal Cast session end as a user disconnect so local playback restores correctly.
- Limit collapsed mobile player tray swipes to a single track skip instead of distance-based multi-skip.

## Test plan
- [x] `./gradlew :playback:desktopTest --tests "com.phoebe.app.player.CastPlaybackPolicyTest"`
- [ ] Select a Plex server on a cold network path; confirm libraries load or show retry with actionable error
- [ ] Connect to Chromecast, tap Cast again — controller or connected dialog appears; disconnect restores local playback
- [ ] Swipe collapsed mobile player tray — advances one track per gesture


Made with [Cursor](https://cursor.com)