### PR TITLE
Stop playback stalling on dead public Plex origins

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
@@ -79,6 +79,7 @@ import com.phoebe.app.data.PlayHistoryRankedEntries
 import com.phoebe.app.data.PlexPlayHistorySyncResult
 import com.phoebe.app.data.PlexClient
 import com.phoebe.app.data.defaultPlexRadioStations
+import com.phoebe.app.data.shouldSkipAdvertisedLan
 import com.phoebe.app.playlists.PlaylistExportFormat
 import com.phoebe.app.player.MusicAssistantRemotePlayback
 import com.phoebe.app.player.PlaybackOriginResolver
@@ -2750,7 +2751,9 @@ class AppState(
                 val current = session.value ?: return null
                 val server = current.selectedServer ?: return null
                 val token = current.serverAuthToken() ?: return null
-                return resolver.resolve(server, token, deadlineMs = deadlineMs)
+                return withContext(Dispatchers.Default) {
+                    resolver.resolveFresh(server, token, deadlineMs = deadlineMs)
+                }
             }
 
             override fun demoteLocalOrigins(): Boolean = resolver.demoteLocalOrigins()
@@ -2769,6 +2772,11 @@ class AppState(
                     preferredOrigin = currentPlaybackOrigin(),
                     demoteLocalOrigins = resolver.demoteLocalOrigins(),
                 )
+            }
+
+            override fun forgetOrigin(origin: String) {
+                val server = session.value?.selectedServer ?: return
+                resolver.forget(server.id, origin)
             }
         }
         val server = session.value?.selectedServer
@@ -4199,9 +4207,10 @@ internal fun Track.withFreshPlaybackUrls(
     session: PlexSession,
     liveOrigin: String? = null,
 ): Track {
+    val identity = currentNetworkIdentity()
     val demoteLocalOrigins = StreamingPlaybackPolicyHolder.settings.shouldDemoteLocalOrigins(
-        currentNetworkIdentity().demotesLocalOrigins,
-    )
+        identity.demotesLocalOrigins,
+    ) || session.selectedServer?.let { identity.shouldSkipAdvertisedLan(it) } == true
     val origins = playbackOriginCandidates(
         server = session.selectedServer,
         preferredOrigin = liveOrigin,

--- a/core/platform/src/androidMain/kotlin/com/phoebe/app/platform/AndroidPlatform.kt
+++ b/core/platform/src/androidMain/kotlin/com/phoebe/app/platform/AndroidPlatform.kt
@@ -197,16 +197,35 @@ private fun androidNetworkIdentity(
         isMetered = connectivity.isActiveNetworkMetered,
         isCellular = transport == NetworkTransport.Cellular,
     )
+    val linkProperties = connectivity.getLinkProperties(network)
+    val prefixes = if (transport == NetworkTransport.Cellular || transport == NetworkTransport.None) {
+        emptyList()
+    } else {
+        androidLocalIpv4Prefixes(linkProperties)
+    }
     val material = when (transport) {
         NetworkTransport.Cellular -> "cellular"
         NetworkTransport.None -> ""
-        else -> androidNetworkMaterial(connectivity.getLinkProperties(network))
+        else -> androidNetworkMaterial(linkProperties)
     }
     return NetworkIdentity(
         transport = transport,
         fingerprint = networkFingerprint(transport, material),
         metering = metering,
+        localIpv4Prefixes = prefixes,
     )
+}
+
+private fun androidLocalIpv4Prefixes(linkProperties: LinkProperties?): List<String> {
+    if (linkProperties == null) return emptyList()
+    return linkProperties.linkAddresses
+        .mapNotNull { address ->
+            val host = address.address?.hostAddress ?: return@mapNotNull null
+            if (':' in host) return@mapNotNull null
+            ipv4Slash24Prefix(host)
+        }
+        .distinct()
+        .sorted()
 }
 
 private fun androidNetworkMaterial(linkProperties: LinkProperties?): String {

--- a/core/platform/src/commonMain/kotlin/com/phoebe/app/platform/Platform.kt
+++ b/core/platform/src/commonMain/kotlin/com/phoebe/app/platform/Platform.kt
@@ -35,12 +35,27 @@ data class NetworkIdentity(
     val transport: NetworkTransport = NetworkTransport.Other,
     val fingerprint: String = "",
     val metering: NetworkMeteringStatus = NetworkMeteringStatus(),
+    /**
+     * /24 prefixes of this device's current IPv4 interfaces, e.g. `192.168.4.0`.
+     * Empty when the platform cannot observe addresses (web) — callers must not
+     * treat empty as "on the server LAN".
+     */
+    val localIpv4Prefixes: List<String> = emptyList(),
 ) {
     val demotesLocalOrigins: Boolean
         get() = transport == NetworkTransport.Cellular ||
             transport == NetworkTransport.None ||
             metering.isCellular ||
             metering.isMetered && transport != NetworkTransport.Wifi && transport != NetworkTransport.Ethernet
+}
+
+/** `192.168.4.27` → `192.168.4.0`. */
+fun ipv4Slash24Prefix(host: String): String? {
+    val parts = host.split('.')
+    if (parts.size != 4) return null
+    val octets = parts.map { it.toIntOrNull() ?: return null }
+    if (octets.any { it !in 0..255 }) return null
+    return "${octets[0]}.${octets[1]}.${octets[2]}.0"
 }
 
 expect fun currentNetworkMeteringStatus(): NetworkMeteringStatus

--- a/core/platform/src/desktopMain/kotlin/com/phoebe/app/platform/DesktopPlatform.kt
+++ b/core/platform/src/desktopMain/kotlin/com/phoebe/app/platform/DesktopPlatform.kt
@@ -93,7 +93,7 @@ private val DesktopVirtualInterfaceNamePrefixes = listOf(
 )
 
 private fun desktopNetworkIdentity(): NetworkIdentity {
-    val material = runCatching {
+    val prefixes = runCatching {
         NetworkInterface.getNetworkInterfaces()
             ?.toList()
             .orEmpty()
@@ -113,20 +113,20 @@ private fun desktopNetworkIdentity(): NetworkIdentity {
                     .mapNotNull { address ->
                         val host = address.hostAddress ?: return@mapNotNull null
                         if (address.isLinkLocalAddress) return@mapNotNull null
-                        val parts = host.split('.')
-                        if (parts.size != 4) return@mapNotNull null
-                        "${parts[0]}.${parts[1]}.${parts[2]}.0"
+                        ipv4Slash24Prefix(host)
                     }
             }
             .distinct()
             .sorted()
-            .joinToString("|")
-    }.getOrDefault("")
+            .toList()
+    }.getOrDefault(emptyList())
+    val material = prefixes.joinToString("|")
     val transport = if (material.isBlank()) NetworkTransport.None else NetworkTransport.Other
     return NetworkIdentity(
         transport = transport,
         fingerprint = networkFingerprint(transport, material.ifBlank { transport.name.lowercase() }),
         metering = NetworkMeteringStatus(),
+        localIpv4Prefixes = prefixes,
     )
 }
 

--- a/core/platform/src/iosMain/kotlin/com/phoebe/app/platform/IosPlatform.kt
+++ b/core/platform/src/iosMain/kotlin/com/phoebe/app/platform/IosPlatform.kt
@@ -138,6 +138,7 @@ private fun iosNetworkIdentitySnapshot(): NetworkIdentity {
         transport = transport,
         fingerprint = networkFingerprint(transport, material.ifBlank { transport.name.lowercase() }),
         metering = NetworkMeteringStatus(isMetered = isCellular, isCellular = isCellular),
+        localIpv4Prefixes = listOfNotNull(material.takeIf { it.contains(".0") }),
     )
 }
 
@@ -171,6 +172,11 @@ private fun iosNetworkIdentityFromPath(path: platform.Network.nw_path_t?): Netwo
             isMetered = expensive || constrained || isCellular,
             isCellular = isCellular,
         ),
+        localIpv4Prefixes = if (transport == NetworkTransport.Cellular) {
+            emptyList()
+        } else {
+            listOfNotNull(iosIpv4SubnetMaterial().takeIf { it.isNotBlank() })
+        },
     )
 }
 

--- a/data/database/src/commonMain/sqldelight/com/phoebe/app/db/PlexResolvedOrigin.sq
+++ b/data/database/src/commonMain/sqldelight/com/phoebe/app/db/PlexResolvedOrigin.sq
@@ -21,5 +21,9 @@ VALUES (?, ?, ?, ?);
 deleteForServer:
 DELETE FROM PlexResolvedOriginRow WHERE serverId = ?;
 
+deleteOrigin:
+DELETE FROM PlexResolvedOriginRow
+WHERE serverId = ? AND networkFingerprint = ? AND origin = ?;
+
 clearAll:
 DELETE FROM PlexResolvedOriginRow;

--- a/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexConnectionResolver.kt
+++ b/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexConnectionResolver.kt
@@ -51,6 +51,9 @@ class PlexConnectionResolver(
     private val memoryCache = mutableMapOf<CacheKey, String>()
     /** Last origin that worked for a server, kept across fingerprint flaps (VPN/docker ifaces). */
     private val lastGoodByServer = mutableMapOf<String, String>()
+    /** Dropped until [remember] / a race adopts them again, so hydrate cannot reload a dead row. */
+    private val forgottenOrigins = mutableSetOf<ForgottenOrigin>()
+    private val forgottenServers = mutableSetOf<String>()
     private val mutableIdentity = MutableStateFlow(currentNetworkIdentity())
     val networkIdentity: StateFlow<NetworkIdentity> = mutableIdentity
 
@@ -127,6 +130,7 @@ class PlexConnectionResolver(
 
     suspend fun hydrateFromDisk(server: PlexServer) {
         lastServer = server
+        if (server.id in forgottenServers) return
         val fingerprint = mutableIdentity.value.fingerprint
         val key = CacheKey(server.id, fingerprint)
         if (memoryCache.containsKey(key)) return
@@ -135,6 +139,7 @@ class PlexConnectionResolver(
                 .selectOrigin(server.id, fingerprint)
                 .awaitAsOneOrNull()
         }?.trimEnd('/')?.takeIf { it.isNotBlank() } ?: return
+        if (ForgottenOrigin(server.id, origin) in forgottenOrigins) return
         memoryCache[key] = origin
         lastGoodByServer[server.id] = origin
         PhoebeLog.d("PlexConnectionResolver") {
@@ -189,24 +194,32 @@ class PlexConnectionResolver(
         lastToken = token
         val identity = mutableIdentity.value
         hydrateFromDisk(server)
+        var probedDead: String? = null
         cached(server, identity)?.let { warm ->
             if (!(demoteLocalOrigins(identity) && isLocalOnlyServerOrigin(warm))) {
                 val confirmed = withTimeoutOrNull(probeTimeoutMs(warm, deadlineMs)) {
                     probeIdentity(warm, token)
                 } == true
                 if (confirmed) return warm
+                probedDead = warm
                 PhoebeLog.d("PlexConnectionResolver") {
                     "cached origin missed probe origin=$warm; racing"
                 }
             }
         }
-        if (!resolveMutex.tryLock()) {
-            return cached(server, identity)
-        }
-        try {
-            return raceBases(server, token, deadlineMs, identity)
-        } finally {
-            resolveMutex.unlock()
+        return resolveMutex.withLock {
+            cached(server, identity)?.let { warm ->
+                val alreadyFailed = probedDead?.equals(warm, ignoreCase = true) == true
+                if (!alreadyFailed &&
+                    !(demoteLocalOrigins(identity) && isLocalOnlyServerOrigin(warm))
+                ) {
+                    val confirmed = withTimeoutOrNull(probeTimeoutMs(warm, deadlineMs)) {
+                        probeIdentity(warm, token)
+                    } == true
+                    if (confirmed) return@withLock warm
+                }
+            }
+            raceBases(server, token, deadlineMs, identity)
         }
     }
 
@@ -236,6 +249,8 @@ class PlexConnectionResolver(
 
     fun remember(serverId: String, origin: String) {
         val trimmed = origin.trimEnd('/').takeIf { it.isNotBlank() } ?: return
+        forgottenServers.remove(serverId)
+        forgottenOrigins.remove(ForgottenOrigin(serverId, trimmed))
         val fingerprint = mutableIdentity.value.fingerprint
         memoryCache[CacheKey(serverId, fingerprint)] = trimmed
         lastGoodByServer[serverId] = trimmed
@@ -248,6 +263,8 @@ class PlexConnectionResolver(
         val fingerprint = mutableIdentity.value.fingerprint
         val key = CacheKey(serverId, fingerprint)
         if (origin == null) {
+            forgottenServers.add(serverId)
+            forgottenOrigins.removeAll { it.serverId == serverId }
             memoryCache.remove(key)
             lastGoodByServer.remove(serverId)
             scope.launch {
@@ -257,6 +274,7 @@ class PlexConnectionResolver(
             }
         } else {
             val trimmed = origin.trimEnd('/')
+            forgottenOrigins.add(ForgottenOrigin(serverId, trimmed))
             if (memoryCache[key] == trimmed) memoryCache.remove(key)
             if (lastGoodByServer[serverId] == trimmed) lastGoodByServer.remove(serverId)
             scope.launch {
@@ -346,6 +364,8 @@ class PlexConnectionResolver(
     }
 
     private suspend fun adoptWinner(serverId: String, origin: String, fingerprint: String) {
+        forgottenServers.remove(serverId)
+        forgottenOrigins.remove(ForgottenOrigin(serverId, origin))
         memoryCache[CacheKey(serverId, fingerprint)] = origin
         lastGoodByServer[serverId] = origin
         persist(serverId, fingerprint, origin)
@@ -375,6 +395,11 @@ class PlexConnectionResolver(
     private data class CacheKey(
         val serverId: String,
         val fingerprint: String,
+    )
+
+    private data class ForgottenOrigin(
+        val serverId: String,
+        val origin: String,
     )
 
     companion object {

--- a/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexConnectionResolver.kt
+++ b/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexConnectionResolver.kt
@@ -94,7 +94,9 @@ class PlexConnectionResolver(
 
     fun demoteLocalOrigins(identity: NetworkIdentity = mutableIdentity.value): Boolean {
         if (!preferLocalNetworkProvider()) return true
-        return identity.demotesLocalOrigins
+        if (identity.demotesLocalOrigins) return true
+        val server = lastServer ?: return false
+        return identity.shouldSkipAdvertisedLan(server)
     }
 
     fun cached(server: PlexServer, identity: NetworkIdentity = mutableIdentity.value): String? {
@@ -124,6 +126,7 @@ class PlexConnectionResolver(
     }
 
     suspend fun hydrateFromDisk(server: PlexServer) {
+        lastServer = server
         val fingerprint = mutableIdentity.value.fingerprint
         val key = CacheKey(server.id, fingerprint)
         if (memoryCache.containsKey(key)) return
@@ -142,6 +145,10 @@ class PlexConnectionResolver(
     /**
      * Parallel `/identity` race. Returns the first reachable base within [deadlineMs],
      * preferring a warm cache hit when present.
+     *
+     * Cache hits return immediately so Android/AppState (Main) and catalog warmup never block
+     * on a dead relay. Validation happens in the background; [resolveFresh] is the probed path
+     * for in-flight playback failover.
      */
     suspend fun resolve(
         server: PlexServer,
@@ -153,9 +160,8 @@ class PlexConnectionResolver(
         val identity = mutableIdentity.value
         hydrateFromDisk(server)
         cached(server, identity)?.let { warm ->
-            // Still confirm quickly if demoting local and the warm entry is LAN-only.
             if (!(demoteLocalOrigins(identity) && isLocalOnlyServerOrigin(warm))) {
-                scope.launch { warmKeepAlive(warm, token) }
+                scope.launch { validateCachedOrigin(server, token, warm, identity) }
                 return warm
             }
         }
@@ -164,8 +170,65 @@ class PlexConnectionResolver(
             return cached(server, identity)
         }
         try {
-            cached(server, identity)?.let { return it }
             return raceBases(server, token, deadlineMs, identity)
+        } finally {
+            resolveMutex.unlock()
+        }
+    }
+
+    /**
+     * Confirm the cached origin with `/identity`, then race if it is dead. Safe to call from
+     * a background dispatcher during playback — not from Android AppState on Main.
+     */
+    suspend fun resolveFresh(
+        server: PlexServer,
+        token: String,
+        deadlineMs: Long = RemoteProbeTimeoutMs,
+    ): String? {
+        lastServer = server
+        lastToken = token
+        val identity = mutableIdentity.value
+        hydrateFromDisk(server)
+        cached(server, identity)?.let { warm ->
+            if (!(demoteLocalOrigins(identity) && isLocalOnlyServerOrigin(warm))) {
+                val confirmed = withTimeoutOrNull(probeTimeoutMs(warm, deadlineMs)) {
+                    probeIdentity(warm, token)
+                } == true
+                if (confirmed) return warm
+                PhoebeLog.d("PlexConnectionResolver") {
+                    "cached origin missed probe origin=$warm; racing"
+                }
+            }
+        }
+        if (!resolveMutex.tryLock()) {
+            return cached(server, identity)
+        }
+        try {
+            return raceBases(server, token, deadlineMs, identity)
+        } finally {
+            resolveMutex.unlock()
+        }
+    }
+
+    private suspend fun validateCachedOrigin(
+        server: PlexServer,
+        token: String,
+        warm: String,
+        identity: NetworkIdentity,
+    ) {
+        val confirmed = withTimeoutOrNull(probeTimeoutMs(warm, RemoteProbeTimeoutMs)) {
+            probeIdentity(warm, token)
+        } == true
+        if (confirmed) {
+            warmKeepAlive(warm, token)
+            return
+        }
+        PhoebeLog.d("PlexConnectionResolver") {
+            "cached origin missed background probe origin=$warm; racing"
+        }
+        if (!resolveMutex.tryLock()) return
+        try {
+            raceBases(server, token, RemoteProbeTimeoutMs, identity)
         } finally {
             resolveMutex.unlock()
         }
@@ -187,10 +250,24 @@ class PlexConnectionResolver(
         if (origin == null) {
             memoryCache.remove(key)
             lastGoodByServer.remove(serverId)
+            scope.launch {
+                databaseWriteGate.withWrite {
+                    database.plexResolvedOriginQueries.deleteForServer(serverId)
+                }
+            }
         } else {
             val trimmed = origin.trimEnd('/')
             if (memoryCache[key] == trimmed) memoryCache.remove(key)
             if (lastGoodByServer[serverId] == trimmed) lastGoodByServer.remove(serverId)
+            scope.launch {
+                databaseWriteGate.withWrite {
+                    database.plexResolvedOriginQueries.deleteOrigin(
+                        serverId = serverId,
+                        networkFingerprint = fingerprint,
+                        origin = trimmed,
+                    )
+                }
+            }
         }
     }
 

--- a/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexServerConnections.kt
+++ b/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexServerConnections.kt
@@ -8,10 +8,9 @@ import com.phoebe.app.platform.ipv4Slash24Prefix
  * Ordered Plex server base URLs — Plex-advertised LAN first, synthesized fallbacks last.
  *
  * Plex often advertises `https://172-105-8-66.<token>.plex.direct:8443` alongside
- * `http://192.168.x.x:32400`. We synthesize `http://172.105.8.66:32400` from the plex.direct
- * hostname, but that address is usually the server's *public* IP and is often unreachable on
- * LAN; real local URLs from Plex must win. Servers requiring HTTPS get no synthesized entries
- * at all — see [expandConnectionUris].
+ * `http://192.168.x.x:32400`. We only synthesize `http://<ip>:32400` when the plex.direct
+ * host encodes a *private* address; a WAN IP on :32400 is usually closed and burns failover
+ * budget. Servers requiring HTTPS get no synthesized entries at all — see [expandConnectionUris].
  *
  * When [demoteLocalOrigins] is true (cellular / unknown Wi-Fi), LAN-only hosts sort after
  * remote relays so playback and API probes do not burn seconds on dead private addresses.
@@ -99,10 +98,10 @@ fun bestReachableBaseUri(
 /**
  * Advertised URLs first, then synthesized plain-IP fallbacks derived from plex.direct hosts.
  *
- * `http://<ip>:32400` is the only variant worth synthesizing. Plex's certificate covers
+ * `http://<private-ip>:32400` is the only variant worth synthesizing. Plex's certificate covers
  * `*.<hash>.plex.direct`, so an `https://` URL built from the bare IP can never finish a TLS
- * handshake, and a server with [httpsRequired] refuses the plain-HTTP port outright. Emitting
- * either one just burns entries in the caller's fallback budget on addresses that cannot work.
+ * handshake. A public `http://<wan-ip>:32400` is usually closed (remote access is the 8443
+ * relay). A server with [httpsRequired] refuses the plain-HTTP port outright.
  */
 fun expandConnectionUris(
     advertisedUris: List<String>,
@@ -113,7 +112,8 @@ fun expandConnectionUris(
         addAll(advertised)
         if (httpsRequired) return@buildList
         for (uri in advertised) {
-            decodedIpFromPlexDirect(uri)?.let { ip -> add("http://$ip:32400") }
+            val ip = decodedIpFromPlexDirect(uri) ?: continue
+            if (isPrivateOrLoopbackIpv4(ip)) add("http://$ip:32400")
         }
     }.distinct()
 
@@ -167,10 +167,16 @@ fun isLocalOnlyServerOrigin(uri: String): Boolean {
 }
 
 /**
- * `http://<public-ipv4>:32400` synthesized from a plex.direct WAN host. Remote access uses
- * the 8443 relay; this port is usually closed and burns playback failover budget.
+ * `http://<public-ipv4>:32400` that was not advertised by Plex. Remote access uses the 8443
+ * relay; this port is usually a synthesized WAN fallback and burns playback failover budget.
+ *
+ * When [advertisedUris] contains this origin, it is kept — some servers do expose :32400
+ * on a public address on purpose.
  */
-fun isPublicSynthesizedPlexHttpOrigin(uri: String): Boolean {
+fun isPublicSynthesizedPlexHttpOrigin(
+    uri: String,
+    advertisedUris: Collection<String> = emptyList(),
+): Boolean {
     if (!uri.startsWith("http://", ignoreCase = true)) return false
     if (isLocalOnlyServerOrigin(uri)) return false
     val rest = uri.substringAfter("://")
@@ -180,7 +186,9 @@ fun isPublicSynthesizedPlexHttpOrigin(uri: String): Boolean {
         .toIntOrNull() ?: 80
     if (port != 32400) return false
     val parts = host.split('.')
-    return parts.size == 4 && parts.all { it.toIntOrNull() in 0..255 }
+    if (parts.size != 4 || parts.any { it.toIntOrNull() !in 0..255 }) return false
+    val origin = "http://$host:$port"
+    return advertisedUris.none { it.trimEnd('/') == origin }
 }
 
 /**

--- a/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexServerConnections.kt
+++ b/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexServerConnections.kt
@@ -1,6 +1,8 @@
 package com.phoebe.app.data
 
 import com.phoebe.app.domain.PlexServer
+import com.phoebe.app.platform.NetworkIdentity
+import com.phoebe.app.platform.ipv4Slash24Prefix
 
 /**
  * Ordered Plex server base URLs — Plex-advertised LAN first, synthesized fallbacks last.
@@ -160,11 +162,50 @@ fun isLocalOnlyServerOrigin(uri: String): Boolean {
     if (scheme != "http" && scheme != "https") return false
     val host = uri.substringAfter("://").substringBefore(':').substringBefore('/').lowercase()
     if (host.isBlank() || host == "localhost" || host.endsWith(".local")) return true
-    val ip = when {
-        host.split('.').let { parts -> parts.size == 4 && parts.all { it.toIntOrNull() in 0..255 } } -> host
-        else -> decodedIpFromPlexDirect(uri)
-    } ?: return false
+    val ip = ipv4FromServerOrigin(uri) ?: return false
     return isPrivateOrLoopbackIpv4(ip)
+}
+
+/**
+ * `http://<public-ipv4>:32400` synthesized from a plex.direct WAN host. Remote access uses
+ * the 8443 relay; this port is usually closed and burns playback failover budget.
+ */
+fun isPublicSynthesizedPlexHttpOrigin(uri: String): Boolean {
+    if (!uri.startsWith("http://", ignoreCase = true)) return false
+    if (isLocalOnlyServerOrigin(uri)) return false
+    val rest = uri.substringAfter("://")
+    val host = rest.substringBefore(':').substringBefore('/')
+    val port = rest.substringAfter(':', missingDelimiterValue = "80")
+        .substringBefore('/')
+        .toIntOrNull() ?: 80
+    if (port != 32400) return false
+    val parts = host.split('.')
+    return parts.size == 4 && parts.all { it.toIntOrNull() in 0..255 }
+}
+
+/**
+ * True when this device has IPv4 prefixes and none of them match the server's advertised
+ * LAN addresses — e.g. Windows on `192.168.4.0` vs Plex's `172.16.1.2`.
+ */
+fun NetworkIdentity.shouldSkipAdvertisedLan(server: PlexServer): Boolean {
+    if (localIpv4Prefixes.isEmpty()) return false
+    val locals = (listOf(server.uri) + server.localConnectionUris + server.advertisedConnectionUris)
+        .distinct()
+        .filter { isLocalOnlyServerOrigin(it) }
+    if (locals.isEmpty()) return false
+    return locals.none { origin ->
+        val ip = ipv4FromServerOrigin(origin) ?: return@none false
+        ipv4Slash24Prefix(ip) in localIpv4Prefixes
+    }
+}
+
+internal fun ipv4FromServerOrigin(uri: String): String? {
+    val host = uri.substringAfter("://").substringBefore(':').substringBefore('/').lowercase()
+    if (host.isBlank()) return null
+    host.split('.').let { parts ->
+        if (parts.size == 4 && parts.all { it.toIntOrNull() in 0..255 }) return host
+    }
+    return decodedIpFromPlexDirect(uri)
 }
 
 private fun isPrivateOrLoopbackIpv4(ip: String): Boolean {

--- a/data/providers/plex/src/commonTest/kotlin/com/phoebe/app/PlexServerConnectionsTest.kt
+++ b/data/providers/plex/src/commonTest/kotlin/com/phoebe/app/PlexServerConnectionsTest.kt
@@ -25,14 +25,22 @@ class PlexServerConnectionsTest {
     }
 
     @Test
-    fun expandConnectionUrisAddsOnlyThePlainIpPort() {
+    fun expandConnectionUrisAddsOnlyThePlainLanIpPort() {
         val expanded = expandConnectionUris(
-            listOf("https://172-105-8-66.abc.plex.direct:8443"),
+            listOf("https://172-16-1-2.abc.plex.direct:32400"),
         )
-        assertTrue("http://172.105.8.66:32400" in expanded)
+        assertTrue("http://172.16.1.2:32400" in expanded)
         // Plex's cert covers *.plex.direct, so bare-IP TLS can never complete a handshake.
-        assertFalse("https://172.105.8.66:8443" in expanded)
-        assertFalse("https://172.105.8.66:32400" in expanded)
+        assertFalse("https://172.16.1.2:8443" in expanded)
+        assertFalse("https://172.16.1.2:32400" in expanded)
+    }
+
+    @Test
+    fun expandConnectionUrisDoesNotSynthesizePublicWanHttp32400() {
+        val advertised = "https://172-105-8-66.abc.plex.direct:8443"
+        val expanded = expandConnectionUris(listOf(advertised))
+        assertEquals(listOf(advertised), expanded)
+        assertFalse("http://172.105.8.66:32400" in expanded)
     }
 
     @Test
@@ -63,8 +71,8 @@ class PlexServerConnectionsTest {
     }
 
     @Test
-    fun reachableBaseUrisAdvertisedBeforeSynthesizedIp() {
-        val advertised = listOf("https://172-105-8-66.abc.plex.direct:8443")
+    fun reachableBaseUrisAdvertisedBeforeSynthesizedLanIp() {
+        val advertised = listOf("https://172-16-1-2.abc.plex.direct:32400")
         val server = PlexServer(
             id = "s1",
             name = "plex",
@@ -75,7 +83,7 @@ class PlexServerConnectionsTest {
         )
         val ordered = server.reachableBaseUris()
         assertEquals(advertised.first(), ordered.first())
-        assertTrue(ordered.indexOf("http://172.105.8.66:32400") > 0)
+        assertTrue(ordered.indexOf("http://172.16.1.2:32400") > 0)
     }
 
     @Test
@@ -225,6 +233,12 @@ class PlexServerConnectionsTest {
         assertFalse(isPublicSynthesizedPlexHttpOrigin("http://192.168.4.9:32400"))
         assertFalse(isPublicSynthesizedPlexHttpOrigin("https://45-33-97-28.abc.plex.direct:8443"))
         assertFalse(isPublicSynthesizedPlexHttpOrigin("https://72-58-82-53.abc.plex.direct:32400"))
+        assertFalse(
+            isPublicSynthesizedPlexHttpOrigin(
+                "http://45.33.97.28:32400",
+                advertisedUris = listOf("http://45.33.97.28:32400"),
+            ),
+        )
     }
 
     @Test

--- a/data/providers/plex/src/commonTest/kotlin/com/phoebe/app/PlexServerConnectionsTest.kt
+++ b/data/providers/plex/src/commonTest/kotlin/com/phoebe/app/PlexServerConnectionsTest.kt
@@ -3,9 +3,13 @@ package com.phoebe.app
 import com.phoebe.app.data.decodedIpFromPlexDirect
 import com.phoebe.app.data.expandConnectionUris
 import com.phoebe.app.data.isLocalOnlyServerOrigin
+import com.phoebe.app.data.isPublicSynthesizedPlexHttpOrigin
 import com.phoebe.app.data.reachableBaseUris
+import com.phoebe.app.data.shouldSkipAdvertisedLan
 import com.phoebe.app.data.timelineBaseUris
 import com.phoebe.app.domain.PlexServer
+import com.phoebe.app.platform.NetworkIdentity
+import com.phoebe.app.platform.NetworkTransport
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -211,5 +215,44 @@ class PlexServerConnectionsTest {
             accessToken = "server-specific",
         )
         assertEquals("server-specific", server.authToken("user-token"))
+    }
+
+    @Test
+    fun publicSynthesizedPlexHttpOriginIsTheClosedWanPort() {
+        assertTrue(isPublicSynthesizedPlexHttpOrigin("http://45.33.97.28:32400"))
+        assertTrue(isPublicSynthesizedPlexHttpOrigin("http://72.58.82.53:32400/library/parts/1/file.mp3"))
+        assertFalse(isPublicSynthesizedPlexHttpOrigin("http://172.16.1.2:32400"))
+        assertFalse(isPublicSynthesizedPlexHttpOrigin("http://192.168.4.9:32400"))
+        assertFalse(isPublicSynthesizedPlexHttpOrigin("https://45-33-97-28.abc.plex.direct:8443"))
+        assertFalse(isPublicSynthesizedPlexHttpOrigin("https://72-58-82-53.abc.plex.direct:32400"))
+    }
+
+    @Test
+    fun skipAdvertisedLanWhenClientIsOnADifferentPrivateSubnet() {
+        val server = PlexServer(
+            id = "s1",
+            name = "plex",
+            uri = "http://172.16.1.2:32400",
+            owned = true,
+            advertisedConnectionUris = listOf(
+                "http://172.16.1.2:32400",
+                "https://45-79-210-125.abc.plex.direct:8443",
+            ),
+            localConnectionUris = listOf("http://172.16.1.2:32400"),
+        )
+        val windowsHome = NetworkIdentity(
+            transport = NetworkTransport.Other,
+            fingerprint = "other-home",
+            localIpv4Prefixes = listOf("192.168.4.0"),
+        )
+        assertTrue(windowsHome.shouldSkipAdvertisedLan(server))
+        val onServerLan = NetworkIdentity(
+            transport = NetworkTransport.Other,
+            fingerprint = "other-lan",
+            localIpv4Prefixes = listOf("172.16.1.0"),
+        )
+        assertFalse(onServerLan.shouldSkipAdvertisedLan(server))
+        val unknown = NetworkIdentity(transport = NetworkTransport.Other, fingerprint = "other")
+        assertFalse(unknown.shouldSkipAdvertisedLan(server))
     }
 }

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackOriginResolver.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackOriginResolver.kt
@@ -30,6 +30,12 @@ interface PlaybackOriginResolver {
      */
     suspend fun rediscoverOrigins(): List<String> = emptyList()
 
+    /**
+     * Drop a stream origin that just failed (handshake, connection refused, timeout) so the
+     * next play does not hydrate it from disk and stall on the same dead relay.
+     */
+    fun forgetOrigin(origin: String) = Unit
+
     companion object {
         const val DefaultPlayResolveDeadlineMs = 700L
     }

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackUrlOrigins.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackUrlOrigins.kt
@@ -68,10 +68,15 @@ fun playbackOriginCandidates(
 ): List<String> {
     val preferred = preferredOrigin?.trimEnd('/')?.takeIf { it.isNotBlank() }
         ?: server?.uri?.trimEnd('/')?.takeIf { it.isNotBlank() }
-    val fromServer = server?.reachableBaseUris(
-        preferredFirst = preferred,
-        demoteLocalOrigins = demoteLocalOrigins,
-    ).orEmpty().map { it.trimEnd('/') }.filterNot(::isPublicSynthesizedPlexHttpOrigin)
+    val fromServer = server?.let { plex ->
+        plex.reachableBaseUris(
+            preferredFirst = preferred,
+            demoteLocalOrigins = demoteLocalOrigins,
+        ).map { it.trimEnd('/') }
+            .filterNot { origin ->
+                isPublicSynthesizedPlexHttpOrigin(origin, plex.advertisedConnectionUris)
+            }
+    }.orEmpty()
     // reachableBaseUris already applies demotion to preferredFirst; do not re-prepend
     // server.uri / a stale LAN preferred and undo remote-first ordering.
     if (fromServer.isNotEmpty()) return fromServer

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackUrlOrigins.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackUrlOrigins.kt
@@ -1,6 +1,7 @@
 package com.phoebe.app.player
 
 import com.phoebe.app.data.isLocalOnlyServerOrigin
+import com.phoebe.app.data.isPublicSynthesizedPlexHttpOrigin
 import com.phoebe.app.data.reachableBaseUris
 import com.phoebe.app.domain.PlexServer
 import com.phoebe.app.domain.Track
@@ -70,7 +71,7 @@ fun playbackOriginCandidates(
     val fromServer = server?.reachableBaseUris(
         preferredFirst = preferred,
         demoteLocalOrigins = demoteLocalOrigins,
-    ).orEmpty().map { it.trimEnd('/') }
+    ).orEmpty().map { it.trimEnd('/') }.filterNot(::isPublicSynthesizedPlexHttpOrigin)
     // reachableBaseUris already applies demotion to preferredFirst; do not re-prepend
     // server.uri / a stale LAN preferred and undo remote-first ordering.
     if (fromServer.isNotEmpty()) return fromServer
@@ -114,7 +115,8 @@ internal fun nextPlaybackFailoverCandidate(
     return candidates.firstOrNull { candidate ->
         candidate.isNotBlank() &&
             candidate !in tried &&
-            !(skipLocalOrigins && isLocalOnlyPlaybackOrigin(candidate))
+            !(skipLocalOrigins && isLocalOnlyPlaybackOrigin(candidate)) &&
+            !isPublicSynthesizedPlexHttpOrigin(candidate)
     }
 }
 

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
@@ -200,7 +200,7 @@ abstract class SimpleAudioPlayer(
                 .onFailure { if (it is CancellationException) throw it }
                 .getOrNull()?.trimEnd('/')?.takeIf { it.isNotBlank() } ?: return@launch
             if (!isPlayRequestCurrent(generation) || !playWhenReady) return@launch
-            val accepted = acceptedPlaybackOrigin(resolved) ?: resolved
+            val accepted = acceptedPlaybackOrigin(resolved) ?: return@launch
             rememberStickyPlaybackOrigin(accepted)
             val current = mutableState.value
             if (current.queue.isEmpty()) return@launch

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
@@ -174,37 +174,56 @@ abstract class SimpleAudioPlayer(
         clearStickyIfDemoted()
         val knownOrigin = acceptedPlaybackOrigin(resolver?.cachedOrigin())
             ?: acceptedPlaybackOrigin(stickyPlaybackOrigin)
-        if (knownOrigin != null) {
-            launchPreparedPlayback(
-                queue = queue.withResolvedOrigin(knownOrigin),
-                startIndex = startIndex,
-                generation = generation,
-                sameQueue = sameQueue,
-                origin = knownOrigin,
-            )
-            return
-        }
-        // Cold start: play the already-stamped queue URLs now; learn the winner in the background.
         launchPreparedPlayback(
-            queue = queue,
+            queue = if (knownOrigin != null) queue.withResolvedOrigin(knownOrigin) else queue,
             startIndex = startIndex,
             generation = generation,
             sameQueue = sameQueue,
-            origin = null,
+            origin = knownOrigin,
         )
         if (resolver == null) return
+        followOriginResolutionInBackground(generation, resolver)
+    }
+
+    /**
+     * Cache can be a dead relay from last launch. Probe in the background and switch the
+     * in-flight buffer if a different origin wins, instead of waiting out JavaFX's 10s hang.
+     */
+    private fun followOriginResolutionInBackground(
+        generation: Int,
+        resolver: PlaybackOriginResolver,
+    ) {
         scope.launch {
             val resolved = runCatching {
                 resolver.resolveOrigin(PlaybackOriginResolver.DefaultPlayResolveDeadlineMs)
-            }.getOrNull()?.trimEnd('/')?.takeIf { it.isNotBlank() } ?: return@launch
-            if (!isPlayRequestCurrent(generation)) return@launch
-            rememberStickyPlaybackOrigin(resolved)
+            }
+                .onFailure { if (it is CancellationException) throw it }
+                .getOrNull()?.trimEnd('/')?.takeIf { it.isNotBlank() } ?: return@launch
+            if (!isPlayRequestCurrent(generation) || !playWhenReady) return@launch
+            val accepted = acceptedPlaybackOrigin(resolved) ?: resolved
+            rememberStickyPlaybackOrigin(accepted)
             val current = mutableState.value
             if (current.queue.isEmpty()) return@launch
-            val rebased = current.queue.withResolvedOrigin(resolved)
-            if (rebased === current.queue) return@launch
-            mutableState.value = current.copy(queue = rebased)
-            onQueueEdited(rebased, current.currentIndex)
+            val playing = current.currentTrack ?: return@launch
+            val currentUri = StreamingPlaybackPolicyHolder.resolvePlaybackUri(playing)
+                .ifBlank { playing.streamUrl }
+            val rebased = current.queue.withResolvedOrigin(accepted)
+            if (rebased !== current.queue) {
+                mutableState.value = current.copy(queue = rebased)
+                onQueueEdited(rebased, current.currentIndex)
+            }
+            if (!mutableState.value.isBuffering) return@launch
+            val nextTrack = rebased.getOrNull(current.currentIndex) ?: playing
+            val nextUri = StreamingPlaybackPolicyHolder.resolvePlaybackUri(nextTrack)
+                .ifBlank { nextTrack.streamUrl }
+            if (nextUri.isBlank()) return@launch
+            val currentOrigin = playbackOriginOf(currentUri)
+            val nextOrigin = playbackOriginOf(nextUri) ?: return@launch
+            if (currentOrigin != null && currentOrigin.equals(nextOrigin, ignoreCase = true)) return@launch
+            if (nextUri in triedPlaybackUris) return@launch
+            forgetFailedPlaybackOrigin(currentUri)
+            notePlaybackUri(currentUri, generation)
+            startFailoverAttempt(generation, nextUri)
         }
     }
 
@@ -976,6 +995,7 @@ abstract class SimpleAudioPlayer(
 
     protected fun replayWithFailoverUri(generation: Int, failedUri: String?): Boolean {
         if (!isPlayRequestCurrent(generation) || !playWhenReady) return false
+        forgetFailedPlaybackOrigin(failedUri)
         val next = nextPlaybackFailoverUri(generation, failedUri)
             ?: return rediscoverOriginsAndRetry(generation, failedUri)
         val trackId = mutableState.value.currentTrack?.id
@@ -1010,6 +1030,14 @@ abstract class SimpleAudioPlayer(
             startPositionMs = resumePositionMs,
         )
         return true
+    }
+
+    private fun forgetFailedPlaybackOrigin(failedUri: String?) {
+        val origin = failedUri?.let(::playbackOriginOf)?.takeIf { it.isNotBlank() } ?: return
+        if (stickyPlaybackOrigin?.let { playbackOriginOf(it) }?.equals(origin, ignoreCase = true) == true) {
+            stickyPlaybackOrigin = null
+        }
+        PlaybackOriginResolverHolder.resolver?.forgetOrigin(origin)
     }
 
     /**

--- a/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
@@ -166,6 +166,46 @@ class PlayerStateTest {
     }
 
     @Test
+    fun backgroundResolveDoesNotRestoreDemotedLanOrigin() = runTest {
+        val lanOrigin = "http://192.168.1.9:32400"
+        PlaybackOriginResolverHolder.resolver = object : PlaybackOriginResolver {
+            override fun cachedOrigin(): String? = null
+            override suspend fun resolveOrigin(deadlineMs: Long): String {
+                delay(20)
+                return lanOrigin
+            }
+            override fun demoteLocalOrigins(): Boolean = true
+        }
+        try {
+            val player = QueueAwareTestPlayer(this)
+            val remote = "https://relay.example/library/parts/1/file.mp3"
+            player.play(
+                listOf(
+                    Track(
+                        id = "t1",
+                        title = "One",
+                        artist = "Artist",
+                        album = "Album",
+                        durationMs = 60_000,
+                        streamUrl = remote,
+                        downloadUrl = "",
+                        playbackFallbackUrls = listOf("$lanOrigin/library/parts/1/file.mp3"),
+                    ),
+                ),
+                0,
+            )
+            assertEquals(1, player.fullLoads)
+            assertEquals(remote, player.state.value.currentTrack?.streamUrl)
+            advanceTimeBy(25)
+            runCurrent()
+            assertEquals(remote, player.state.value.currentTrack?.streamUrl)
+            assertEquals(1, player.fullLoads)
+        } finally {
+            PlaybackOriginResolverHolder.resolver = null
+        }
+    }
+
+    @Test
     fun stalledPlatformStartupFailsInsteadOfBufferingForever() = runTest {
         val player = TimeoutTestPlayer(this)
         val tracks = listOf(

--- a/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
@@ -157,8 +157,9 @@ class PlayerStateTest {
             assertTrue(player.state.value.isBuffering)
             advanceTimeBy(25)
             runCurrent()
-            // Background resolve learns the winner for later tracks without restarting.
-            assertEquals(warm, player.state.value.queue.first().streamUrl)
+            // Probe won a different origin while still buffering — switch now, don't wait for timeout.
+            assertEquals(warm, player.state.value.currentTrack?.streamUrl)
+            assertEquals(2, player.fullLoads)
         } finally {
             PlaybackOriginResolverHolder.resolver = null
         }

--- a/playback/src/commonTest/kotlin/com/phoebe/app/player/PlaybackUrlOriginsTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/player/PlaybackUrlOriginsTest.kt
@@ -261,6 +261,38 @@ class PlaybackUrlOriginsTest {
     }
 
     @Test
+    fun playbackOriginCandidatesOmitPublicHttp32400Fallbacks() {
+        val relay = "https://45-33-97-28.abc.plex.direct:8443"
+        val closedWan = "http://45.33.97.28:32400"
+        val server = PlexServer(
+            id = "plex",
+            name = "Plex",
+            uri = relay,
+            owned = true,
+            connectionUris = listOf(relay, closedWan),
+            advertisedConnectionUris = listOf(relay),
+        )
+        val origins = playbackOriginCandidates(server = server, preferredOrigin = relay)
+        assertEquals(relay, origins.first())
+        assertFalse(closedWan in origins)
+    }
+
+    @Test
+    fun failoverSkipsSynthesizedPublicHttp32400() {
+        val relay = "https://45-33-97-28.abc.plex.direct:8443/library/parts/18901/file.mp3"
+        val closedWan = "http://45.33.97.28:32400/library/parts/18901/file.mp3"
+        val nextRelay = "https://23-239-17-63.abc.plex.direct:8443/library/parts/18901/file.mp3"
+        assertEquals(
+            nextRelay,
+            nextPlaybackFailoverCandidate(
+                candidates = listOf(relay, closedWan, nextRelay),
+                tried = setOf(relay),
+                failedUri = relay,
+            ),
+        )
+    }
+
+    @Test
     fun transcodeFailureFallsBackToOriginalPartUrl() {
         val original = "https://23-92-30-53.abc.plex.direct:8443/library/parts/9.flac?X-Plex-Token=token"
         val transcode =

--- a/playback/src/commonTest/kotlin/com/phoebe/app/player/PlaybackUrlOriginsTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/player/PlaybackUrlOriginsTest.kt
@@ -278,6 +278,22 @@ class PlaybackUrlOriginsTest {
     }
 
     @Test
+    fun playbackOriginCandidatesKeepAdvertisedPublicHttp32400() {
+        val relay = "https://45-33-97-28.abc.plex.direct:8443"
+        val advertisedWan = "http://45.33.97.28:32400"
+        val server = PlexServer(
+            id = "plex",
+            name = "Plex",
+            uri = relay,
+            owned = true,
+            connectionUris = listOf(relay, advertisedWan),
+            advertisedConnectionUris = listOf(relay, advertisedWan),
+        )
+        val origins = playbackOriginCandidates(server = server, preferredOrigin = relay)
+        assertTrue(advertisedWan in origins)
+    }
+
+    @Test
     fun failoverSkipsSynthesizedPublicHttp32400() {
         val relay = "https://45-33-97-28.abc.plex.direct:8443/library/parts/18901/file.mp3"
         val closedWan = "http://45.33.97.28:32400/library/parts/18901/file.mp3"


### PR DESCRIPTION
## Summary
- Skip synthesized `http://<public-ip>:32400` candidates during playback (those WAN ports are usually closed and burn the 9s-per-URL failover budget).
- Demote advertised LAN when the client is on a different private subnet, and forget unreachable origins so the next play does not hydrate the same dead relay.
- Probe cache in the background (`resolve` stays non-blocking on Android Main; playback uses `resolveFresh`) and switch the in-flight buffer if a different origin wins.

## Test plan
- [ ] Play a Plex track on Android Wi-Fi that previously stalled around 8:54 CDT — failover should not walk `http://72.58.82.53:32400` / `http://45.79.210.125:32400`
- [ ] Confirm Sentry no longer shows those synthesized public HTTP origins in playback URI walks after this build
- [ ] Desktop: play while the cached origin is a dead relay; buffering should switch when the background probe wins instead of hanging ~10s on JavaFX
- [ ] On-LAN playback still prefers the server LAN when the client shares that subnet

Local: `:data:providers:plex:desktopTest`, `:playback:desktopTest`, `:core:platform:desktopTest`, `:composeApp:compileKotlinDesktop`


Made with [Cursor](https://cursor.com)