### PR TITLE
Improve playback origin resolution and cast/queue reliability

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
@@ -2919,6 +2919,12 @@ class AppState(
         dependencies.catalogRepository.rebasePlexMediaOrigins(candidate, emptyList())
     }
 
+    private data class RetryOriginKey(
+        val serverId: String?,
+        val token: String?,
+        val hasOrigin: Boolean,
+    )
+
     /**
      * Publish the `/identity`-confirmed origin to Coil, and keep racing while there is none.
      *
@@ -2938,16 +2944,33 @@ class AppState(
         }
         // Retry only while there is nothing probed. `collectLatest` cancels the pending backoff
         // the moment a race succeeds or the session changes, so a healthy app is not polling.
+        //
+        // Keyed off (serverId, token, hasOrigin) rather than the raw session: the loop itself
+        // calls refreshSelectedServerConnections() each round, which rewrites selectedServer
+        // (relay reassignment gives a different connection list nearly every call) and used to
+        // re-emit `session` with the *same* server/token. That re-emission fed back into this
+        // same combine and made collectLatest restart the block on every round, resetting
+        // backoffMs to 2s forever instead of doubling (observed: "retry in 2000ms" indefinitely).
         scope.launch {
-            combine(session, resolver.probedOrigin) { current, origin -> current to origin }
-                .collectLatest { (current, origin) ->
-                    if (origin != null) return@collectLatest
-                    val plex = current?.takeIf { it.isPlex() } ?: return@collectLatest
-                    val server = plex.selectedServer ?: return@collectLatest
-                    val token = plex.serverAuthToken() ?: plex.token
-                    if (token.isBlank()) return@collectLatest
+            combine(session, resolver.probedOrigin) { current, origin ->
+                val plex = current?.takeIf { it.isPlex() }
+                RetryOriginKey(
+                    serverId = plex?.selectedServer?.id,
+                    token = plex?.serverAuthToken() ?: plex?.token,
+                    hasOrigin = origin != null,
+                )
+            }
+                .distinctUntilChanged()
+                .collectLatest { key ->
+                    if (key.hasOrigin || key.serverId == null) return@collectLatest
+                    val token = key.token?.takeIf { it.isNotBlank() } ?: return@collectLatest
                     var backoffMs = 2_000L
                     while (!disposed) {
+                        // Re-read the server fresh each round: refreshSelectedServerConnections()
+                        // below may have handed us a new relay/connection list to try.
+                        val server = session.value?.takeIf { it.isPlex() }?.selectedServer
+                            ?.takeIf { it.id == key.serverId }
+                            ?: return@collectLatest
                         val resolved = runCatching {
                             resolver.resolveFresh(server, token)
                         }.onFailure { error ->

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAudioPlayer.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAudioPlayer.kt
@@ -825,10 +825,16 @@ class AndroidAudioPlayer(
             val mediaItem = playbackMediaItem(windowTracks[targetIndex], inAppPlayback = true)
             player.addMediaItem(removeFrom + (targetIndex - prefix), mediaItem)
         }
+        // The reconcile only patches the window from the currently-playing item onward, so any
+        // platform items before platformCurrentIndex are retained untouched. Map them too:
+        // platform index 0 is app index (currentIndex - platformCurrentIndex), and the whole
+        // platform queue is indexable. Recording firstAppIndex == currentIndex (as if the rebuilt
+        // window began at platform 0) would make appIndexFor() double the offset whenever the
+        // queue had already advanced past platform index 0.
         loadedPlatformQueue = LoadedPlatformQueue(
             queueIds = queue.map { it.id },
-            firstAppIndex = currentIndex,
-            itemCount = windowTracks.size,
+            firstAppIndex = currentIndex - platformCurrentIndex,
+            itemCount = player.mediaItemCount,
         )
         return true
     }

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAudioPlayer.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAudioPlayer.kt
@@ -752,20 +752,85 @@ class AndroidAudioPlayer(
             val shouldPlay = playWhenReady && (player.isPlaying || player.playWhenReady)
             appControllerMutationInProgress = true
             try {
-                rebasePlatformQueueOnCurrentTrackLocked(
+                val windowEndExclusive = platformQueueWindowEndExclusive(
+                    startIndex = currentIndex,
+                    queueSize = queue.size,
+                    repeatMode = state.value.repeat,
+                )
+                val windowTracks = queue.subList(currentIndex, windowEndExclusive)
+                val reconciled = reconcilePlatformQueueIncrementally(
                     player = player,
                     queue = queue,
                     currentIndex = currentIndex,
-                    generation = generation,
-                    startPositionMs = positionMs,
-                    shouldPlay = shouldPlay,
+                    windowTracks = windowTracks,
                 )
+                if (!reconciled) {
+                    rebasePlatformQueueOnCurrentTrackLocked(
+                        player = player,
+                        queue = queue,
+                        currentIndex = currentIndex,
+                        generation = generation,
+                        startPositionMs = positionMs,
+                        shouldPlay = shouldPlay,
+                    )
+                }
             } finally {
                 appControllerMutationInProgress = false
             }
             clearPendingPlatformQueueRebase(queue, currentIndex, generation)
             syncFromController(generation)
         }
+    }
+
+    /**
+     * Queue edits (append to end, insert at "up next", remove/move an upcoming item) never
+     * touch the item that's already playing — only its neighbors in the Media3 window. Media3
+     * supports inserting/removing items anywhere in the window via addMediaItem/removeMediaItem
+     * without stopping playback, as long as we never move the currently-playing index itself.
+     * So diff the already-loaded platform ids against the target window (common prefix + common
+     * suffix, same idea as a line diff) and patch just the differing middle span, instead of the
+     * previous unconditional stop/clear/prepare cycle that paused (or, if a second edit raced in
+     * mid-reload, sometimes never resumed) on every single queue edit — including a plain
+     * "add to up next" tap.
+     */
+    private fun reconcilePlatformQueueIncrementally(
+        player: Player,
+        queue: List<Track>,
+        currentIndex: Int,
+        windowTracks: List<Track>,
+    ): Boolean {
+        val platformCurrentIndex = player.currentMediaItemIndex
+        if (platformCurrentIndex < 0) return false
+        val currentIds = (platformCurrentIndex until player.mediaItemCount).map { player.getMediaItemAt(it).mediaId }
+        val targetIds = windowTracks.map { it.id }
+        if (currentIds.isEmpty() || targetIds.isEmpty() || currentIds[0] != targetIds[0]) return false
+
+        val maxOverlap = minOf(currentIds.size, targetIds.size)
+        var prefix = 0
+        while (prefix < maxOverlap && currentIds[prefix] == targetIds[prefix]) prefix++
+        var suffix = 0
+        val maxSuffix = maxOverlap - prefix
+        while (suffix < maxSuffix &&
+            currentIds[currentIds.size - 1 - suffix] == targetIds[targetIds.size - 1 - suffix]
+        ) {
+            suffix++
+        }
+
+        val removeFrom = platformCurrentIndex + prefix
+        val removeToExclusive = platformCurrentIndex + currentIds.size - suffix
+        for (i in removeToExclusive - 1 downTo removeFrom) {
+            player.removeMediaItem(i)
+        }
+        for (targetIndex in prefix until targetIds.size - suffix) {
+            val mediaItem = playbackMediaItem(windowTracks[targetIndex], inAppPlayback = true)
+            player.addMediaItem(removeFrom + (targetIndex - prefix), mediaItem)
+        }
+        loadedPlatformQueue = LoadedPlatformQueue(
+            queueIds = queue.map { it.id },
+            firstAppIndex = currentIndex,
+            itemCount = windowTracks.size,
+        )
+        return true
     }
 
     private suspend fun rebasePlatformQueueOnCurrentTrackLocked(

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidCastController.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidCastController.kt
@@ -147,6 +147,11 @@ private class AndroidCastController : CastController {
         }
 
         override fun onSessionEnding(session: CastSession) {
+            // Reached for any graceful teardown (our own disconnect() call, or the user tapping
+            // Disconnect/Stop casting in the system Cast dialog) — unexpected drops go straight to
+            // onSessionEnded with an error instead. Mark it intentional here so both paths restore
+            // local playback instead of showing a "Reconnecting..." message that's doomed to time out.
+            endingSessionIntentionally = true
             PhoebeLog.d(TAG) { "session ending intentional=$endingSessionIntentionally" }
         }
 

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
@@ -23,6 +23,8 @@ internal const val PlaybackReadyBufferedAheadMs = 500L
 internal const val PlaybackStartupTimeoutMs = 9_000L
 internal const val PlaybackStartupTimeoutLocalMs = 4_000L
 internal const val PlaybackStartupTimeoutRemoteMs = 9_000L
+internal const val ColdOriginResolveAttempts = 2
+internal const val ColdOriginResolveRetryDelayMs = 500L
 
 internal fun hasPlaybackReadyBuffer(
     positionMs: Long,
@@ -190,11 +192,7 @@ abstract class SimpleAudioPlayer(
             return
         }
         scope.launch {
-            val resolved = runCatching {
-                resolver.resolveOrigin(PlaybackOriginResolver.DefaultPlayResolveDeadlineMs)
-            }
-                .onFailure { if (it is CancellationException) throw it }
-                .getOrNull()?.trimEnd('/')?.takeIf { it.isNotBlank() }
+            val resolved = resolveColdOriginWithRetries(resolver, generation)
             if (!isPlayRequestCurrent(generation) || !playWhenReady) return@launch
             val accepted = acceptedPlaybackOrigin(resolved)
             // No origin and nothing to bind the queue onto: the server is unreachable right now.
@@ -214,6 +212,31 @@ abstract class SimpleAudioPlayer(
                 origin = accepted,
             )
         }
+    }
+
+    /**
+     * A cold play tap with no cached origin joins whatever identity race is already in flight
+     * (`PlexConnectionResolver` coalesces concurrent callers into one race) rather than getting
+     * its own full [PlaybackOriginResolver.DefaultPlayResolveDeadlineMs] budget. That race can
+     * miss by a hair — observed on-device: a race missed all candidates, and the very next race,
+     * ~1s later, won — so one miss must not be a permanent failure while the server is this close
+     * to answering. Retry a couple more full-budget attempts before giving up.
+     */
+    private suspend fun resolveColdOriginWithRetries(
+        resolver: PlaybackOriginResolver,
+        generation: Int,
+    ): String? {
+        repeat(ColdOriginResolveAttempts) { attempt ->
+            val resolved = runCatching {
+                resolver.resolveOrigin(PlaybackOriginResolver.DefaultPlayResolveDeadlineMs)
+            }
+                .onFailure { if (it is CancellationException) throw it }
+                .getOrNull()?.trimEnd('/')?.takeIf { it.isNotBlank() }
+            if (resolved != null) return resolved
+            if (!isPlayRequestCurrent(generation) || !playWhenReady) return null
+            if (attempt < ColdOriginResolveAttempts - 1) delay(ColdOriginResolveRetryDelayMs)
+        }
+        return null
     }
 
     /**


### PR DESCRIPTION
Follow-on to #191. Four playback-reliability fixes.

**Changes**

1. **`SimpleAudioPlayer` — retry cold origin resolution.** A cold play tap with no cached origin joins the in-flight Plex identity race instead of getting its own full resolve budget. That race can miss by a hair (observed on-device: a race missed all candidates, and the next race ~1s later won), so one miss should not permanently fail playback while the server is close to answering. Now retries up to 2 full-budget attempts.

2. **`AndroidAudioPlayer` — incremental Media3 window reconcile.** Queue edits (append, insert up-next, remove/move an upcoming item) never touch the currently-playing item, only its window neighbors. Media3 supports inserting/removing window items without stopping playback as long as the playing index doesn't move. Replaces the previous unconditional stop/clear/prepare cycle — which paused on every queue edit (and could leave playback stuck paused if a second edit raced in mid-reload) — with a common-prefix/suffix diff that patches only the differing middle span.

3. **`AndroidCastController` — treat graceful teardown as intentional.** `onSessionEnding` is reached for any graceful teardown (our own `disconnect()` or the user tapping Disconnect/Stop in the system Cast dialog). Marking it intentional lets both teardown paths restore local playback instead of showing a "Reconnecting…" message doomed to time out.

4. **`AppState` — fix infinite origin-retry loop.** The retry loop calls `refreshSelectedServerConnections()` each round, which rewrites `selectedServer` (relay reassignment yields a different connection list nearly every call) and re-emitted `session` with the *same* server/token. That re-emission fed back into the same `combine` and made `collectLatest` restart the block every round, resetting backoff to 2s forever. Keying off `(serverId, token, hasOrigin)` with `distinctUntilChanged` lets backoff double properly.

**Tests**: relied on CI (desktop ×3, Android host/instrumented/screenshots, wasm, web, backend). Changes are playback/relay specific; no screenshot or backend impact expected.