### PR TITLE
Keep established Plex origin stable across relay rotations

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
@@ -416,6 +416,7 @@ class AppState(
     private val activeDownloadJobs = mutableSetOf<Job>()
     private var lastPlaybackHistoryRecord = PlaybackHistoryRecord()
     private var lastRebasedPlaybackOrigin: String? = null
+    private var lastRebasedPlaybackNetwork: String? = null
     private var pendingLastFmAuth: PendingLastFmAuth? = null
     private val artistEventJobs = mutableMapOf<String, Job>()
     private val albumMusicBrainzJobs = mutableMapOf<String, Job>()
@@ -2882,8 +2883,18 @@ class AppState(
         publishPlexArtworkOrigins(probedOrigin = originOverride, logMiss = true)
         val origin = ArtworkOriginHolder.liveOrigin ?: return
         if (origin == lastRebasedPlaybackOrigin) return
+        // Only a handoff invalidates the socket a playing track is already streaming over. On one
+        // network the base still moves — Plex relays rotate and startup adopts a few in a row —
+        // and re-opening the current stream for each of those restarted the song mid-play.
+        val network = runCatching { dependencies.appGraph.plexConnectionResolver }
+            .getOrNull()
+            ?.networkIdentity
+            ?.value
+            ?.fingerprint
+        val networkChanged = lastRebasedPlaybackOrigin != null && network != lastRebasedPlaybackNetwork
         lastRebasedPlaybackOrigin = origin
-        dependencies.audioPlayer.rebasePlaybackOrigins(origin)
+        lastRebasedPlaybackNetwork = network
+        dependencies.audioPlayer.rebasePlaybackOrigins(origin, networkChanged = networkChanged)
         scope.launch {
             runCatching { dependencies.sessionRepository.adoptProbedServerOrigin(origin) }
         }

--- a/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexConnectionResolver.kt
+++ b/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexConnectionResolver.kt
@@ -318,10 +318,14 @@ class PlexConnectionResolver(
         }
         forgottenServers.remove(serverId)
         forgottenOrigins.remove(ForgottenOrigin(serverId, trimmed))
+        val server = lastServer?.takeIf { it.id == serverId }
+        if (keepEstablishedOrigin(server, trimmed, mutableIdentity.value) != null) {
+            noteWorkingOrigin(serverId, fingerprint, trimmed)
+            return
+        }
         memoryCache[CacheKey(serverId, fingerprint)] = trimmed
         lastGoodByServer[CacheKey(serverId, fingerprint)] = trimmed
         markProbed(serverId, fingerprint, trimmed)
-        val server = lastServer?.takeIf { it.id == serverId }
         if (isPlexRelayOrigin(trimmed, server)) {
             sessionRelayByServer[serverId] = trimmed
             return
@@ -518,7 +522,6 @@ class PlexConnectionResolver(
         }
         PhoebeLog.d("PlexConnectionResolver") { "identity race winner=$winner" }
         adoptWinner(server, winner, identity.fingerprint)
-        winner
     }
 
     private suspend fun probeIdentity(
@@ -584,7 +587,8 @@ class PlexConnectionResolver(
             ?.takeIf { it.isNotBlank() }
     }
 
-    private suspend fun adoptWinner(server: PlexServer, origin: String, fingerprint: String) {
+    /** Returns the base that is in force for [server] afterwards, which may be the established one. */
+    private suspend fun adoptWinner(server: PlexServer, origin: String, fingerprint: String): String? {
         if (fingerprint != mutableIdentity.value.fingerprint) {
             // The network moved while this race was in flight. Its winner only proves the origin
             // was reachable from where we no longer are, so publishing it would bind artwork and
@@ -592,7 +596,14 @@ class PlexConnectionResolver(
             PhoebeLog.d("PlexConnectionResolver") {
                 "discarding origin=$origin from previous network fingerprint=$fingerprint"
             }
-            return
+            return null
+        }
+        keepEstablishedOrigin(server, origin, mutableIdentity.value)?.let { established ->
+            PhoebeLog.d("PlexConnectionResolver") {
+                "keeping established base=$established over race winner=$origin"
+            }
+            noteWorkingOrigin(server.id, fingerprint, origin)
+            return established
         }
         forgottenServers.remove(server.id)
         forgottenOrigins.remove(ForgottenOrigin(server.id, origin))
@@ -604,13 +615,50 @@ class PlexConnectionResolver(
             PhoebeLog.d("PlexConnectionResolver") {
                 "resolved relay origin=$origin server=${server.id} fingerprint=$fingerprint (session only)"
             }
-            return
+            return origin
         }
         sessionRelayByServer.remove(server.id)
         persist(server.id, fingerprint, origin)
         PhoebeLog.d("PlexConnectionResolver") {
             "resolved origin=$origin server=${server.id} fingerprint=$fingerprint"
         }
+        return origin
+    }
+
+    /**
+     * The base already in force for [server], when [candidate] is no reason to leave it.
+     *
+     * An origin that answered proves *that hop* works — not that the app should move onto it.
+     * plex.tv hands back a different relay in nearly every connections refresh, and a startup runs
+     * several API calls that each finish on whichever base was live when they began, so "the last
+     * answer wins" made the published base alternate between two equally good relays six times in
+     * the first seven seconds. Every flip re-bound artwork (cancelling and restarting every
+     * in-flight thumbnail fetch, on the slowest hop there is) and looked to playback like the
+     * server had moved.
+     *
+     * So the established base stands while it is still one this resolver would hand out
+     * ([cached]) and still `/identity`-confirmed on this network. Only a genuinely better hop —
+     * LAN or direct over a relay — takes over. Anything worse or equal is recorded and ignored;
+     * when the live base does break, [forget] clears it and the next answer is adopted normally.
+     */
+    private fun keepEstablishedOrigin(
+        server: PlexServer?,
+        candidate: String,
+        identity: NetworkIdentity,
+    ): String? {
+        if (server == null) return null
+        val current = cached(server, identity)?.takeIf { it == mutableProbedOrigin.value } ?: return null
+        if (current == candidate) return null
+        if (ProbedOrigin(server.id, identity.fingerprint, current) !in probedOk) return null
+        val demote = demoteLocalOrigins(identity)
+        val better = locationRank(candidate, server, demote) < locationRank(current, server, demote)
+        return if (better) null else current
+    }
+
+    /** Record a hop that answered without promoting it, so a later [forget] can fall back to it. */
+    private fun noteWorkingOrigin(serverId: String, fingerprint: String, origin: String) {
+        probedOk.add(ProbedOrigin(serverId, fingerprint, origin))
+        lastGoodByServer[CacheKey(serverId, fingerprint)] = origin
     }
 
     private fun markProbed(serverId: String, fingerprint: String, origin: String) {

--- a/data/providers/plex/src/desktopTest/kotlin/com/phoebe/app/PlexConnectionResolverTest.kt
+++ b/data/providers/plex/src/desktopTest/kotlin/com/phoebe/app/PlexConnectionResolverTest.kt
@@ -246,6 +246,61 @@ class PlexConnectionResolverTest {
     }
 
     @Test
+    fun aSecondRelayDoesNotDisplaceTheEstablishedOne() = runBlocking {
+        val (db, d) = newInMemoryPhoebeDatabase()
+        driver = d
+        val firstRelay = "https://45-79-202-250.abc.plex.direct:8443"
+        val secondRelay = "https://23-92-30-53.abc.plex.direct:8443"
+        val server = sampleServer(relayUris = listOf(firstRelay, secondRelay))
+        val resolver = resolver(db)
+        resolver.hydrateFromDisk(server)
+        resolver.remember(server.id, firstRelay)
+
+        // plex.tv rotates relays, so a second in-flight API call finishes on the other one. That
+        // is not a reason to move the whole app onto it: each move re-binds artwork mid-load.
+        resolver.remember(server.id, secondRelay)
+
+        assertEquals(firstRelay, resolver.probedOrigin.value)
+        assertEquals(firstRelay, ArtworkOriginHolder.liveOrigin)
+        assertEquals(firstRelay, resolver.cached(server))
+    }
+
+    @Test
+    fun aBetterHopStillDisplacesAnEstablishedRelay() = runBlocking {
+        val (db, d) = newInMemoryPhoebeDatabase()
+        driver = d
+        val lan = "http://192.168.1.9:32400"
+        val relay = "https://45-79-202-250.abc.plex.direct:8443"
+        val server = sampleServer(lan = lan, relayUris = listOf(relay))
+        val resolver = resolver(db)
+        resolver.hydrateFromDisk(server)
+        resolver.remember(server.id, relay)
+
+        resolver.remember(server.id, lan)
+
+        assertEquals(lan, resolver.probedOrigin.value, "LAN outranks a relay and must take over")
+        assertEquals(lan, ArtworkOriginHolder.liveOrigin)
+    }
+
+    @Test
+    fun forgettingTheEstablishedRelayLetsTheNextOneTakeOver() = runBlocking {
+        val (db, d) = newInMemoryPhoebeDatabase()
+        driver = d
+        val firstRelay = "https://45-79-202-250.abc.plex.direct:8443"
+        val secondRelay = "https://23-92-30-53.abc.plex.direct:8443"
+        val server = sampleServer(relayUris = listOf(firstRelay, secondRelay))
+        val resolver = resolver(db)
+        resolver.hydrateFromDisk(server)
+        resolver.remember(server.id, firstRelay)
+        resolver.forget(server.id, firstRelay)
+
+        resolver.remember(server.id, secondRelay)
+
+        assertEquals(secondRelay, resolver.probedOrigin.value)
+        assertEquals(secondRelay, resolver.cached(server))
+    }
+
+    @Test
     fun withReachableBaseHitsOnlyTheProbedRelay() = runBlocking {
         val (db, d) = newInMemoryPhoebeDatabase()
         driver = d

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/AudioPlayer.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/AudioPlayer.kt
@@ -65,8 +65,14 @@ interface AudioPlayer {
     /**
      * Prefer [origin] for upcoming queue entries after a network change or successful race,
      * without restarting the currently playing item.
+     *
+     * [networkChanged] is the one case where the item that is already playing must be re-opened:
+     * a handoff leaves its socket pointing at an address this network cannot reach. A new origin
+     * on the *same* network is just a better/rotated address (Plex hands out a different relay
+     * host almost every time it is asked), and re-opening a healthy stream for that restarts the
+     * song from where it is — audibly, and once per adoption.
      */
-    fun rebasePlaybackOrigins(origin: String) = Unit
+    fun rebasePlaybackOrigins(origin: String, networkChanged: Boolean = false) = Unit
 
     /**
      * Keep per-app output at unity while [updateReportedVolume] mirrors the OS level on the slider.

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
@@ -1316,11 +1316,18 @@ abstract class SimpleAudioPlayer(
      *
      * Plex queue entries hold relative part keys, so nothing in the queue needs rewriting; the
      * next read binds onto the new base by itself. What does need attention is the stream that
-     * is *already open*: its socket points at the old address and will sit there until the
-     * platform player's own timeout expires, which is 20-30s of silence. Re-prepare it at the
-     * current position instead.
+     * is *already open* after a handoff ([networkChanged]): its socket points at the old address
+     * and will sit there until the platform player's own timeout expires, which is 20-30s of
+     * silence. Re-prepare it at the current position instead.
+     *
+     * A new origin on the same network is not that. Plex relay hosts rotate — a fresh connection
+     * list or a second `/identity` race adopts a different `*.plex.direct:8443` address most
+     * times it runs, and startup runs several — so treating every adoption as a moved server
+     * re-opened a perfectly healthy stream once per adoption. At startup the position is still
+     * near zero, so each one sounded like the song restarting from the top. If the origin we are
+     * playing on really is dead, the stream stalls and the failover path recovers it.
      */
-    override fun rebasePlaybackOrigins(origin: String) {
+    override fun rebasePlaybackOrigins(origin: String, networkChanged: Boolean) {
         val trimmed = origin.trimEnd('/').takeIf { it.isNotBlank() } ?: return
         rememberStickyPlaybackOrigin(trimmed)
         val current = mutableState.value
@@ -1334,7 +1341,7 @@ abstract class SimpleAudioPlayer(
             mutableState.value = current.copy(queue = playbackQueue)
             onQueueEdited(playbackQueue, current.currentIndex)
         }
-        reopenCurrentStreamOnNewOrigin(trimmed)
+        if (networkChanged) reopenCurrentStreamOnNewOrigin(trimmed)
     }
 
     private fun reopenCurrentStreamOnNewOrigin(origin: String) {

--- a/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
@@ -1419,7 +1419,7 @@ class PlayerStateTest {
 
             // Wi-Fi -> cellular: the resolver publishes a new base.
             ArtworkOriginHolder.update(cellular)
-            player.rebasePlaybackOrigins(cellular)
+            player.rebasePlaybackOrigins(cellular, networkChanged = true)
             runCurrent()
 
             // Without this, the open socket sits on the dead LAN address until the platform
@@ -1453,6 +1453,39 @@ class PlayerStateTest {
             runCurrent()
 
             assertEquals(1, player.openedUris.size, "re-resolving to the same base must be a no-op")
+        } finally {
+            player.close()
+            ArtworkOriginHolder.clear()
+            ArtworkAuthHolder.clear()
+        }
+    }
+
+    @Test
+    fun rotatedRelayOnTheSameNetworkDoesNotRestartTheCurrentTrack() = runTest {
+        val firstRelay = "https://45-79-202-250.abc.plex.direct:8443"
+        val secondRelay = "https://23-92-30-53.abc.plex.direct:8443"
+        ArtworkAuthHolder.update("token")
+        ArtworkOriginHolder.update(firstRelay)
+        val player = OpenedUriTestPlayer()
+        try {
+            player.play(
+                listOf(Track("t1", "One", "Artist", "Album", 60_000, "/library/parts/1/file.mp3", "")),
+                0,
+            )
+            player.finishPendingLoad()
+
+            // Same network, second `/identity` race (or a successful API call) adopts the other
+            // relay plex.tv handed out. The open stream is fine; restarting it is what made a
+            // freshly started song play a second and jump back to the top.
+            ArtworkOriginHolder.update(secondRelay)
+            player.rebasePlaybackOrigins(secondRelay)
+            runCurrent()
+
+            assertEquals(
+                1,
+                player.openedUris.size,
+                "a rotated relay on the same network must not re-open the stream, got ${player.openedUris}",
+            )
         } finally {
             player.close()
             ArtworkOriginHolder.clear()


### PR DESCRIPTION
## Summary
- Keep an already-published Plex base when a same-rank relay (or worse hop) answers later, instead of flipping artwork/playback onto every race winner.
- Re-open the currently playing stream only when the network fingerprint changes; same-network origin adoptions no longer restart the track mid-play.
- Add resolver and player tests covering relay stickiness, LAN promotion, forget-and-replace, and no-restart on relay rotation.

## Test plan
- [x] `./gradlew :data:providers:plex:desktopTest --tests 'com.phoebe.app.PlexConnectionResolverTest'`
- [x] `./gradlew :playback:desktopTest --tests 'com.phoebe.app.PlayerStateTest'`
- [ ] Start playback on relay, confirm song does not restart when a second relay is adopted at startup
- [ ] Confirm Wi-Fi → cellular still reopens the current stream on the new origin
- [ ] Confirm LAN discovery still displaces an established relay


Made with [Cursor](https://cursor.com)