### PR TITLE
Fix Android VPN LAN playback and compact player artwork

### DIFF
--- a/core/platform/src/androidMain/kotlin/com/phoebe/app/platform/AndroidPlatform.kt
+++ b/core/platform/src/androidMain/kotlin/com/phoebe/app/platform/AndroidPlatform.kt
@@ -215,32 +215,62 @@ private fun androidNetworkIdentity(
         )
     }
     val capabilities = connectivity.getNetworkCapabilities(network)
-    // A VPN hides the underlying transport, and its tunnel does not reach the server's LAN.
-    // Reported as `Other` it used to keep LAN-first ordering on a VPN over cellular.
     val vpn = capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) == true
+    val hasWifi = capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
+    val hasCellular = capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) == true
+    val hasEthernet = capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) == true
+    // Overlay / split-tunnel VPNs (Tailscale, WireGuard app VPN) report WIFI|VPN on one
+    // Network. Treating every VPN as off-LAN demoted Plex to relays that fail when remote
+    // access is off, even though the underlying Wi-Fi still reaches the server. Prefer the
+    // underlying transport when present; only a VPN with no Wi-Fi/Ethernet stays Other.
     val transport = when {
         capabilities == null -> NetworkTransport.Other
+        hasWifi -> NetworkTransport.Wifi
+        hasEthernet -> NetworkTransport.Ethernet
+        hasCellular -> NetworkTransport.Cellular
         vpn -> NetworkTransport.Other
-        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> NetworkTransport.Wifi
-        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> NetworkTransport.Cellular
-        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> NetworkTransport.Ethernet
         else -> NetworkTransport.Other
     }
+    // Full-tunnel / cellular VPN still counts as metered. Split-tunnel over Wi-Fi does not.
+    val vpnForcesMetered = vpn && !hasWifi && !hasEthernet
     val metering = NetworkMeteringStatus(
-        isMetered = connectivity.isActiveNetworkMetered || vpn,
+        isMetered = connectivity.isActiveNetworkMetered || vpnForcesMetered,
         isCellular = transport == NetworkTransport.Cellular,
     )
     val linkProperties = connectivity.getLinkProperties(network)
-    val prefixes = if (transport == NetworkTransport.Cellular || transport == NetworkTransport.None || vpn) {
-        emptyList()
-    } else {
-        androidLocalIpv4Prefixes(linkProperties)
+    val prefixes = when (transport) {
+        NetworkTransport.Cellular,
+        NetworkTransport.None,
+        -> emptyList()
+        else -> {
+            // VPN LinkProperties are the tunnel; LAN prefixes live on the underlying
+            // Wi-Fi/Ethernet Network object.
+            if (vpn) {
+                androidLocalIpv4PrefixesFromNonVpnNetworks(connectivity)
+                    .ifEmpty { androidLocalIpv4Prefixes(linkProperties) }
+            } else {
+                androidLocalIpv4Prefixes(linkProperties)
+            }
+        }
     }
+    val lanMaterial = when (transport) {
+        NetworkTransport.Cellular -> "cellular"
+        NetworkTransport.None -> ""
+        else -> {
+            if (vpn) {
+                androidNetworkMaterialFromNonVpnNetworks(connectivity)
+                    .ifBlank { androidNetworkMaterial(linkProperties) }
+            } else {
+                androidNetworkMaterial(linkProperties)
+            }
+        }
+    }
+    // Keep "vpn" in the fingerprint so connecting/disconnecting Tailscale still counts as a
+    // network change and re-runs the Plex origin race.
     val material = when {
+        vpn && lanMaterial.isNotBlank() -> "$lanMaterial|vpn"
         vpn -> "vpn"
-        transport == NetworkTransport.Cellular -> "cellular"
-        transport == NetworkTransport.None -> ""
-        else -> androidNetworkMaterial(linkProperties)
+        else -> lanMaterial
     }
     // A captive portal or a Wi-Fi that has not finished associating reports INTERNET without
     // being usable. Fold that into the fingerprint so leaving it counts as a network change.
@@ -253,6 +283,33 @@ private fun androidNetworkIdentity(
         localIpv4Prefixes = prefixes,
     )
 }
+
+/**
+ * Underlying Wi-Fi/Ethernet Networks, ignoring the VPN overlay Network that Tailscale-style
+ * apps register with TRANSPORT_VPN (and often WIFI|VPN together on a different object).
+ */
+private fun androidNonVpnNetworks(connectivity: ConnectivityManager): List<Network> =
+    connectivity.allNetworks.filter { candidate ->
+        val caps = connectivity.getNetworkCapabilities(candidate) ?: return@filter false
+        if (caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) return@filter false
+        caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ||
+            caps.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)
+    }
+
+private fun androidLocalIpv4PrefixesFromNonVpnNetworks(connectivity: ConnectivityManager): List<String> =
+    androidNonVpnNetworks(connectivity)
+        .flatMap { network -> androidLocalIpv4Prefixes(connectivity.getLinkProperties(network)) }
+        .distinct()
+        .sorted()
+
+private fun androidNetworkMaterialFromNonVpnNetworks(connectivity: ConnectivityManager): String =
+    androidNonVpnNetworks(connectivity)
+        .mapNotNull { network ->
+            androidNetworkMaterial(connectivity.getLinkProperties(network)).takeIf { it.isNotBlank() }
+        }
+        .distinct()
+        .sorted()
+        .joinToString("|")
 
 private fun androidLocalIpv4Prefixes(linkProperties: LinkProperties?): List<String> {
     if (linkProperties == null) return emptyList()

--- a/feature/playback/src/commonMain/kotlin/com/phoebe/app/feature/playback/MobilePlayer.kt
+++ b/feature/playback/src/commonMain/kotlin/com/phoebe/app/feature/playback/MobilePlayer.kt
@@ -483,10 +483,13 @@ fun MobilePlayer(
         )
         val artworkHeightTrim = artworkLayout.heightTrim
         val fullArtworkHeight = artworkLayout.displaySize
-        val artworkEdgeInset = artworkLayout.edgeInset
+        val artworkSideInset = artworkLayout.sideInset
+        val artworkTopInset = artworkLayout.topInset
         val artworkLayoutHeight = artworkLayout.layoutHeight
+        // metadataReserve historically included metadataTopGap above the title. Only the
+        // unused portion of that gap may be reclaimed — never the content lines themselves.
         val artworkMetadataReserve = (
-            metadataReserve - (artworkLayoutHeight - fullArtworkHeight)
+            metadataReserve - (MobilePlayerExpandedMetadataTopGap - artworkLayout.metadataGap)
         ).coerceAtLeast(0.dp)
         val fullArtworkDisplayWidth = if (artworkIsImage) {
             fullArtworkHeight.coerceAtLeast(collapsedArtworkSize)
@@ -504,8 +507,8 @@ fun MobilePlayer(
             .coerceIn(0.01f, 1f)
         val artworkLayerScaleY = (currentArtworkHeight.value / fullArtworkDisplayHeight.value.coerceAtLeast(1f))
             .coerceIn(0.01f, 1f)
-        val targetArtworkX = artworkEdgeInset
-        val targetArtworkY = artworkEdgeInset
+        val targetArtworkX = artworkSideInset
+        val targetArtworkY = artworkTopInset
         val currentArtworkX = lerp(12.dp, targetArtworkX, clampedExpansionFraction)
         val currentArtworkY = lerp(14.dp, targetArtworkY, clampedExpansionFraction)
 

--- a/feature/playback/src/commonMain/kotlin/com/phoebe/app/feature/playback/MobilePlayer.kt
+++ b/feature/playback/src/commonMain/kotlin/com/phoebe/app/feature/playback/MobilePlayer.kt
@@ -81,6 +81,7 @@ private val MobilePlayerRemoteTargetReserve = 18.dp
 private val MobilePlayerCompactRemoteTargetReserve = 14.dp
 private val MobilePlayerExpandedTopGap = 8.dp
 private val MobilePlayerExpandedArtworkBodyGap = 8.dp
+private val MobilePlayerExpandedMetadataTopGap = 22.dp
 private val MobilePlayerExpandedProgressLineHeight = 72.dp
 private val MobilePlayerExpandedControlsGap = 10.dp
 private val MobilePlayerCompactControlsGap = 4.dp
@@ -469,16 +470,24 @@ fun MobilePlayer(
             .coerceAtLeast(MobilePlayerExtraCompactMinArtworkHeight)
             .coerceAtMost(fullArtworkWidth)
         val maxArtworkHeightTrim = fullArtworkWidth - minArtworkHeight
-        val artworkHeightTrim = (compactPlayerHeight - screenHeight).coerceIn(0.dp, maxArtworkHeightTrim)
-        val fullArtworkHeight = fullArtworkWidth - artworkHeightTrim
-
         val collapsedArtworkSize = 44.dp
         val artworkIsImage = visualizerPreset == NowPlayingVisualizerPreset.Artwork
-        val artworkEdgeInset = if (artworkIsImage) {
-            ((fullArtworkWidth - fullArtworkHeight) / 2f).coerceAtLeast(0.dp)
-        } else {
-            0.dp
-        }
+        val artworkLayout = mobilePlayerArtworkLayout(
+            artworkWidth = fullArtworkWidth,
+            compactPlayerHeight = compactPlayerHeight,
+            availableHeight = screenHeight,
+            maxHeightTrim = maxArtworkHeightTrim,
+            isArtworkImage = artworkIsImage,
+            metadataTopGap = MobilePlayerExpandedMetadataTopGap,
+            minimumMetadataGap = MobilePlayerExpandedArtworkBodyGap,
+        )
+        val artworkHeightTrim = artworkLayout.heightTrim
+        val fullArtworkHeight = artworkLayout.displaySize
+        val artworkEdgeInset = artworkLayout.edgeInset
+        val artworkLayoutHeight = artworkLayout.layoutHeight
+        val artworkMetadataReserve = (
+            metadataReserve - (artworkLayoutHeight - fullArtworkHeight)
+        ).coerceAtLeast(0.dp)
         val fullArtworkDisplayWidth = if (artworkIsImage) {
             fullArtworkHeight.coerceAtLeast(collapsedArtworkSize)
         } else {
@@ -496,10 +505,7 @@ fun MobilePlayer(
         val artworkLayerScaleY = (currentArtworkHeight.value / fullArtworkDisplayHeight.value.coerceAtLeast(1f))
             .coerceIn(0.01f, 1f)
         val targetArtworkX = artworkEdgeInset
-        // X insets the square artwork to center it in the full-width row. Y must stay 0: the
-        // box is already exactly fullArtworkHeight tall and siblings are laid out relative to
-        // that height, so any downward shift overlaps the metadata below on compact screens.
-        val targetArtworkY = 0.dp
+        val targetArtworkY = artworkEdgeInset
         val currentArtworkX = lerp(12.dp, targetArtworkX, clampedExpansionFraction)
         val currentArtworkY = lerp(14.dp, targetArtworkY, clampedExpansionFraction)
 
@@ -662,7 +668,7 @@ fun MobilePlayer(
                     .graphicsLayer { alpha = fullPlayerAlpha }
             ) {
                 if (track != null) {
-                    Spacer(Modifier.height(fullArtworkHeight + metadataReserve + MobilePlayerExpandedArtworkBodyGap))
+                    Spacer(Modifier.height(artworkLayoutHeight + artworkMetadataReserve + MobilePlayerExpandedArtworkBodyGap))
                 } else {
                     Spacer(Modifier.height(28.dp))
                     Box(
@@ -828,7 +834,11 @@ fun MobilePlayer(
             val targetTextX = 20.dp
             val currentTextX = lerp(68.dp, targetTextX, clampedExpansionFraction)
             val collapsedTextY = (MobileMiniPlayerChromeHeight - CollapsedMobilePlayerMetadataHeight) / 2f
-            val currentTextY = lerp(collapsedTextY, fullArtworkHeight + 22.dp, clampedExpansionFraction)
+            val currentTextY = lerp(
+                collapsedTextY,
+                artworkLayoutHeight + artworkLayout.metadataGap,
+                clampedExpansionFraction,
+            )
             val collapsedTextWidth = if (castState.isConnected) {
                 (screenWidth - 176.dp).coerceAtLeast(96.dp)
             } else {
@@ -916,7 +926,10 @@ fun MobilePlayer(
             if (fullPlayerElementsAlpha > 0f) {
                 Box(
                     modifier = Modifier
-                        .offset(x = screenWidth - 64.dp, y = fullArtworkHeight + 20.dp)
+                        .offset(
+                            x = screenWidth - 64.dp,
+                            y = artworkLayoutHeight + (artworkLayout.metadataGap - 2.dp),
+                        )
                         .graphicsLayer { alpha = fullPlayerElementsAlpha },
                 ) {
                     TransportIcon(PhoebeIcon.More, "More options", { onOpenSongDetail(track) })
@@ -939,8 +952,8 @@ fun MobilePlayer(
             val collapsedPlayButtonX = screenWidth - 12.dp - collapsedPlayButtonSize
             val collapsedPlayButtonY = (MobileMiniPlayerChromeHeight - collapsedPlayButtonSize) / 2f
             val expandedPlayButtonX = (screenWidth - expandedPlayButtonSize) / 2f
-            val expandedPlayButtonY = fullArtworkHeight +
-                metadataReserve +
+            val expandedPlayButtonY = artworkLayoutHeight +
+                artworkMetadataReserve +
                 MobilePlayerExpandedArtworkBodyGap +
                 expandedProgressLineHeight +
                 expandedControlsGap

--- a/feature/playback/src/commonMain/kotlin/com/phoebe/app/feature/playback/MobilePlayerArtworkLayout.kt
+++ b/feature/playback/src/commonMain/kotlin/com/phoebe/app/feature/playback/MobilePlayerArtworkLayout.kt
@@ -5,7 +5,8 @@ import androidx.compose.ui.unit.dp
 
 internal data class MobilePlayerArtworkLayout(
     val displaySize: Dp,
-    val edgeInset: Dp,
+    val sideInset: Dp,
+    val topInset: Dp,
     val layoutHeight: Dp,
     val heightTrim: Dp,
     val metadataGap: Dp,
@@ -23,11 +24,11 @@ internal fun mobilePlayerArtworkLayout(
     val compactHeightDeficit = (compactPlayerHeight - availableHeight).coerceAtLeast(0.dp)
     val baseHeightTrim = compactHeightDeficit.coerceIn(0.dp, maxHeightTrim)
     val baseArtworkHeight = artworkWidth - baseHeightTrim
-    val edgeInset = if (isArtworkImage) {
-        // Use the existing gap above the metadata before shrinking the cover. For a centered
-        // square, its envelope is (artworkWidth - edgeInset), so this is the largest equal-
-        // inset square that still leaves the minimum gap below it.
-        val maximumArtworkEnvelope = baseArtworkHeight + metadataTopGap - minimumMetadataGap
+    val gapBudget = (metadataTopGap - minimumMetadataGap).coerceAtLeast(0.dp)
+    // Largest equal-inset square whose top-inset + square + minimum gap still fits the
+    // original artwork row plus the metadata top-gap budget (does not steal metadata content).
+    val maximumArtworkEnvelope = baseArtworkHeight + gapBudget
+    val sideInset = if (isArtworkImage) {
         (artworkWidth - maximumArtworkEnvelope)
             .coerceAtLeast(0.dp)
             .coerceAtMost(maxHeightTrim / 2f)
@@ -35,18 +36,26 @@ internal fun mobilePlayerArtworkLayout(
         0.dp
     }
     val displaySize = if (isArtworkImage) {
-        (artworkWidth - edgeInset * 2f).coerceAtLeast(0.dp)
+        (artworkWidth - sideInset * 2f).coerceAtLeast(0.dp)
     } else {
         baseArtworkHeight
     }
+    // When side inset is capped by max trim, keep top inset inside the gap budget so the
+    // metadata column retains its content reserve.
+    val topInset = if (isArtworkImage) {
+        sideInset.coerceAtMost((maximumArtworkEnvelope - displaySize).coerceAtLeast(0.dp))
+    } else {
+        0.dp
+    }
     val heightTrim = artworkWidth - displaySize
-    val layoutHeight = displaySize + edgeInset
+    val layoutHeight = displaySize + topInset
     val metadataGap = (baseArtworkHeight + metadataTopGap - layoutHeight)
         .coerceAtLeast(minimumMetadataGap)
 
     return MobilePlayerArtworkLayout(
         displaySize = displaySize,
-        edgeInset = edgeInset,
+        sideInset = sideInset,
+        topInset = topInset,
         layoutHeight = layoutHeight,
         heightTrim = heightTrim,
         metadataGap = metadataGap,

--- a/feature/playback/src/commonMain/kotlin/com/phoebe/app/feature/playback/MobilePlayerArtworkLayout.kt
+++ b/feature/playback/src/commonMain/kotlin/com/phoebe/app/feature/playback/MobilePlayerArtworkLayout.kt
@@ -1,0 +1,54 @@
+package com.phoebe.app.feature.playback
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+internal data class MobilePlayerArtworkLayout(
+    val displaySize: Dp,
+    val edgeInset: Dp,
+    val layoutHeight: Dp,
+    val heightTrim: Dp,
+    val metadataGap: Dp,
+)
+
+internal fun mobilePlayerArtworkLayout(
+    artworkWidth: Dp,
+    compactPlayerHeight: Dp,
+    availableHeight: Dp,
+    maxHeightTrim: Dp,
+    isArtworkImage: Boolean,
+    metadataTopGap: Dp,
+    minimumMetadataGap: Dp,
+): MobilePlayerArtworkLayout {
+    val compactHeightDeficit = (compactPlayerHeight - availableHeight).coerceAtLeast(0.dp)
+    val baseHeightTrim = compactHeightDeficit.coerceIn(0.dp, maxHeightTrim)
+    val baseArtworkHeight = artworkWidth - baseHeightTrim
+    val edgeInset = if (isArtworkImage) {
+        // Use the existing gap above the metadata before shrinking the cover. For a centered
+        // square, its envelope is (artworkWidth - edgeInset), so this is the largest equal-
+        // inset square that still leaves the minimum gap below it.
+        val maximumArtworkEnvelope = baseArtworkHeight + metadataTopGap - minimumMetadataGap
+        (artworkWidth - maximumArtworkEnvelope)
+            .coerceAtLeast(0.dp)
+            .coerceAtMost(maxHeightTrim / 2f)
+    } else {
+        0.dp
+    }
+    val displaySize = if (isArtworkImage) {
+        (artworkWidth - edgeInset * 2f).coerceAtLeast(0.dp)
+    } else {
+        baseArtworkHeight
+    }
+    val heightTrim = artworkWidth - displaySize
+    val layoutHeight = displaySize + edgeInset
+    val metadataGap = (baseArtworkHeight + metadataTopGap - layoutHeight)
+        .coerceAtLeast(minimumMetadataGap)
+
+    return MobilePlayerArtworkLayout(
+        displaySize = displaySize,
+        edgeInset = edgeInset,
+        layoutHeight = layoutHeight,
+        heightTrim = heightTrim,
+        metadataGap = metadataGap,
+    )
+}

--- a/feature/playback/src/commonTest/kotlin/com/phoebe/app/feature/playback/MobilePlayerArtworkLayoutTest.kt
+++ b/feature/playback/src/commonTest/kotlin/com/phoebe/app/feature/playback/MobilePlayerArtworkLayoutTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.assertEquals
 
 class MobilePlayerArtworkLayoutTest {
     @Test
-    fun imageArtworkUsesEqualTopAndSideInsetsWithinReservedEnvelope() {
+    fun imageArtworkUsesEqualInsetsWhenGapBudgetAllows() {
         val layout = mobilePlayerArtworkLayout(
             artworkWidth = 420.dp,
             compactPlayerHeight = 900.dp,
@@ -19,11 +19,12 @@ class MobilePlayerArtworkLayoutTest {
 
         assertEquals(92.dp, layout.heightTrim)
         assertEquals(328.dp, layout.displaySize)
-        assertEquals(46.dp, layout.edgeInset)
+        assertEquals(46.dp, layout.sideInset)
+        assertEquals(46.dp, layout.topInset)
         assertEquals(374.dp, layout.layoutHeight)
         assertEquals(8.dp, layout.metadataGap)
-        assertEquals(420.dp, layout.displaySize + layout.edgeInset * 2f)
-        assertEquals(layout.layoutHeight, layout.edgeInset + layout.displaySize)
+        assertEquals(420.dp, layout.displaySize + layout.sideInset * 2f)
+        assertEquals(layout.layoutHeight, layout.topInset + layout.displaySize)
         assertEquals(382.dp, layout.layoutHeight + layout.metadataGap)
     }
 
@@ -41,7 +42,8 @@ class MobilePlayerArtworkLayoutTest {
 
         assertEquals(0.dp, layout.heightTrim)
         assertEquals(420.dp, layout.displaySize)
-        assertEquals(0.dp, layout.edgeInset)
+        assertEquals(0.dp, layout.sideInset)
+        assertEquals(0.dp, layout.topInset)
         assertEquals(420.dp, layout.layoutHeight)
         assertEquals(22.dp, layout.metadataGap)
     }
@@ -60,8 +62,33 @@ class MobilePlayerArtworkLayoutTest {
 
         assertEquals(60.dp, layout.heightTrim)
         assertEquals(360.dp, layout.displaySize)
-        assertEquals(0.dp, layout.edgeInset)
+        assertEquals(0.dp, layout.sideInset)
+        assertEquals(0.dp, layout.topInset)
         assertEquals(360.dp, layout.layoutHeight)
         assertEquals(22.dp, layout.metadataGap)
+    }
+
+    @Test
+    fun imageArtworkCapsTopInsetWhenSideInsetHitsMaxTrim() {
+        // 360×640-class: height trim hits the max, so equal top inset would overflow the
+        // metadata gap budget. Keep side inset for centering; limit top inset so title→progress
+        // still has the full metadata content reserve.
+        val layout = mobilePlayerArtworkLayout(
+            artworkWidth = 360.dp,
+            compactPlayerHeight = 724.dp,
+            availableHeight = 640.dp,
+            maxHeightTrim = 80.dp,
+            isArtworkImage = true,
+            metadataTopGap = 22.dp,
+            minimumMetadataGap = 8.dp,
+        )
+
+        assertEquals(80.dp, layout.heightTrim)
+        assertEquals(280.dp, layout.displaySize)
+        assertEquals(40.dp, layout.sideInset)
+        assertEquals(14.dp, layout.topInset)
+        assertEquals(294.dp, layout.layoutHeight)
+        assertEquals(8.dp, layout.metadataGap)
+        assertEquals(302.dp, layout.layoutHeight + layout.metadataGap)
     }
 }

--- a/feature/playback/src/commonTest/kotlin/com/phoebe/app/feature/playback/MobilePlayerArtworkLayoutTest.kt
+++ b/feature/playback/src/commonTest/kotlin/com/phoebe/app/feature/playback/MobilePlayerArtworkLayoutTest.kt
@@ -1,0 +1,67 @@
+package com.phoebe.app.feature.playback
+
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MobilePlayerArtworkLayoutTest {
+    @Test
+    fun imageArtworkUsesEqualTopAndSideInsetsWithinReservedEnvelope() {
+        val layout = mobilePlayerArtworkLayout(
+            artworkWidth = 420.dp,
+            compactPlayerHeight = 900.dp,
+            availableHeight = 840.dp,
+            maxHeightTrim = 200.dp,
+            isArtworkImage = true,
+            metadataTopGap = 22.dp,
+            minimumMetadataGap = 8.dp,
+        )
+
+        assertEquals(92.dp, layout.heightTrim)
+        assertEquals(328.dp, layout.displaySize)
+        assertEquals(46.dp, layout.edgeInset)
+        assertEquals(374.dp, layout.layoutHeight)
+        assertEquals(8.dp, layout.metadataGap)
+        assertEquals(420.dp, layout.displaySize + layout.edgeInset * 2f)
+        assertEquals(layout.layoutHeight, layout.edgeInset + layout.displaySize)
+        assertEquals(382.dp, layout.layoutHeight + layout.metadataGap)
+    }
+
+    @Test
+    fun imageArtworkDoesNotAddInsetWhenThereIsNoHeightDeficit() {
+        val layout = mobilePlayerArtworkLayout(
+            artworkWidth = 420.dp,
+            compactPlayerHeight = 900.dp,
+            availableHeight = 940.dp,
+            maxHeightTrim = 200.dp,
+            isArtworkImage = true,
+            metadataTopGap = 22.dp,
+            minimumMetadataGap = 8.dp,
+        )
+
+        assertEquals(0.dp, layout.heightTrim)
+        assertEquals(420.dp, layout.displaySize)
+        assertEquals(0.dp, layout.edgeInset)
+        assertEquals(420.dp, layout.layoutHeight)
+        assertEquals(22.dp, layout.metadataGap)
+    }
+
+    @Test
+    fun nonImageArtworkKeepsExistingHeightTrimGeometry() {
+        val layout = mobilePlayerArtworkLayout(
+            artworkWidth = 420.dp,
+            compactPlayerHeight = 900.dp,
+            availableHeight = 840.dp,
+            maxHeightTrim = 200.dp,
+            isArtworkImage = false,
+            metadataTopGap = 22.dp,
+            minimumMetadataGap = 8.dp,
+        )
+
+        assertEquals(60.dp, layout.heightTrim)
+        assertEquals(360.dp, layout.displaySize)
+        assertEquals(0.dp, layout.edgeInset)
+        assertEquals(360.dp, layout.layoutHeight)
+        assertEquals(22.dp, layout.metadataGap)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,6 +65,7 @@ androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx
 androidx-fragment = { module = "androidx.fragment:fragment", version.ref = "fragment" }
 androidx-documentfile = { module = "androidx.documentfile:documentfile", version.ref = "documentfile" }
 androidx-media3-cast = { module = "androidx.media3:media3-cast", version.ref = "media3" }
+androidx-media3-datasource-okhttp = { module = "androidx.media3:media3-datasource-okhttp", version.ref = "media3" }
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3" }
 androidx-media3-exoplayer-hls = { module = "androidx.media3:media3-exoplayer-hls", version.ref = "media3" }
 androidx-media3-session = { module = "androidx.media3:media3-session", version.ref = "media3" }

--- a/playback/build.gradle.kts
+++ b/playback/build.gradle.kts
@@ -80,6 +80,7 @@ kotlin {
         androidMain {
             dependencies {
                 implementation(libs.androidx.media3.cast)
+                implementation(libs.androidx.media3.datasource.okhttp)
                 implementation(libs.androidx.media3.exoplayer)
                 implementation(libs.androidx.media3.exoplayer.hls)
                 implementation(libs.androidx.media3.session)

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidPlaybackDiagnostics.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidPlaybackDiagnostics.kt
@@ -14,7 +14,6 @@ import androidx.media3.common.audio.BaseAudioProcessor
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.common.util.Util
 import androidx.media3.datasource.DefaultDataSource
-import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
@@ -36,10 +35,9 @@ internal object AndroidPlaybackDiagnostics {
         engine: PlaybackEnginePath,
     ): ExoPlayer.Builder {
         diagnostics.engineSelected(engine)
-        val httpDataSourceFactory = DefaultHttpDataSource.Factory()
-            .setAllowCrossProtocolRedirects(true)
-            .setConnectTimeoutMs(3_000)
-            .setReadTimeoutMs(8_000)
+        // OkHttp + underlying Wi-Fi Network binding — DefaultHttpDataSource fails under
+        // Tailscale/split-tunnel VPN UID routing while artwork/API (also OkHttp) still work.
+        val httpDataSourceFactory = AndroidPlaybackHttp.dataSourceFactory(context)
         return ExoPlayer.Builder(
             context,
             PhoebeRenderersFactory(

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidPlaybackHttp.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidPlaybackHttp.kt
@@ -1,0 +1,41 @@
+package com.phoebe.app.player
+
+import android.content.Context
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.okhttp.OkHttpDataSource
+import okhttp3.Dns
+import okhttp3.OkHttpClient
+import java.net.Inet4Address
+import java.util.concurrent.TimeUnit
+
+/**
+ * Media3 HTTP stack aligned with Phoebe's Ktor/OkHttp clients (artwork + Plex API).
+ *
+ * DefaultHttpDataSource (HttpURLConnection) fails under split-tunnel VPNs such as Tailscale
+ * while OkHttp still reaches the LAN Plex server. Do **not** bind sockets to the underlying
+ * Wi-Fi [android.net.Network]: Tailscale sets `bypassable=false`, so `Network.bindSocket`
+ * throws EPERM for VPN-included UIDs.
+ */
+internal object AndroidPlaybackHttp {
+    private val ipv4PreferredDns = Dns { hostname ->
+        val all = Dns.SYSTEM.lookup(hostname)
+        val ipv4 = all.filterIsInstance<Inet4Address>()
+        if (ipv4.isEmpty()) all else ipv4 + all.filter { it !is Inet4Address }
+    }
+
+    private val sharedClient: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .dns(ipv4PreferredDns)
+            .fastFallback(true)
+            .connectTimeout(8, TimeUnit.SECONDS)
+            .readTimeout(20, TimeUnit.SECONDS)
+            .callTimeout(0, TimeUnit.MILLISECONDS)
+            .retryOnConnectionFailure(true)
+            .build()
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    fun dataSourceFactory(context: Context): DataSource.Factory =
+        OkHttpDataSource.Factory(sharedClient)
+            .setUserAgent("Phoebe")
+}


### PR DESCRIPTION
## Summary
- Prefer underlying Wi-Fi/Ethernet over Tailscale-style VPN overlays when classifying Android network transport, metering, and LAN prefixes so Plex stays on LAN when remote access is off.
- Switch Media3 HTTP to OkHttp (aligned with artwork/API clients) so split-tunnel VPN UID routing no longer breaks playback while other traffic still works.
- Extract mobile player artwork layout math so expanded cover art insets equally and keeps a usable gap above metadata on short screens.

## Test plan
- [x] `./gradlew :feature:playback:desktopTest --tests 'com.phoebe.app.feature.playback.MobilePlayerArtworkLayoutTest'`
- [ ] On Android with Tailscale (or similar VPN) on Wi-Fi and remote access off, confirm LAN Plex origin is selected and playback starts
- [ ] Toggle VPN connect/disconnect and confirm origin rediscovery still runs
- [ ] On a short phone viewport, expand the mobile player and confirm artwork does not overlap title/artist
- [ ] Confirm cellular + full-tunnel VPN still reports metered/cellular behavior as before


Made with [Cursor](https://cursor.com)