### PR TITLE
Run all module tests in CI and unflake PlexPlaybackReporterTest

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -77,16 +77,16 @@ jobs:
         if: matrix.os == 'linux'
         env:
           GALLIUM_DRIVER: softpipe
-        run: xvfb-run -a ./gradlew desktopTest -Pphoebe.realAudioTests=true
+        run: xvfb-run -a ./gradlew desktopTest --continue -Pphoebe.realAudioTests=true
 
       - name: Run macOS desktop tests
         if: matrix.os == 'macos'
-        run: ./gradlew desktopTest -Pphoebe.realAudioTests=true
+        run: ./gradlew desktopTest --continue -Pphoebe.realAudioTests=true
 
       - name: Run Windows desktop tests
         if: matrix.os == 'windows'
         shell: pwsh
-        run: ./gradlew.bat desktopTest
+        run: ./gradlew.bat desktopTest --continue
 
       - name: Upload desktop test artifacts
         if: failure()

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -77,16 +77,16 @@ jobs:
         if: matrix.os == 'linux'
         env:
           GALLIUM_DRIVER: softpipe
-        run: xvfb-run -a ./gradlew :composeApp:desktopTest -Pphoebe.realAudioTests=true
+        run: xvfb-run -a ./gradlew desktopTest -Pphoebe.realAudioTests=true
 
       - name: Run macOS desktop tests
         if: matrix.os == 'macos'
-        run: ./gradlew :composeApp:desktopTest -Pphoebe.realAudioTests=true
+        run: ./gradlew desktopTest -Pphoebe.realAudioTests=true
 
       - name: Run Windows desktop tests
         if: matrix.os == 'windows'
         shell: pwsh
-        run: ./gradlew.bat :composeApp:desktopTest
+        run: ./gradlew.bat desktopTest
 
       - name: Upload desktop test artifacts
         if: failure()
@@ -95,10 +95,10 @@ jobs:
           name: desktop-test-${{ matrix.os }}-artifacts
           if-no-files-found: ignore
           path: |
-            composeApp/build/reports/tests/desktopTest/**
+            **/build/reports/tests/desktopTest/**
             composeApp/build/reports/roborazzi/**
             composeApp/build/outputs/roborazzi/**
-            composeApp/build/test-results/desktopTest/**
+            **/build/test-results/desktopTest/**
 
   android-screenshots:
     name: Android screenshots
@@ -163,6 +163,37 @@ jobs:
             composeApp/build/reports/roborazzi/**
             composeApp/build/outputs/roborazzi/**
             composeApp/build/test-results/desktopTest/**
+
+  android-host-tests:
+    name: Android host tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run Android host tests
+        run: ./gradlew testAndroidHostTest
+
+      - name: Upload Android host test artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-host-test-artifacts
+          if-no-files-found: ignore
+          path: |
+            **/build/reports/tests/testAndroidHostTest/**
+            **/build/test-results/testAndroidHostTest/**
 
   ios-build:
     name: iOS build
@@ -268,7 +299,7 @@ jobs:
   wasm-test:
     name: Wasm JS tests
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - name: Checkout
@@ -292,7 +323,17 @@ jobs:
             ${{ runner.os }}-kotlin-wasm-binaryen-
 
       - name: Run wasm JS tests
-        run: ./.github/scripts/gradle-wasm-retry.sh :composeApp:wasmJsTest
+        run: ./.github/scripts/gradle-wasm-retry.sh :composeApp:wasmJsTest :playback:wasmJsTest
+
+      - name: Upload wasm test artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-test-artifacts
+          if-no-files-found: ignore
+          path: |
+            **/build/reports/tests/wasmJsTest/**
+            **/build/test-results/wasmJsTest/**
 
   android-instrumented-tests:
     name: Android instrumented tests

--- a/build-logic/convention/src/main/kotlin/phoebe.compose.library.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/phoebe.compose.library.gradle.kts
@@ -39,5 +39,8 @@ kotlin {
                 implementation(libs.findLibrary("compose-ui-tooling-preview").get())
             }
         }
+        findByName("androidHostTest")?.apply {
+            kotlin.srcDir("src/androidUnitTest/kotlin")
+        }
     }
 }

--- a/build-logic/convention/src/main/kotlin/phoebe.kmp.library.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/phoebe.kmp.library.gradle.kts
@@ -33,5 +33,8 @@ kotlin {
                 implementation(libs.findLibrary("coroutines-core").get())
             }
         }
+        findByName("androidHostTest")?.apply {
+            kotlin.srcDir("src/androidUnitTest/kotlin")
+        }
     }
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -656,6 +656,10 @@ tasks.withType<Test>().configureEach {
         filter {
             includeTestsMatching("com.phoebe.app.PhoebeAndroid*ScreenshotTest")
         }
+    } else if (name == "testAndroidHostTest") {
+        filter {
+            excludeTestsMatching("com.phoebe.app.PhoebeAndroid*ScreenshotTest")
+        }
     }
     if (requestedAnyRoborazzi && name == "desktopTest") {
         filter {

--- a/data/catalog/src/commonMain/kotlin/com/phoebe/app/data/RadioNowPlayingRepository.kt
+++ b/data/catalog/src/commonMain/kotlin/com/phoebe/app/data/RadioNowPlayingRepository.kt
@@ -189,6 +189,7 @@ private suspend fun ByteReadChannel.discardBytes(byteCount: Int): Boolean {
     val buffer = ByteArray(minOf(byteCount, 4096))
     var remaining = byteCount
     while (remaining > 0) {
+        if (!awaitContent()) return false
         val read = readAvailable(buffer, 0, minOf(buffer.size, remaining))
         if (read <= 0) return false
         remaining -= read
@@ -200,6 +201,7 @@ private suspend fun ByteReadChannel.readExactly(byteCount: Int): ByteArray? {
     val bytes = ByteArray(byteCount)
     var offset = 0
     while (offset < byteCount) {
+        if (!awaitContent()) return null
         val read = readAvailable(bytes, offset, byteCount - offset)
         if (read <= 0) return null
         offset += read

--- a/data/catalog/src/commonTest/kotlin/com/phoebe/app/RadioNowPlayingRepositoryTest.kt
+++ b/data/catalog/src/commonTest/kotlin/com/phoebe/app/RadioNowPlayingRepositoryTest.kt
@@ -5,8 +5,8 @@ import com.phoebe.app.data.RadioNowPlayingRepository
 import com.phoebe.app.domain.RadioNowPlayingSource
 import com.phoebe.app.domain.RadioNowPlayingSourceType
 import com.phoebe.app.domain.Track
+import com.phoebe.app.testing.testMockEngine
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.engine.mock.respondOk
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -20,7 +20,7 @@ class RadioNowPlayingRepositoryTest {
     @Test
     fun resolvesBbcRmsSegmentsMetadata() = runTest {
         val repository = RadioNowPlayingRepository(
-            HttpClient(MockEngine {
+            HttpClient(testMockEngine {
                 respondOk(
                     """
                     {
@@ -55,7 +55,7 @@ class RadioNowPlayingRepositoryTest {
     @Test
     fun resolvesKexpPlaysMetadata() = runTest {
         val repository = RadioNowPlayingRepository(
-            HttpClient(MockEngine {
+            HttpClient(testMockEngine {
                 respondOk(
                     """
                     {
@@ -102,7 +102,7 @@ class RadioNowPlayingRepositoryTest {
         icyMetadata.encodeToByteArray().copyInto(metadataBlock)
         val body = ByteArray(metaint) { 0 } + byteArrayOf(blockLength.toByte()) + metadataBlock
         val repository = RadioNowPlayingRepository(
-            HttpClient(MockEngine {
+            HttpClient(testMockEngine {
                 respond(
                     content = body,
                     headers = headersOf(

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -4,9 +4,10 @@
 
 Pull requests targeting `main` run:
 
-- `./gradlew :composeApp:desktopTest` across Linux, macOS, and Windows. Linux and macOS enable `-Pphoebe.realAudioTests=true`; Linux runs under `xvfb-run` with a PulseAudio null sink, while Windows keeps real-audio tests skipped.
-- `./gradlew :composeApp:wasmJsTest`
+- `./gradlew desktopTest` across Linux, macOS, and Windows, covering every module with a desktop target. Linux and macOS enable `-Pphoebe.realAudioTests=true`; Linux runs under `xvfb-run` with a PulseAudio null sink, while Windows keeps real-audio tests skipped.
+- `./gradlew :composeApp:wasmJsTest :playback:wasmJsTest`
 - `./gradlew :composeApp:verifyRoborazziAndroidHostTest`
+- `./gradlew testAndroidHostTest` for every module with Android host tests
 - `./gradlew :composeApp:verifyRoborazziDesktop`
 - `npm run web:screenshots`
 - `./gradlew :composeApp:compileAndroidDeviceTestSources`

--- a/playback/build.gradle.kts
+++ b/playback/build.gradle.kts
@@ -56,6 +56,16 @@ kotlin {
                 implementation(libs.ktor.serialization.json)
             }
         }
+        named("androidHostTest") {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(libs.junit)
+                implementation(libs.androidx.test.core)
+                implementation(libs.androidx.test.runner)
+                implementation(libs.coroutines.test)
+                implementation(libs.robolectric)
+            }
+        }
         desktopTest {
             kotlin.srcDir("$rootDir/test-support/database/desktop/kotlin")
             kotlin.srcDir("$rootDir/test-support/platform/desktop/kotlin")

--- a/playback/src/androidUnitTest/kotlin/com/phoebe/app/player/BrowseMediaItemsTest.kt
+++ b/playback/src/androidUnitTest/kotlin/com/phoebe/app/player/BrowseMediaItemsTest.kt
@@ -1,5 +1,6 @@
 package com.phoebe.app.player
 
+import android.app.Application
 import android.os.Bundle
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
@@ -7,12 +8,17 @@ import androidx.media3.common.Player
 import androidx.media3.session.SessionResult
 import com.phoebe.app.domain.Track
 import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35], application = Application::class)
 class BrowseMediaItemsTest {
     @Test
     fun playbackMediaItemIncludesCarDisplayMetadata() {

--- a/playback/src/commonTest/kotlin/com/phoebe/app/PlexPlaybackReporterTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/PlexPlaybackReporterTest.kt
@@ -16,6 +16,7 @@ import com.phoebe.app.domain.RepeatMode
 import com.phoebe.app.domain.Track
 import com.phoebe.app.player.AudioPlayer
 import com.phoebe.app.testing.testHttpClient
+import com.phoebe.app.testing.testMockEngine
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.MockRequestHandleScope
 import io.ktor.client.engine.mock.respond
@@ -24,20 +25,21 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import kotlinx.coroutines.async
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
 import kotlin.coroutines.coroutineContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -67,6 +69,7 @@ class PlexPlaybackReporterTest {
 
         try {
             reporter.start(scope, includePeriodicTimeline = false)
+            runCurrent()
 
             audioPlayer.mutableState.value = PlayerState(
                 queue = listOf(track),
@@ -75,6 +78,7 @@ class PlexPlaybackReporterTest {
                 positionMs = 1_000L,
                 durationMs = track.durationMs,
             )
+            runCurrent()
             advanceUntilIdle()
             timelineStates.awaitSize(1)
 
@@ -85,6 +89,7 @@ class PlexPlaybackReporterTest {
                 positionMs = track.durationMs,
                 durationMs = track.durationMs,
             )
+            runCurrent()
             advanceUntilIdle()
             timelineStates.awaitSize(2)
 
@@ -105,6 +110,7 @@ class PlexPlaybackReporterTest {
 
         try {
             reporter.start(scope, includePeriodicTimeline = false)
+            runCurrent()
             val changed = async(UnconfinedTestDispatcher(testScheduler)) {
                 reporter.playHistoryChanged.first()
             }
@@ -116,6 +122,7 @@ class PlexPlaybackReporterTest {
                 positionMs = 1_000L,
                 durationMs = track.durationMs,
             )
+            runCurrent()
             advanceUntilIdle()
             timelineStates.awaitSize(1)
 
@@ -126,6 +133,7 @@ class PlexPlaybackReporterTest {
                 positionMs = track.durationMs,
                 durationMs = track.durationMs,
             )
+            runCurrent()
             advanceUntilIdle()
             timelineStates.awaitSize(2)
             advanceUntilIdle()
@@ -145,7 +153,7 @@ class PlexPlaybackReporterTest {
         val keys = MutableStateFlow<List<String>>(emptyList())
         val audioPlayer = FakeAudioPlayer()
         val reporter = newReporter(
-            MockEngine { request ->
+            testMockEngine { request ->
                 requests.update { it + request.url.encodedPath }
                 when (request.url.encodedPath) {
                     "/:/scrobble" -> {
@@ -182,6 +190,7 @@ class PlexPlaybackReporterTest {
         val track = plexTrack()
 
         reporter.start(scope, includePeriodicTimeline = false)
+        runCurrent()
 
         audioPlayer.mutableState.value = PlayerState(
             queue = listOf(track),
@@ -190,10 +199,12 @@ class PlexPlaybackReporterTest {
             positionMs = 42_000L,
             durationMs = track.durationMs,
         )
+        runCurrent()
         advanceUntilIdle()
         timelineStates.awaitSize(1)
 
         scopeJob.cancelAndJoin()
+        runCurrent()
         advanceUntilIdle()
         timelineStates.awaitSize(2)
 
@@ -214,6 +225,7 @@ class PlexPlaybackReporterTest {
             reporter.markPlayed(track, playedAtMs = 123_000L)
             scrobbles.awaitSize(1)
             reporter.start(scope, includePeriodicTimeline = false)
+            runCurrent()
 
             audioPlayer.mutableState.value = PlayerState(
                 queue = listOf(track),
@@ -222,6 +234,7 @@ class PlexPlaybackReporterTest {
                 positionMs = 91_000L,
                 durationMs = track.durationMs,
             )
+            runCurrent()
             advanceUntilIdle()
 
             assertEquals(1, scrobbles.value.size)
@@ -242,6 +255,7 @@ class PlexPlaybackReporterTest {
 
         try {
             reporter.start(scope, includePeriodicTimeline = false)
+            runCurrent()
 
             audioPlayer.mutableState.value = PlayerState(
                 queue = listOf(track),
@@ -250,6 +264,7 @@ class PlexPlaybackReporterTest {
                 positionMs = 91_000L,
                 durationMs = track.durationMs,
             )
+            runCurrent()
             advanceUntilIdle()
             scrobbles.awaitSize(1)
 
@@ -271,6 +286,7 @@ class PlexPlaybackReporterTest {
 
         try {
             reporter.start(scope, includePeriodicTimeline = false)
+            runCurrent()
 
             audioPlayer.mutableState.value = PlayerState(
                 queue = listOf(track),
@@ -279,6 +295,7 @@ class PlexPlaybackReporterTest {
                 positionMs = 91_000L,
                 durationMs = track.durationMs,
             )
+            runCurrent()
             advanceUntilIdle()
             scrobbles.awaitSize(1)
 
@@ -289,6 +306,7 @@ class PlexPlaybackReporterTest {
                 positionMs = track.durationMs,
                 durationMs = track.durationMs,
             )
+            runCurrent()
             advanceUntilIdle()
 
             assertEquals(1, scrobbles.value.size)
@@ -349,7 +367,7 @@ class PlexPlaybackReporterTest {
         timelineStates: MutableStateFlow<List<String>>,
         continuingValues: MutableStateFlow<List<String?>> = MutableStateFlow(emptyList()),
         requests: MutableStateFlow<List<String>> = MutableStateFlow(emptyList()),
-    ): MockEngine = MockEngine { request ->
+    ): MockEngine = testMockEngine { request ->
         requests.update { it + request.url.encodedPath }
         when {
             request.url.encodedPath == "/identity" -> respondJson(
@@ -369,7 +387,7 @@ class PlexPlaybackReporterTest {
 
     private fun subsonicEngine(
         scrobbles: MutableStateFlow<List<Map<String, String>>>,
-    ): MockEngine = MockEngine { request ->
+    ): MockEngine = testMockEngine { request ->
         when (request.url.encodedPath) {
             "/rest/scrobble.view" -> {
                 scrobbles.update {
@@ -412,10 +430,15 @@ class PlexPlaybackReporterTest {
         )
 
     private suspend fun <T> StateFlow<List<T>>.awaitSize(size: Int) {
-        withContext(Dispatchers.Default) {
+        try {
             withTimeout(2_000L) {
-                first { it.size >= size }
+                while (value.size < size) {
+                    yield()
+                    delay(1)
+                }
             }
+        } catch (error: Throwable) {
+            throw AssertionError("Expected at least $size items, got ${value.size}: $value", error)
         }
     }
 

--- a/test-support/network/kotlin/com/phoebe/app/testing/TestHttpClient.kt
+++ b/test-support/network/kotlin/com/phoebe/app/testing/TestHttpClient.kt
@@ -3,9 +3,12 @@ package com.phoebe.app.testing
 import com.phoebe.app.data.PhoebeDataJson
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockEngineConfig
+import io.ktor.client.engine.mock.MockRequestHandler
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.Dispatchers
 
 fun testHttpClient(engine: MockEngine): HttpClient =
     HttpClient(engine) {
@@ -16,3 +19,11 @@ fun testHttpClient(engine: MockEngine): HttpClient =
             json(PhoebeDataJson)
         }
     }
+
+fun testMockEngine(handler: MockRequestHandler): MockEngine =
+    MockEngine(
+        MockEngineConfig().apply {
+            dispatcher = Dispatchers.Unconfined
+            addHandler(handler)
+        },
+    )

--- a/ui/media/src/commonTest/kotlin/com/phoebe/app/ui/RemoteArtworkCacheTest.kt
+++ b/ui/media/src/commonTest/kotlin/com/phoebe/app/ui/RemoteArtworkCacheTest.kt
@@ -269,7 +269,7 @@ class RemoteArtworkCacheTest {
         RemoteArtworkCache.fetchRemoteArtworkBytesForTest = { _, requestedFetchUrl ->
             requests += requestedFetchUrl
             if (requestedFetchUrl == sizedFetchUrl) {
-                delay(650L)
+                delay(400L)
                 byteArrayOf(DiskHitByte)
             } else {
                 byteArrayOf(NetworkHitByte)
@@ -279,7 +279,7 @@ class RemoteArtworkCacheTest {
             when (bytes.singleOrNull()) {
                 DiskHitByte -> {
                     val started = TimeSource.Monotonic.markNow()
-                    while (started.elapsedNow() < 200.milliseconds) {
+                    while (started.elapsedNow() < 400.milliseconds) {
                         // Keep this synchronous to mirror BitmapFactory.decodeByteArray on Android.
                     }
                     testImageBitmap(maxDecodeDimension, maxDecodeDimension)


### PR DESCRIPTION
## Summary
- PR Checks now run `desktopTest` and `testAndroidHostTest` across every module, plus playback Wasm tests, so library coverage is no longer limited to `:composeApp` and `:backend`.
- `PlexPlaybackReporterTest` uses an unconfined `MockEngine` and stays on the test dispatcher while waiting, which removes the Default-dispatcher deadlock that made it flake on main.
- Android `src/androidUnitTest` sources are wired into host tests so playback Android unit tests actually compile and run.

## Test plan
- [ ] Confirm PR Checks desktop jobs run module tests beyond `:composeApp` (playback, plex providers, etc.).
- [ ] Confirm the new Android host tests job is green, including playback Robolectric tests.
- [ ] Confirm Wasm tests still run for composeApp and playback.
- [ ] Spot-check `PlexPlaybackReporterTest` is included in desktop/Android host results and does not flake.


Made with [Cursor](https://cursor.com)