### PR TITLE
Recover Plex playback when the server changes address mid-session

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
@@ -2754,6 +2754,22 @@ class AppState(
             }
 
             override fun demoteLocalOrigins(): Boolean = resolver.demoteLocalOrigins()
+
+            override suspend fun rediscoverOrigins(): List<String> {
+                if (!session.value.isPlex()) return emptyList()
+                val before = session.value?.selectedServer ?: return emptyList()
+                runCatching { dependencies.sessionRepository.refreshSelectedServerConnections() }
+                val after = session.value?.selectedServer ?: return emptyList()
+                // Unchanged addresses mean there is nothing new to try; fail fast instead.
+                if (after == before) return emptyList()
+                PhoebeLog.d("AppState") { "playback stalled → refreshed Plex connections" }
+                runCatching { dependencies.sessionRepository.warmServerConnection() }
+                return playbackOriginCandidates(
+                    server = after,
+                    preferredOrigin = currentPlaybackOrigin(),
+                    demoteLocalOrigins = resolver.demoteLocalOrigins(),
+                )
+            }
         }
         val server = session.value?.selectedServer
         if (server != null) {

--- a/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexClient.kt
+++ b/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexClient.kt
@@ -137,7 +137,7 @@ class PlexClient private constructor(
                 if (connections.isEmpty()) return@mapNotNull null
                 val advertised = connections.map { it.uri.trimEnd('/') }.filter { it.isNotBlank() }.distinct()
                 val local = connections.filter { it.local }.map { it.uri.trimEnd('/') }.distinct()
-                val allUris = expandConnectionUris(advertised)
+                val allUris = expandConnectionUris(advertised, httpsRequired = device.httpsRequired)
                 val bestUri = bestReachableBaseUri(
                     advertisedUris = advertised,
                     localUris = local,

--- a/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexServerConnections.kt
+++ b/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexServerConnections.kt
@@ -8,7 +8,8 @@ import com.phoebe.app.domain.PlexServer
  * Plex often advertises `https://172-105-8-66.<token>.plex.direct:8443` alongside
  * `http://192.168.x.x:32400`. We synthesize `http://172.105.8.66:32400` from the plex.direct
  * hostname, but that address is usually the server's *public* IP and is often unreachable on
- * LAN; real local URLs from Plex must win.
+ * LAN; real local URLs from Plex must win. Servers requiring HTTPS get no synthesized entries
+ * at all — see [expandConnectionUris].
  *
  * When [demoteLocalOrigins] is true (cellular / unknown Wi-Fi), LAN-only hosts sort after
  * remote relays so playback and API probes do not burn seconds on dead private addresses.
@@ -20,7 +21,8 @@ fun PlexServer.reachableBaseUris(
     val primary = uri.trimEnd('/').takeIf { it.isNotBlank() }
     val advertised = advertisedConnectionUris.ifEmpty { connectionUris }
     val expanded = when {
-        advertised.isNotEmpty() -> listOfNotNull(primary) + expandConnectionUris(advertised)
+        advertised.isNotEmpty() ->
+            listOfNotNull(primary) + expandConnectionUris(advertised, httpsRequired = httpsRequired)
         primary != null -> listOf(primary)
         else -> emptyList()
     }.distinct()
@@ -84,7 +86,7 @@ fun bestReachableBaseUri(
         name = "",
         uri = advertisedUris.firstOrNull().orEmpty(),
         owned = false,
-        connectionUris = expandConnectionUris(advertisedUris),
+        connectionUris = expandConnectionUris(advertisedUris, httpsRequired = httpsRequired),
         advertisedConnectionUris = advertisedUris,
         localConnectionUris = localUris,
         httpsRequired = httpsRequired,
@@ -92,18 +94,24 @@ fun bestReachableBaseUri(
     return server.reachableBaseUris().firstOrNull()
 }
 
-/** Advertised URLs first, then synthesized plain-IP fallbacks derived from plex.direct hosts. */
-fun expandConnectionUris(advertisedUris: List<String>): List<String> =
+/**
+ * Advertised URLs first, then synthesized plain-IP fallbacks derived from plex.direct hosts.
+ *
+ * `http://<ip>:32400` is the only variant worth synthesizing. Plex's certificate covers
+ * `*.<hash>.plex.direct`, so an `https://` URL built from the bare IP can never finish a TLS
+ * handshake, and a server with [httpsRequired] refuses the plain-HTTP port outright. Emitting
+ * either one just burns entries in the caller's fallback budget on addresses that cannot work.
+ */
+fun expandConnectionUris(
+    advertisedUris: List<String>,
+    httpsRequired: Boolean = false,
+): List<String> =
     buildList {
         val advertised = advertisedUris.map { it.trimEnd('/') }.filter { it.isNotBlank() }
         addAll(advertised)
+        if (httpsRequired) return@buildList
         for (uri in advertised) {
-            val port = uri.substringAfter("://").substringAfter(':', "").substringBefore('/').toIntOrNull()
-            decodedIpFromPlexDirect(uri)?.let { ip ->
-                add("http://$ip:32400")
-                add("https://$ip:32400")
-                if (port == 8443) add("https://$ip:8443")
-            }
+            decodedIpFromPlexDirect(uri)?.let { ip -> add("http://$ip:32400") }
         }
     }.distinct()
 

--- a/data/providers/plex/src/commonTest/kotlin/com/phoebe/app/PlexServerConnectionsTest.kt
+++ b/data/providers/plex/src/commonTest/kotlin/com/phoebe/app/PlexServerConnectionsTest.kt
@@ -21,12 +21,23 @@ class PlexServerConnectionsTest {
     }
 
     @Test
-    fun expandConnectionUrisAddsPlainLanAnd8443() {
+    fun expandConnectionUrisAddsOnlyThePlainIpPort() {
         val expanded = expandConnectionUris(
             listOf("https://172-105-8-66.abc.plex.direct:8443"),
         )
         assertTrue("http://172.105.8.66:32400" in expanded)
-        assertTrue("https://172.105.8.66:8443" in expanded)
+        // Plex's cert covers *.plex.direct, so bare-IP TLS can never complete a handshake.
+        assertFalse("https://172.105.8.66:8443" in expanded)
+        assertFalse("https://172.105.8.66:32400" in expanded)
+    }
+
+    @Test
+    fun expandConnectionUrisSynthesizesNothingWhenHttpsRequired() {
+        val advertised = "https://172-105-8-66.abc.plex.direct:8443"
+
+        val expanded = expandConnectionUris(listOf(advertised), httpsRequired = true)
+
+        assertEquals(listOf(advertised), expanded)
     }
 
     @Test
@@ -103,7 +114,10 @@ class PlexServerConnectionsTest {
         )
         val ordered = server.reachableBaseUris()
         assertTrue(ordered.indexOf(remoteRelay) < ordered.indexOf(closedWan))
-        assertTrue(ordered.indexOf(remoteRelay) < ordered.indexOf("https://72.58.82.53:32400"))
+        assertTrue(
+            ordered.none { it.contains("72.58.82.53") || it.contains("45.79.202.250") },
+            "an https-only server gets no bare-IP fallbacks to waste attempts on",
+        )
     }
 
     @Test

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackOriginResolver.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackOriginResolver.kt
@@ -20,6 +20,16 @@ interface PlaybackOriginResolver {
     /** True when LAN-only hosts should be demoted (always remote-first, or cellular). */
     fun demoteLocalOrigins(): Boolean
 
+    /**
+     * Re-asks the provider (plex.tv) for the server's current connection list and returns
+     * playback origins best-first, or an empty list when the addresses are unchanged.
+     *
+     * Queues are stamped with origins when they are built, so a server that moves — new WAN
+     * address, relay swap, container restart — stays unreachable for the rest of the session
+     * unless something refetches that list. Only call this after every known URL has failed.
+     */
+    suspend fun rediscoverOrigins(): List<String> = emptyList()
+
     companion object {
         const val DefaultPlayResolveDeadlineMs = 700L
     }

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
@@ -10,6 +10,7 @@ import com.phoebe.app.domain.StreamingPolicySettings
 import com.phoebe.app.domain.Track
 import com.phoebe.app.platform.PhoebeLog
 import com.phoebe.app.platform.currentTimeMs
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -1028,7 +1029,12 @@ abstract class SimpleAudioPlayer(
         originRediscoveryGeneration = generation
         val alreadyTried = triedPlaybackUris.toSet()
         scope.launch {
-            val origins = runCatching { resolver.rediscoverOrigins() }.getOrNull().orEmpty()
+            val origins = runCatching { resolver.rediscoverOrigins() }
+                // Swallowing cancellation here would let the rest of this block publish a failure
+                // and mutate player state after the scope that owns it is already gone.
+                .onFailure { if (it is CancellationException) throw it }
+                .getOrNull()
+                .orEmpty()
             if (!isPlayRequestCurrent(generation) || !playWhenReady) return@launch
             // An empty list means the addresses did not move, so the URLs already walked are still
             // the only ones that exist. Retrying would re-time-out on every one of them, and the

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
@@ -47,6 +47,7 @@ abstract class SimpleAudioPlayer(
     private var systemVolumeScale = 1f
     private var playGeneration = 0
     private var failoverGeneration = -1
+    private var originRediscoveryGeneration = -1
     private val triedPlaybackUris = linkedSetOf<String>()
     private var stickyPlaybackOrigin: String? = null
     private var crossfadeDurationMs = 0L
@@ -974,13 +975,18 @@ abstract class SimpleAudioPlayer(
 
     protected fun replayWithFailoverUri(generation: Int, failedUri: String?): Boolean {
         if (!isPlayRequestCurrent(generation) || !playWhenReady) return false
-        val next = nextPlaybackFailoverUri(generation, failedUri) ?: return false
+        val next = nextPlaybackFailoverUri(generation, failedUri)
+            ?: return rediscoverOriginsAndRetry(generation, failedUri)
         val trackId = mutableState.value.currentTrack?.id
         if (!failedUri.isNullOrBlank() && failedUri.isPlexUniversalTranscodeUrl() && !trackId.isNullOrBlank()) {
             StreamingPlaybackPolicyHolder.preferDirectStreamFor(trackId)
         }
         notePlaybackUri(next, generation)
-        adoptFailoverStreamUrl(next)
+        return startFailoverAttempt(generation, next)
+    }
+
+    private fun startFailoverAttempt(generation: Int, uri: String): Boolean {
+        adoptFailoverStreamUrl(uri)
         val current = mutableState.value
         val track = current.currentTrack ?: return false
         val index = current.currentIndex.takeIf { it in current.queue.indices } ?: return false
@@ -992,17 +998,75 @@ abstract class SimpleAudioPlayer(
             playbackErrorMessage = null,
         )
         PhoebeLog.d("AudioPlayer") {
-            "playback failover uri=${PlaybackFailureClassifier.redactStreamUri(next)} positionMs=$resumePositionMs"
+            "playback failover uri=${PlaybackFailureClassifier.redactStreamUri(uri)} positionMs=$resumePositionMs"
         }
         startPlaybackStartupWatchdog(generation)
         playQueueOnPlatform(
             queue = mutableState.value.queue,
             startIndex = index,
-            track = track.copy(streamUrl = next),
+            track = track.copy(streamUrl = uri),
             generation = generation,
             startPositionMs = resumePositionMs,
         )
         return true
+    }
+
+    /**
+     * Every URL we knew about failed. Ask the provider for the server's current addresses before
+     * giving up: a server that changed address mid-session is unreachable on every stamped URL,
+     * and refetching that list is the only reason quitting and relaunching the app recovered.
+     *
+     * Returns true when a refresh is in flight, so the caller defers surfacing an error — this
+     * publishes the failure itself if nothing new turns up. Capped at one attempt per play
+     * request so a genuinely offline server cannot spin.
+     */
+    private fun rediscoverOriginsAndRetry(generation: Int, failedUri: String?): Boolean {
+        val resolver = PlaybackOriginResolverHolder.resolver ?: return false
+        if (originRediscoveryGeneration == generation) return false
+        val track = mutableState.value.currentTrack ?: return false
+        if (!track.localUri.isNullOrBlank()) return false
+        originRediscoveryGeneration = generation
+        val alreadyTried = triedPlaybackUris.toSet()
+        scope.launch {
+            val origins = runCatching { resolver.rediscoverOrigins() }.getOrNull().orEmpty()
+            if (!isPlayRequestCurrent(generation) || !playWhenReady) return@launch
+            restampQueueWithOrigins(origins)
+            val target = mutableState.value.currentTrack
+                ?.playbackUriCandidates()
+                ?.firstOrNull { it !in alreadyTried }
+            if (target == null) {
+                PhoebeLog.d("AudioPlayer") { "origin rediscovery surfaced no untried stream URL" }
+                publishPlaybackFailure(
+                    PlaybackFailure(
+                        kind = PlaybackFailureKind.Unreachable,
+                        message = "every known stream URL for this server failed",
+                        streamUri = failedUri,
+                    ),
+                    generation,
+                )
+                return@launch
+            }
+            PhoebeLog.d("AudioPlayer") {
+                "origin rediscovery found ${origins.size} origin(s); retrying playback"
+            }
+            // The addresses are new, so the exhausted attempt budget no longer applies.
+            resetPlaybackUriFailover(generation)
+            notePlaybackUri(target, generation)
+            startFailoverAttempt(generation, target)
+        }
+        return true
+    }
+
+    private fun restampQueueWithOrigins(origins: List<String>) {
+        val preferred = origins.firstOrNull() ?: return
+        val current = mutableState.value
+        var changed = false
+        val restamped = current.queue.map { track ->
+            val next = track.withPlaybackOrigins(preferred, origins.drop(1))
+            if (next !== track) changed = true
+            next
+        }
+        if (changed) mutableState.value = current.copy(queue = restamped)
     }
 
     private fun adoptFailoverStreamUrl(uri: String) {

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
@@ -1030,10 +1030,23 @@ abstract class SimpleAudioPlayer(
         scope.launch {
             val origins = runCatching { resolver.rediscoverOrigins() }.getOrNull().orEmpty()
             if (!isPlayRequestCurrent(generation) || !playWhenReady) return@launch
-            restampQueueWithOrigins(origins)
-            val target = mutableState.value.currentTrack
-                ?.playbackUriCandidates()
-                ?.firstOrNull { it !in alreadyTried }
+            // An empty list means the addresses did not move, so the URLs already walked are still
+            // the only ones that exist. Retrying would re-time-out on every one of them, and the
+            // attempt budget may have cut the walk short while dead candidates remained.
+            val target = if (origins.isEmpty()) {
+                null
+            } else {
+                restampQueueWithOrigins(origins)
+                nextPlaybackFailoverCandidate(
+                    candidates = mutableState.value.currentTrack?.playbackUriCandidates().orEmpty(),
+                    tried = alreadyTried,
+                    failedUri = failedUri,
+                    // The addresses are new, so the exhausted budget no longer applies. Going
+                    // through the shared candidate picker keeps the LAN-only skip after a remote
+                    // failure, which a plain "first untried" scan would lose.
+                    maxTriedUris = alreadyTried.size + MaxTriedPlaybackUris,
+                )
+            }
             if (target == null) {
                 PhoebeLog.d("AudioPlayer") { "origin rediscovery surfaced no untried stream URL" }
                 publishPlaybackFailure(
@@ -1049,7 +1062,6 @@ abstract class SimpleAudioPlayer(
             PhoebeLog.d("AudioPlayer") {
                 "origin rediscovery found ${origins.size} origin(s); retrying playback"
             }
-            // The addresses are new, so the exhausted attempt budget no longer applies.
             resetPlaybackUriFailover(generation)
             notePlaybackUri(target, generation)
             startFailoverAttempt(generation, target)

--- a/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
@@ -4,6 +4,7 @@ import com.phoebe.app.domain.AudioProcessingSettings
 import com.phoebe.app.domain.EqualizerProfile
 import com.phoebe.app.domain.Track
 import com.phoebe.app.domain.RepeatMode
+import com.phoebe.app.player.MaxTriedPlaybackUris
 import com.phoebe.app.player.PlaybackFailure
 import com.phoebe.app.player.PlaybackFailureClassifier
 import com.phoebe.app.player.PlaybackOriginResolver
@@ -19,6 +20,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -310,6 +312,45 @@ class PlayerStateTest {
                 player.state.value.playbackErrorMessage,
             )
             assertFalse(player.playIntentActive())
+        } finally {
+            PlaybackOriginResolverHolder.resolver = null
+        }
+    }
+
+    @Test
+    fun unchangedAddressesDoNotHandTheAttemptBudgetASecondWalk() = runTest {
+        PlaybackOriginResolverHolder.resolver = movedServerResolver()
+        try {
+            val player = TimeoutTestPlayer(this)
+            // One more candidate than the attempt budget, so the walk is cut short with an
+            // untried URL still on the list. That leftover is on the same dead server, so
+            // rediscovery reporting "nothing moved" has to surface the error rather than
+            // reset the budget and burn a timeout on it.
+            val candidates = (1..MaxTriedPlaybackUris + 1).map { "https://dead$it.example/library/parts/1/f.mp3" }
+
+            player.play(
+                listOf(
+                    Track(
+                        id = "t1",
+                        title = "One",
+                        artist = "Artist",
+                        album = "Album",
+                        durationMs = 60_000,
+                        streamUrl = candidates.first(),
+                        downloadUrl = "",
+                        playbackFallbackUrls = candidates.drop(1),
+                    ),
+                ),
+                0,
+            )
+            repeat(MaxTriedPlaybackUris) {
+                advanceTimeBy(player.testStartupTimeoutMs + 1L)
+                runCurrent()
+            }
+
+            assertEquals(1, player.state.value.playbackErrorSerial)
+            assertFalse(player.playIntentActive())
+            assertNotEquals(candidates.last(), player.state.value.currentTrack?.streamUrl)
         } finally {
             PlaybackOriginResolverHolder.resolver = null
         }

--- a/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
@@ -261,6 +261,87 @@ class PlayerStateTest {
     }
 
     @Test
+    fun exhaustedFailoverRefetchesOriginsAndRetriesOnTheMovedAddress() = runTest {
+        val movedOrigin = "https://45-79-202-250.abc.plex.direct:8443"
+        PlaybackOriginResolverHolder.resolver = movedServerResolver(movedOrigin)
+        try {
+            val player = TimeoutTestPlayer(this)
+            val dead = "https://173-230-135-80.abc.plex.direct:8443/library/parts/1/file.mp3"
+
+            player.play(
+                listOf(Track("t1", "One", "Artist", "Album", 60_000, dead, "")),
+                0,
+            )
+            advanceTimeBy(player.testStartupTimeoutMs + 1L)
+            runCurrent()
+
+            assertEquals(
+                "$movedOrigin/library/parts/1/file.mp3",
+                player.state.value.currentTrack?.streamUrl,
+            )
+            assertEquals(0, player.state.value.playbackErrorSerial)
+            assertTrue(player.state.value.isBuffering)
+
+            player.finishPendingLoad()
+
+            assertTrue(player.state.value.isPlaying)
+            assertNull(player.state.value.playbackErrorMessage)
+        } finally {
+            PlaybackOriginResolverHolder.resolver = null
+        }
+    }
+
+    @Test
+    fun exhaustedFailoverFailsFastWhenTheServerAddressesAreUnchanged() = runTest {
+        PlaybackOriginResolverHolder.resolver = movedServerResolver()
+        try {
+            val player = TimeoutTestPlayer(this)
+
+            player.play(
+                listOf(Track("t1", "One", "Artist", "Album", 60_000, "https://dead.example/f.mp3", "")),
+                0,
+            )
+            advanceTimeBy(player.testStartupTimeoutMs + 1L)
+            runCurrent()
+
+            assertEquals(1, player.state.value.playbackErrorSerial)
+            assertEquals(
+                "Can't reach the music server. Check your connection and try again.",
+                player.state.value.playbackErrorMessage,
+            )
+            assertFalse(player.playIntentActive())
+        } finally {
+            PlaybackOriginResolverHolder.resolver = null
+        }
+    }
+
+    @Test
+    fun originRediscoveryRunsOncePerPlayRequestSoAnOfflineServerCannotSpin() = runTest {
+        var rediscoveries = 0
+        val movedOrigin = "https://45-79-202-250.abc.plex.direct:8443"
+        PlaybackOriginResolverHolder.resolver = movedServerResolver(movedOrigin) { rediscoveries++ }
+        try {
+            val player = TimeoutTestPlayer(this)
+            val dead = "https://173-230-135-80.abc.plex.direct:8443/library/parts/1/file.mp3"
+
+            player.play(
+                listOf(Track("t1", "One", "Artist", "Album", 60_000, dead, "")),
+                0,
+            )
+            // First stall refetches and retries; the moved address then stalls too.
+            advanceTimeBy(player.testStartupTimeoutMs + 1L)
+            runCurrent()
+            advanceTimeBy(player.testStartupTimeoutMs + 1L)
+            runCurrent()
+
+            assertEquals(1, rediscoveries)
+            assertEquals(1, player.state.value.playbackErrorSerial)
+        } finally {
+            PlaybackOriginResolverHolder.resolver = null
+        }
+    }
+
+    @Test
     fun newPlayRequestsReuseTheOriginThatAlreadyWorked() = runTest {
         val player = TimeoutTestPlayer(this)
         val lanOne = "https://172-16-1-2.abc.plex.direct:32400/library/parts/1/file.mp3"
@@ -1230,6 +1311,23 @@ class PlayerStateTest {
         assertEquals(55_000, player.state.value.positionMs)
         assertFalse(player.state.value.isPlaying)
         assertTrue(player.stopCalls >= 1)
+    }
+}
+
+/** Resolver whose only useful answer is the refetched connection list. */
+private fun movedServerResolver(
+    vararg origins: String,
+    onRediscover: () -> Unit = {},
+): PlaybackOriginResolver = object : PlaybackOriginResolver {
+    override fun cachedOrigin(): String? = null
+
+    override suspend fun resolveOrigin(deadlineMs: Long): String? = null
+
+    override fun demoteLocalOrigins(): Boolean = false
+
+    override suspend fun rediscoverOrigins(): List<String> {
+        onRediscover()
+        return origins.toList()
     }
 }
 


### PR DESCRIPTION
## What happened

A Windows session stalled for ~4 minutes with nothing playing. Sentry shows every stream URL for the track failing, then the app cycling the *same* cached address list for three tracks in a row. Quitting and relaunching fixed it, because startup is the only place that refetches the server's connection list from plex.tv.

Two independent causes, both fixed here.

## 1. Failover never refetches the connection list

`SimpleAudioPlayer` walked its cached origin list, and once `nextPlaybackFailoverUri` returned `null` it just published a failure. If the server had actually moved (new WAN IP, new relay, LAN address reassigned), every cached URL was permanently dead and no amount of retrying could recover.

Now, when the candidate list is exhausted:

- `PlaybackOriginResolver.rediscoverOrigins()` refetches the connection list. In `AppState` this calls `refreshSelectedServerConnections()` + `warmServerConnection()` and returns candidates **only if the addresses actually changed**.
- The queue is re-stamped onto the new origins and playback retries from the same position.
- If the refetched list comes back empty (nothing moved), the unreachable error surfaces immediately rather than rewalking dead URLs.
- Rediscovery is gated to once per play request (`originRediscoveryGeneration`), so a genuinely offline server can't spin.

A subtlety worth flagging for review: `nextPlaybackFailoverUri` returns `null` for three different reasons, not just "every candidate was tried". It also returns `null` when the `MaxTriedPlaybackUris` budget runs out with untried candidates left, and when the only untried candidates are LAN-only after a remote URL already failed. So the retry deliberately bails on an empty origin list rather than scanning for the first untried URL, and picks its target through `nextPlaybackFailoverCandidate` so the LAN-only skip still applies. Scanning directly would have reset the budget for a second walk over dead URLs and could have picked a LAN host the failover policy intentionally skipped — 30s of nothing on cellular.

## 2. Synthesizing URLs that can never connect

`expandConnectionUris` derived bare-IP variants from `plex.direct` hosts, including `https://<ip>:8443` and `https://<ip>:32400`. Plex's certificate covers `*.<hash>.plex.direct`, so a TLS handshake against a bare IP can never complete — those two are structurally guaranteed to fail. Separately, a server with `httpsRequired` refuses the plain-HTTP port, so `http://<ip>:32400` is dead there too.

`MaxTriedPlaybackUris` is 5, so in the stalled session three of the five attempts per track were spent on addresses that could not work — roughly 25 seconds of guaranteed-dead waiting before the real addresses were even exhausted.

Now only `http://<ip>:32400` is synthesized, and only when `httpsRequired` is false. `PlexClient` passes the device's `httpsRequired` flag through.

## Tests

New coverage in `PlayerStateTest`:

- `exhaustedFailoverRefetchesOriginsAndRetriesOnTheMovedAddress` — the moved-server recovery path.
- `exhaustedFailoverFailsFastWhenTheServerAddressesAreUnchanged` — no pointless retry when nothing moved.
- `unchangedAddressesDoNotHandTheAttemptBudgetASecondWalk` — the budget-exhaustion path above. Verified to fail against the first commit and pass after the fix.
- `originRediscoveryRunsOncePerPlayRequestSoAnOfflineServerCannotSpin` — the spin guard.

Updated/added in `PlexServerConnectionsTest`:

- `expandConnectionUrisAddsOnlyThePlainIpPort` — asserts the bare-IP HTTPS variants are gone.
- `expandConnectionUrisSynthesizesNothingWhenHttpsRequired`.

Run locally: `:playback:desktopTest`, `:data:providers:plex:desktopTest`, `:composeApp:desktopTest`, `:composeApp:wasmJsTest`, plus Android/iOS compiles.

## Notes for the reviewer

- `rediscoverOrigins()` has a default `emptyList()` implementation on the interface, so other resolvers keep the previous fail-fast behavior.
- `PR Checks` runs `:composeApp:*` and `:backend:*` tasks only, so the new `:playback` and `:data:providers:plex` tests here are not exercised by CI. Pre-existing gap, called out rather than changed.
- `PlexPlaybackReporterTest[desktop]` is flaky and fails on `main` too — confirmed by checking out the base branch and running the class there, where `emitsPlayHistoryChangedAfterSuccessfulStoppedReport` fails with no changes present. Not run by CI either.