### PR TITLE
Key artwork by path instead of origin and fail fast on unbound Plex paths

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeDesktopPlayer.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeDesktopPlayer.kt
@@ -547,6 +547,7 @@ internal fun DesktopPlayer(
                                             onLibraryColumns = onLibraryColumns,
                                             onCollectionItems = onCollectionValue,
                                             onSearchQuery = onSearchQuery,
+                                            onAddToEndOfQueue = onAddToEndOfQueue,
                                         ),
                                         modifier = Modifier.fillMaxSize(),
                                     )

--- a/feature/details/src/commonMain/kotlin/com/phoebe/app/feature/details/PhoebeDetailPanels.kt
+++ b/feature/details/src/commonMain/kotlin/com/phoebe/app/feature/details/PhoebeDetailPanels.kt
@@ -2174,6 +2174,11 @@ fun ArtistDetailPanel(
             ?.take(10)
             ?: popularTracksFromPlayHistory(tracks, playHistory, limit = 10)
     }
+    val onPlayPopularTracks: (List<Track>, Int) -> Unit = { tracksToPlay, index ->
+        onPlayTracks(tracksToPlay, index)
+        val playedIds = tracksToPlay.mapTo(mutableSetOf()) { it.id }
+        tracks.filterNot { it.id in playedIds }.shuffled().forEach(onAddToEndOfQueue)
+    }
     val albumWord = if (albums.size == 1) "album" else "albums"
     val songWord = if (tracks.size == 1) "song" else "songs"
 
@@ -2339,7 +2344,7 @@ fun ArtistDetailPanel(
                                             tracks = popularTracks,
                                             useTable = true,
                                             columns = libraryUi.columns,
-                                            onPlayTracks = onPlayTracks,
+                                            onPlayTracks = onPlayPopularTracks,
                                             onAddToUpNext = onAddToUpNext,
                                             onDownload = onDownload,
                                             onAddToEndOfQueue = onAddToEndOfQueue,
@@ -2394,7 +2399,7 @@ fun ArtistDetailPanel(
                                         tracks = popularTracks,
                                         useTable = false,
                                         columns = libraryUi.columns,
-                                        onPlayTracks = onPlayTracks,
+                                        onPlayTracks = onPlayPopularTracks,
                                         onAddToUpNext = onAddToUpNext,
                                         onDownload = onDownload,
                                         modifier = contentPaddingModifier.padding(top = 8.dp),

--- a/feature/details/src/commonMain/kotlin/com/phoebe/app/feature/details/PhoebeDetailPanels.kt
+++ b/feature/details/src/commonMain/kotlin/com/phoebe/app/feature/details/PhoebeDetailPanels.kt
@@ -2175,9 +2175,12 @@ fun ArtistDetailPanel(
             ?: popularTracksFromPlayHistory(tracks, playHistory, limit = 10)
     }
     val onPlayPopularTracks: (List<Track>, Int) -> Unit = { tracksToPlay, index ->
-        onPlayTracks(tracksToPlay, index)
         val playedIds = tracksToPlay.mapTo(mutableSetOf()) { it.id }
-        tracks.filterNot { it.id in playedIds }.shuffled().forEach(onAddToEndOfQueue)
+        val fullQueue = buildList {
+            addAll(tracksToPlay)
+            addAll(tracks.filterNot { it.id in playedIds }.shuffled())
+        }
+        onPlayTracks(fullQueue, index)
     }
     val albumWord = if (albums.size == 1) "album" else "albums"
     val songWord = if (tracks.size == 1) "song" else "songs"

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackUrlOrigins.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackUrlOrigins.kt
@@ -181,9 +181,30 @@ fun Track.withRelativePlexPlaybackPaths(): Track {
 internal fun Track.holdsRelativePlexPath(): Boolean =
     localUri.isNullOrBlank() &&
         streamUrl.isNotBlank() &&
-        !streamUrl.startsWith("http://", ignoreCase = true) &&
-        !streamUrl.startsWith("https://", ignoreCase = true) &&
-        streamUrl.isPlexMediaPathOrUrl()
+        isUnboundServerPath(streamUrl)
+
+/**
+ * True when [uri] is a media-server path that never got an origin bound onto it.
+ *
+ * Such a URI is non-blank but not openable: it has no host. Platform players do not reject it,
+ * they reinterpret it as a local file path — on Android that surfaces as "open failed: ENOENT"
+ * only after the startup watchdog expires, which reads as a hang rather than "server is down".
+ *
+ * Deliberately stricter than [isPlexMediaPathOrUrl], which matches any scheme-less string that
+ * merely *contains* `/library/` — a downloaded file under `.../Music/library/` would qualify.
+ * Only the exact prefixes the catalog stores for unbound Plex assets count here.
+ */
+internal fun isUnboundServerPath(uri: String): Boolean {
+    if (uri.isBlank()) return false
+    // Any scheme at all (file://, content://, http://) means something can open it.
+    if (Regex("^[a-zA-Z][a-zA-Z0-9+.-]*:").containsMatchIn(uri)) return false
+    val path = uri.substringBefore('?')
+    return path.startsWith("/library/") ||
+        path.startsWith("/playlists/") ||
+        path.startsWith("/photo/") ||
+        path.startsWith("/:/") ||
+        path.startsWith("/music/:/transcode/")
+}
 
 internal fun Track.playbackUriCandidates(): List<String> {
     localUri?.takeIf { it.isNotBlank() }?.let { return listOf(it) }

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
@@ -197,6 +197,14 @@ abstract class SimpleAudioPlayer(
                 .getOrNull()?.trimEnd('/')?.takeIf { it.isNotBlank() }
             if (!isPlayRequestCurrent(generation) || !playWhenReady) return@launch
             val accepted = acceptedPlaybackOrigin(resolved)
+            // No origin and nothing to bind the queue onto: the server is unreachable right now.
+            // Opening anyway hands the platform player a host-less `/library/parts/...` path,
+            // which ExoPlayer reads as a local file and fails with a bare ENOENT ~9s later
+            // (the startup watchdog). Say so immediately instead.
+            if (accepted == null && track.holdsRelativePlexPath()) {
+                failServerUnreachable(track, generation)
+                return@launch
+            }
             val playbackQueue = if (accepted != null) queue.withResolvedOrigin(accepted) else queue
             launchPreparedPlayback(
                 queue = playbackQueue,
@@ -277,18 +285,39 @@ abstract class SimpleAudioPlayer(
      * resolves a schemeless/empty URI to a local file path and crashes with a bare
      * "open failed: ENOENT" instead of a reportable player error. Checking here lets that one
      * track fail with a normal [PlaybackFailure] instead.
+     *
+     * A still-relative Plex path (`/library/parts/...`) is the same trap: it is non-blank, so
+     * it survives the emptiness check, but no origin has been bound onto it yet. Every caller
+     * must have resolved an origin first, so treat an unbound path as "nothing to play".
      */
     private fun resolvedInitialPlaybackUriOrNull(track: Track): String? =
         StreamingPlaybackPolicyHolder.resolvePlaybackUri(track)
             .ifBlank { track.playbackUriCandidates().firstOrNull().orEmpty() }
-            .takeIf { it.isNotBlank() }
+            .takeIf { it.isNotBlank() && !isUnboundServerPath(it) }
 
     private fun failNoPlayableSource(track: Track, generation: Int) {
+        // An unbound server path means "no live origin", not "this file is missing". NotFound
+        // walks the queue, which would march through every song while the server is down.
+        if (track.localUri.isNullOrBlank() && track.holdsRelativePlexPath()) {
+            failServerUnreachable(track, generation)
+            return
+        }
         PhoebeLog.d("AudioPlayer") { "no playable uri for track=${track.id}; skipping" }
         publishPlaybackFailure(
             PlaybackFailure(
                 kind = PlaybackFailureKind.NotFound,
                 message = "no playable source for track ${track.id}",
+            ),
+            generation,
+        )
+    }
+
+    private fun failServerUnreachable(track: Track, generation: Int) {
+        PhoebeLog.d("AudioPlayer") { "no live origin for track=${track.id}; server unreachable" }
+        publishPlaybackFailure(
+            PlaybackFailure(
+                kind = PlaybackFailureKind.Unreachable,
+                message = "no live music-server origin for track ${track.id}",
             ),
             generation,
         )

--- a/playback/src/commonTest/kotlin/com/phoebe/app/player/UnboundServerPathTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/player/UnboundServerPathTest.kt
@@ -1,0 +1,79 @@
+package com.phoebe.app.player
+
+import com.phoebe.app.domain.Track
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * A host-less server path must never reach the platform player. ExoPlayer reinterprets it as a
+ * local file and reports "open failed: ENOENT" only once the startup watchdog expires, so the
+ * user sees a ~9s hang followed by a wrong error instead of "can't reach the server".
+ */
+class UnboundServerPathTest {
+    @Test
+    fun relativePlexPartKeyIsUnbound() {
+        assertTrue(isUnboundServerPath("/library/parts/36576/file.mp3"))
+        assertTrue(isUnboundServerPath("/library/parts/36576/file.mp3?download=1"))
+        assertTrue(isUnboundServerPath("/music/:/transcode/universal/start.mp3?maxAudioBitrate=320"))
+        assertTrue(isUnboundServerPath("/photo/:/transcode?width=512"))
+        assertTrue(isUnboundServerPath("/:/timeline"))
+        assertTrue(isUnboundServerPath("/playlists/12/items"))
+    }
+
+    @Test
+    fun boundAbsoluteUrlIsPlayable() {
+        assertFalse(
+            isUnboundServerPath(
+                "https://45-79-210-225.abc.plex.direct:8443/library/parts/36576/file.mp3?X-Plex-Token=t",
+            ),
+        )
+        assertFalse(isUnboundServerPath("http://192.168.1.20:32400/library/parts/1/file.flac"))
+    }
+
+    /**
+     * The regression this guard exists for: [com.phoebe.app.data.isPlexMediaPathOrUrl] matches any
+     * scheme-less string merely *containing* `/library/`, so a downloaded file living under a
+     * `library` folder would have been misread as an unplayable server path.
+     */
+    @Test
+    fun localFilesAreNeverTreatedAsUnbound() {
+        assertFalse(isUnboundServerPath("file:///Users/joe/Music/library/song.flac"))
+        assertFalse(isUnboundServerPath("content://media/external/audio/media/42"))
+        assertFalse(isUnboundServerPath("/storage/emulated/0/Music/library/song.flac"))
+        assertFalse(isUnboundServerPath("/Users/joe/Library/Phoebe/downloads/song.mp3"))
+        assertFalse(isUnboundServerPath(""))
+    }
+
+    @Test
+    fun downloadedTrackDoesNotHoldARelativePathEvenWithAServerStreamUrl() {
+        val downloaded = Track(
+            id = "track:1",
+            title = "One",
+            artist = "Artist",
+            album = "Album",
+            durationMs = 1_000,
+            streamUrl = "/library/parts/36576/file.mp3",
+            downloadUrl = "/library/parts/36576/file.mp3",
+            localUri = "file:///data/user/0/com.phoebe.app/files/downloads/one.mp3",
+        )
+
+        // A downloaded song must stay playable while the server is unreachable.
+        assertFalse(downloaded.holdsRelativePlexPath())
+    }
+
+    @Test
+    fun streamingTrackWithNoOriginHoldsARelativePath() {
+        val streaming = Track(
+            id = "track:2",
+            title = "Two",
+            artist = "Artist",
+            album = "Album",
+            durationMs = 1_000,
+            streamUrl = "/library/parts/36576/file.mp3",
+            downloadUrl = "/library/parts/36576/file.mp3",
+        )
+
+        assertTrue(streaming.holdsRelativePlexPath())
+    }
+}

--- a/ui/media/src/androidMain/kotlin/com/phoebe/app/ui/ArtworkDiskCache.android.kt
+++ b/ui/media/src/androidMain/kotlin/com/phoebe/app/ui/ArtworkDiskCache.android.kt
@@ -1,6 +1,7 @@
 package com.phoebe.app.ui
 
 import com.phoebe.app.AndroidContextHolder
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -88,3 +89,5 @@ private class AndroidArtworkDiskCacheBackend : ArtworkDiskCacheBackend {
 private const val ArtworkDiskCacheDirectory = "phoebe-artwork"
 private const val MaxArtworkDiskCacheBytes = 128L * 1024L * 1024L
 private const val TrimIntervalMs = 5L * 60L * 1000L
+
+internal actual fun artworkIoDispatcher(): CoroutineDispatcher = Dispatchers.IO

--- a/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/ArtworkCacheKey.kt
+++ b/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/ArtworkCacheKey.kt
@@ -1,0 +1,104 @@
+package com.phoebe.app.ui
+
+import com.phoebe.app.data.bindPlexCoverArt
+import com.phoebe.app.data.isPlexMediaPathOrUrl
+
+/**
+ * A host that never resolves, used only to build a fetch URL whose *shape* is right when no
+ * live origin is known yet. [stableArtworkCacheKey] strips the origin back off, so a URL built
+ * on this placeholder keys identically to the same asset fetched from a real relay or LAN hop.
+ */
+private const val PlaceholderArtworkOrigin = "https://origin.invalid"
+
+/**
+ * Query parameters that identify the *session* rather than the *image*.
+ *
+ * Plex reissues `X-Plex-Token`, and Subsonic's `u`/`t`/`s`/`p` rotate per request. Leaving them
+ * in a cache key means every token refresh silently orphans the entire artwork cache.
+ */
+private val VolatileArtworkQueryParams = setOf(
+    "x-plex-token",
+    "api_key",
+    "apikey",
+    "u",
+    "p",
+    "t",
+    "s",
+    "c",
+    "v",
+)
+
+/**
+ * Origin- and token-independent Coil cache key for an artwork fetch URL.
+ *
+ * Coil keys its memory and disk caches by request URL (`options.diskCacheKey ?: url`). Ours embed
+ * the live Plex origin and the session token, which has two costs: the cache is orphaned wholesale
+ * every time the relay rotates, and — the expensive one — it cannot be consulted at all until an
+ * origin has been probed. That is exactly the window where a cold start most needs it: a phone that
+ * spent 45s failing to reach any Plex hop still had every thumbnail on disk and could not show one.
+ *
+ * Keying on path + non-volatile query keeps entries valid across every hop to the same server.
+ *
+ * Returns null for local `file://` / `content://` artwork, where Coil's own key is already stable
+ * and no origin is involved.
+ */
+internal fun stableArtworkCacheKey(fetchUrl: String): String? {
+    val raw = fetchUrl.trim()
+    if (raw.isBlank()) return null
+    val remote = raw.startsWith("http://", ignoreCase = true) ||
+        raw.startsWith("https://", ignoreCase = true)
+    val identity = when {
+        remote -> originIndependentRemotePath(raw)
+        // A host-less Plex path is already origin-independent.
+        raw.isPlexMediaPathOrUrl() -> normalizeArtworkPathAndQuery(raw)
+        else -> null
+    } ?: return null
+    return "phoebe-art:$identity"
+}
+
+/** Strip `scheme://host:port` and session query parameters, keeping a stable parameter order. */
+private fun originIndependentRemotePath(url: String): String? {
+    val withoutFragment = url.substringBefore('#')
+    val afterScheme = withoutFragment.substringBefore('?').substringAfter("://", "")
+    if (afterScheme.isBlank()) return null
+    val slash = afterScheme.indexOf('/')
+    val path = if (slash < 0) "/" else afterScheme.substring(slash)
+    return normalizeArtworkPathAndQuery(path + queryOf(withoutFragment))
+}
+
+private fun queryOf(withoutFragment: String): String =
+    withoutFragment.substringAfter('?', "").let { if (it.isBlank()) "" else "?$it" }
+
+private fun normalizeArtworkPathAndQuery(pathAndQuery: String): String {
+    val path = pathAndQuery.substringBefore('?').ifBlank { "/" }
+    val params = pathAndQuery.substringAfter('?', "")
+        .split('&')
+        .filter { it.isNotBlank() }
+        .filterNot { it.substringBefore('=').lowercase() in VolatileArtworkQueryParams }
+        // Sorted so a parameter reordering upstream cannot split one image across two entries.
+        .sorted()
+    return if (params.isEmpty()) path else "$path?${params.joinToString("&")}"
+}
+
+/**
+ * The fetch URLs this artwork *would* use, built against [PlaceholderArtworkOrigin].
+ *
+ * Used to look an image up in Coil's disk cache before any origin is known. Because
+ * [stableArtworkCacheKey] discards the origin, these key identically to the real requests.
+ */
+internal fun placeholderArtworkFetchUrls(sourceUrl: String, maxDecodeDimension: Int): List<String> {
+    val raw = sourceUrl.trim()
+    if (raw.isBlank()) return emptyList()
+    if (raw.isPlexMediaPathOrUrl()) {
+        return listOf(
+            bindPlexCoverArt(raw, PlaceholderArtworkOrigin, token = "", size = maxDecodeDimension),
+            bindPlexCoverArt(raw, PlaceholderArtworkOrigin, token = "", size = null),
+        ).distinct()
+    }
+    if (!raw.startsWith("http://", ignoreCase = true) &&
+        !raw.startsWith("https://", ignoreCase = true)
+    ) {
+        return emptyList()
+    }
+    return remoteArtworkRequestUrls(raw, maxDecodeDimension)
+}

--- a/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/ArtworkDiskCache.kt
+++ b/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/ArtworkDiskCache.kt
@@ -1,11 +1,21 @@
 package com.phoebe.app.ui
 
+import kotlinx.coroutines.CoroutineDispatcher
+
 internal interface ArtworkDiskCacheBackend {
     suspend fun read(fetchUrl: String): ByteArray?
     suspend fun write(fetchUrl: String, bytes: ByteArray)
 }
 
 internal expect fun defaultArtworkDiskCacheBackend(): ArtworkDiskCacheBackend
+
+/**
+ * Dispatcher for blocking artwork file reads.
+ *
+ * Reading a cache snapshot is blocking I/O, and parking it on [kotlinx.coroutines.Dispatchers.Default]
+ * starves the shared compute pool — the same failure mode that made tapping a song freeze the UI.
+ */
+internal expect fun artworkIoDispatcher(): CoroutineDispatcher
 
 internal object NoopArtworkDiskCacheBackend : ArtworkDiskCacheBackend {
     override suspend fun read(fetchUrl: String): ByteArray? = null

--- a/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeArtwork.kt
+++ b/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeArtwork.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
@@ -92,6 +93,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.yield
 import kotlin.math.PI
@@ -180,10 +182,21 @@ private fun CoilArtworkImage(
             ImageRequest.Builder(platformContext)
                 .data(it.fetchUrl)
                 .applyArtworkHeaders(it.fetchUrl)
+                .applyStableArtworkCacheKeys(it.fetchUrl)
                 .build()
         }
     }
     val imageLoader = rememberPhoebeArtworkImageLoader(platformContext)
+    // Paint from Coil's disk cache while the origin is still being probed. Without this the
+    // whole screen sits on spinners for as long as `/identity` takes, even though every one of
+    // these images is already on disk.
+    val diskPreview = rememberDiskCachedArtwork(
+        imageLoader = imageLoader,
+        thumbUrl = thumbUrl,
+        fallbackThumbUrl = fallbackThumbUrl,
+        maxDecodeDimension = maxDecodeDimension,
+        enabled = waitingForLiveOrigin,
+    )
     val painter = key(candidate?.fetchUrl, candidateIndex, maxDecodeDimension, waitingForLiveOrigin, retryAttempt) {
         rememberAsyncImagePainter(model = request, imageLoader = imageLoader)
     }
@@ -216,17 +229,19 @@ private fun CoilArtworkImage(
         }
     }
 
+    val diskPreviewPainter = remember(diskPreview) { diskPreview?.let(::BitmapPainter) }
     val visualState = resolveCoilArtworkVisualState(
         painterState = painterState,
         hasCandidate = candidate != null,
         exhaustedCandidates = candidateIndex >= candidates.lastIndex && retryAttempt >= MaxArtworkLoadAutoRetries,
-        hasRetainedPainter = retainedPainter != null,
+        hasRetainedPainter = retainedPainter != null || diskPreviewPainter != null,
         retainFallbackWhileLoading = retainFallbackWhileLoading,
         waitingForLiveOrigin = waitingForLiveOrigin,
     )
     val displayPainter = when {
         painterState.painter != null -> painter
-        else -> retainedPainter
+        retainedPainter != null -> retainedPainter
+        else -> diskPreviewPainter
     }
 
     Box(modifier) {
@@ -284,6 +299,75 @@ internal fun phoebeArtworkImageLoader(context: PlatformContext): ImageLoader {
 private fun rememberPhoebeArtworkImageLoader(context: PlatformContext): ImageLoader {
     val loaderContext = stableArtworkImageLoaderContext(context)
     return remember(loaderContext) { phoebeArtworkImageLoader(context) }
+}
+
+/**
+ * Pin this request to an origin-independent cache key.
+ *
+ * See [stableArtworkCacheKey]: without it Coil keys on the full URL, so the relay host and the
+ * session token become part of the key and every cached thumbnail is orphaned the moment either
+ * one changes.
+ */
+private fun ImageRequest.Builder.applyStableArtworkCacheKeys(fetchUrl: String): ImageRequest.Builder {
+    val key = stableArtworkCacheKey(fetchUrl) ?: return this
+    return memoryCacheKey(key).diskCacheKey(key)
+}
+
+/**
+ * Decode this artwork straight out of Coil's disk cache, bypassing the request pipeline.
+ *
+ * Only used while [enabled] (no probed origin), where the pipeline cannot run at all: there is
+ * no host to build a URL against. Reading the snapshot directly means a cold start paints known
+ * artwork immediately instead of holding spinners for the length of the `/identity` race.
+ */
+@Composable
+private fun rememberDiskCachedArtwork(
+    imageLoader: ImageLoader,
+    thumbUrl: String?,
+    fallbackThumbUrl: String?,
+    maxDecodeDimension: Int,
+    enabled: Boolean,
+): ImageBitmap? = produceState<ImageBitmap?>(
+    initialValue = null,
+    thumbUrl,
+    fallbackThumbUrl,
+    maxDecodeDimension,
+    enabled,
+    imageLoader,
+) {
+    if (!enabled) {
+        value = null
+        return@produceState
+    }
+    val sources = listOfNotNull(
+        thumbUrl?.takeIf { it.isNotBlank() },
+        fallbackThumbUrl?.takeIf { it.isNotBlank() },
+    )
+    if (sources.isEmpty()) return@produceState
+    value = withContext(artworkIoDispatcher()) {
+        sources.firstNotNullOfOrNull { source ->
+            placeholderArtworkFetchUrls(source, maxDecodeDimension)
+                .firstNotNullOfOrNull { fetchUrl ->
+                    val key = stableArtworkCacheKey(fetchUrl) ?: return@firstNotNullOfOrNull null
+                    readDiskCachedArtwork(imageLoader, key, maxDecodeDimension)
+                }
+        }
+    }
+}.value
+
+@OptIn(ExperimentalCoilApi::class)
+private fun readDiskCachedArtwork(
+    imageLoader: ImageLoader,
+    key: String,
+    maxDecodeDimension: Int,
+): ImageBitmap? {
+    val diskCache = imageLoader.diskCache ?: return null
+    return runCatching {
+        diskCache.openSnapshot(key)?.use { snapshot ->
+            val bytes = diskCache.fileSystem.read(snapshot.data) { readByteArray() }
+            bytes.takeIf { it.isNotEmpty() }?.let { decodeImageBitmap(it, maxDecodeDimension) }
+        }
+    }.getOrNull()
 }
 
 @OptIn(ExperimentalCoilApi::class)

--- a/ui/media/src/commonTest/kotlin/com/phoebe/app/ui/ArtworkCacheKeyTest.kt
+++ b/ui/media/src/commonTest/kotlin/com/phoebe/app/ui/ArtworkCacheKeyTest.kt
@@ -1,0 +1,122 @@
+package com.phoebe.app.ui
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ArtworkCacheKeyTest {
+    private val thumbPath = "/library/metadata/1234/thumb/1699999999"
+
+    /**
+     * The whole point: a relay rotation must not orphan the cache. Both of these hops serve the
+     * same bytes, and before this key they were two unrelated disk entries.
+     */
+    @Test
+    fun sameAssetOnDifferentOriginsSharesOneKey() {
+        val lan = stableArtworkCacheKey("http://192.168.1.20:32400$thumbPath?X-Plex-Token=abc")
+        val relay = stableArtworkCacheKey(
+            "https://45-79-210-125.hash.plex.direct:8443$thumbPath?X-Plex-Token=abc",
+        )
+
+        assertNotNull(lan)
+        assertEquals(lan, relay)
+    }
+
+    @Test
+    fun tokenRotationDoesNotChangeTheKey() {
+        val old = stableArtworkCacheKey("https://relay.plex.direct:8443$thumbPath?X-Plex-Token=old")
+        val new = stableArtworkCacheKey("https://relay.plex.direct:8443$thumbPath?X-Plex-Token=new")
+
+        assertNotNull(old)
+        assertEquals(old, new)
+        assertTrue("old" !in old && "new" !in old, "session token leaked into cache key: $old")
+    }
+
+    @Test
+    fun hostlessPlexPathKeysTheSameAsABoundUrl() {
+        val unbound = stableArtworkCacheKey(thumbPath)
+        val bound = stableArtworkCacheKey("https://relay.plex.direct:8443$thumbPath?X-Plex-Token=abc")
+
+        assertNotNull(unbound)
+        assertEquals(unbound, bound)
+    }
+
+    /** Different images must not collide, and different sizes are different bytes on disk. */
+    @Test
+    fun differentAssetsAndSizesKeepDistinctKeys() {
+        val a = stableArtworkCacheKey("https://relay.plex.direct:8443/library/metadata/1/thumb/1")
+        val b = stableArtworkCacheKey("https://relay.plex.direct:8443/library/metadata/2/thumb/1")
+        assertTrue(a != b)
+
+        val small = stableArtworkCacheKey(
+            "https://relay.plex.direct:8443/photo/:/transcode?width=160&height=160&url=%2Fthumb",
+        )
+        val large = stableArtworkCacheKey(
+            "https://relay.plex.direct:8443/photo/:/transcode?width=512&height=512&url=%2Fthumb",
+        )
+        assertTrue(small != large)
+    }
+
+    @Test
+    fun parameterOrderDoesNotSplitOneImageAcrossTwoEntries() {
+        val one = stableArtworkCacheKey(
+            "https://s/photo/:/transcode?width=512&height=512&url=%2Fthumb&X-Plex-Token=t",
+        )
+        val two = stableArtworkCacheKey(
+            "https://s/photo/:/transcode?url=%2Fthumb&height=512&X-Plex-Token=t&width=512",
+        )
+
+        assertNotNull(one)
+        assertEquals(one, two)
+    }
+
+    @Test
+    fun subsonicRotatingAuthIsStrippedButItemIdIsKept() {
+        val first = stableArtworkCacheKey(
+            "https://nav.example/rest/getCoverArt?id=al-42&size=256&u=joe&t=aaa&s=bbb&c=phoebe&v=1.16",
+        )
+        val second = stableArtworkCacheKey(
+            "https://nav.example/rest/getCoverArt?id=al-42&size=256&u=joe&t=ccc&s=ddd&c=phoebe&v=1.16",
+        )
+
+        assertNotNull(first)
+        assertEquals(first, second)
+        assertTrue("id=al-42" in first, "item id must stay in the key: $first")
+        assertTrue("size=256" in first, "size must stay in the key: $first")
+    }
+
+    /** Local artwork has no origin to strip; Coil's own key is already stable there. */
+    @Test
+    fun localAndBlankSourcesHaveNoCustomKey() {
+        assertNull(stableArtworkCacheKey("file:///data/user/0/com.phoebe.app/files/art/1.jpg"))
+        assertNull(stableArtworkCacheKey("content://media/external/audio/albumart/12"))
+        assertNull(stableArtworkCacheKey(""))
+        assertNull(stableArtworkCacheKey("   "))
+    }
+
+    /**
+     * The pre-pass builds fetch URLs on a placeholder host so it can look an image up before any
+     * origin is probed. Those must key identically to the real request or the lookup always misses.
+     */
+    @Test
+    fun placeholderFetchUrlsKeyLikeRealRequests() {
+        val placeholderKeys = placeholderArtworkFetchUrls(thumbPath, GridArtworkMaxDecodeDimension)
+            .mapNotNull { stableArtworkCacheKey(it) }
+        assertTrue(placeholderKeys.isNotEmpty(), "expected placeholder fetch urls for a Plex path")
+
+        val realKeys = artworkOriginFetchCandidates(
+            sourceUrl = thumbPath,
+            maxDecodeDimension = GridArtworkMaxDecodeDimension,
+            liveOrigin = "https://45-79-210-125.hash.plex.direct:8443",
+            plexToken = "a-real-token",
+        ).mapNotNull { stableArtworkCacheKey(it.fetchUrl) }
+        assertTrue(realKeys.isNotEmpty(), "expected real fetch candidates for a Plex path")
+
+        assertTrue(
+            realKeys.all { it in placeholderKeys },
+            "real request keys $realKeys are not covered by placeholder keys $placeholderKeys",
+        )
+    }
+}

--- a/ui/media/src/desktopMain/kotlin/com/phoebe/app/ui/ArtworkDiskCache.desktop.kt
+++ b/ui/media/src/desktopMain/kotlin/com/phoebe/app/ui/ArtworkDiskCache.desktop.kt
@@ -1,4 +1,9 @@
 package com.phoebe.app.ui
 
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
 internal actual fun defaultArtworkDiskCacheBackend(): ArtworkDiskCacheBackend =
     NoopArtworkDiskCacheBackend
+
+internal actual fun artworkIoDispatcher(): CoroutineDispatcher = Dispatchers.IO

--- a/ui/media/src/iosMain/kotlin/com/phoebe/app/ui/ArtworkDiskCache.ios.kt
+++ b/ui/media/src/iosMain/kotlin/com/phoebe/app/ui/ArtworkDiskCache.ios.kt
@@ -1,4 +1,11 @@
 package com.phoebe.app.ui
 
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
 internal actual fun defaultArtworkDiskCacheBackend(): ArtworkDiskCacheBackend =
     NoopArtworkDiskCacheBackend
+
+// `Dispatchers.IO` is internal on Kotlin/Native. Default is a multi-threaded worker pool here,
+// not the single shared compute pool the JVM has, so a short file read on it is acceptable.
+internal actual fun artworkIoDispatcher(): CoroutineDispatcher = Dispatchers.Default

--- a/ui/media/src/wasmJsMain/kotlin/com/phoebe/app/ui/ArtworkDiskCache.wasmJs.kt
+++ b/ui/media/src/wasmJsMain/kotlin/com/phoebe/app/ui/ArtworkDiskCache.wasmJs.kt
@@ -1,4 +1,10 @@
 package com.phoebe.app.ui
 
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
 internal actual fun defaultArtworkDiskCacheBackend(): ArtworkDiskCacheBackend =
     NoopArtworkDiskCacheBackend
+
+// wasmJs has no IO dispatcher; browser storage access is not blocking in the JVM sense.
+internal actual fun artworkIoDispatcher(): CoroutineDispatcher = Dispatchers.Default


### PR DESCRIPTION
## Summary
- Add origin-independent Coil cache keys so artwork survives relay rotation and can be read from disk before any live origin is probed (no more spinner wall during `/identity` races).
- Refuse to open host-less Plex server paths in the player, surfacing unreachable-server errors immediately instead of a ~9s ENOENT hang.
- Playing an artist's popular tracks now queues the rest of their catalog shuffled to the end of the queue.

## Test plan
- [x] `./gradlew :playback:testAndroidHostTest :ui:media:testAndroidHostTest`
- [ ] Cold start with unreachable LAN but cached artwork — thumbnails paint from disk
- [ ] Play a track while server is down — fast "can't reach server" instead of hang
- [ ] Play popular tracks on artist detail — remaining tracks append to queue


Made with [Cursor](https://cursor.com)