### PR TITLE
Fix playback robustness, Android Auto origin binding, cast artwork, and voice search ranking

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/AppDependencies.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/AppDependencies.kt
@@ -40,6 +40,8 @@ import com.phoebe.app.di.RouteViewModelFactory
 import com.phoebe.app.di.createPhoebeAppGraph
 import com.phoebe.app.data.ArtworkAuthHolder
 import com.phoebe.app.data.ArtworkOriginHolder
+import com.phoebe.app.domain.isPlex
+import com.phoebe.app.domain.serverAuthToken
 import com.phoebe.app.platform.PhoebeAppDataRevision
 import com.phoebe.app.platform.PhoebeLog
 import com.phoebe.app.platform.PlatformStorage
@@ -110,6 +112,23 @@ class AppDependencies(
     val remoteDiscoveryClient: com.phoebe.app.remote.RemoteDiscoveryClient,
     val remoteControlClient: com.phoebe.app.remote.RemoteControlClient,
 ) : PlaybackRuntimeDependencies {
+    /**
+     * Bind an origin for a process that came up without Compose — Android Auto binds
+     * `PlaybackService` directly, so `AppState.wirePlaybackOriginResolver` never runs and
+     * [ArtworkOriginHolder] stays empty. `resolveFresh` publishes the holders itself once
+     * `/identity` answers (`PlexConnectionResolver.markProbed`).
+     */
+    override suspend fun ensureLivePlaybackOrigin(): String? {
+        ArtworkOriginHolder.liveOrigin?.let { return it }
+        val current = sessionRepository.session.value.takeIf { it.isPlex() } ?: return null
+        val server = current.selectedServer ?: return null
+        val token = current.serverAuthToken() ?: return null
+        // Artwork binding needs the token even if the origin race ends up missing.
+        ArtworkAuthHolder.update(token)
+        val resolver = runCatching { appGraph.plexConnectionResolver }.getOrNull() ?: return null
+        return runCatching { resolver.resolveFresh(server, token) }.getOrNull()
+    }
+
     /**
      * Sign out and wipe once when the stored-data revision moves.
      *

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeRoot.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeRoot.kt
@@ -393,6 +393,7 @@ private fun PhoebeRootStateHolder(
     val tracksLoading by state.tracksLoading.collectAsState()
     val supportedCollectionEntries = remember(session) { session.supportedCollectionEntries().toSet() }
     val shellPlayback by state.shellPlayback.collectAsState()
+    val player by state.player.collectAsState()
     val playerTransport by state.playerTransport.collectAsState()
     val playerQueue by state.playerQueue.collectAsState()
     val musicAssistantRemotePlayback by state.musicAssistantRemotePlayback.collectAsState()
@@ -2326,6 +2327,7 @@ private fun PhoebeRootStateHolder(
                     playbackState = PlaybackUiState(
                         shellPlayback = shellPlayback,
                         playerTransport = playerTransport,
+                        player = player,
                         track = currentTrack,
                         radioNowPlaying = radioNowPlaying,
                         upNext = upNext,

--- a/composeApp/src/desktopTest/kotlin/com/phoebe/app/CatalogBrowseTreeSearchTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/phoebe/app/CatalogBrowseTreeSearchTest.kt
@@ -46,7 +46,10 @@ class CatalogBrowseTreeSearchTest {
 
         val results = tree.searchTracks(query = "")
 
-        assertEquals(listOf("track-river", "track-moon", "track-sun"), results.map { it.id })
+        assertEquals(
+            listOf("track-ms-jackson", "track-river", "track-moon", "track-sun"),
+            results.map { it.id },
+        )
     }
 
     @Test
@@ -67,6 +70,47 @@ class CatalogBrowseTreeSearchTest {
         val results = tree.searchTracks(query = "moon song by signal garden", title = "Moon Song", artist = "Signal Garden")
 
         assertEquals(listOf("track-moon"), results.map { it.id })
+    }
+
+    @Test
+    fun searchTracksMatchesSongByArtistFreeformQuery() = runTest {
+        val db = populatedDatabase()
+        val tree = CatalogBrowseTree(db)
+
+        val results = tree.searchTracks(query = "Ms Jackson by Outkast")
+
+        assertEquals(listOf("track-ms-jackson"), results.map { it.id })
+    }
+
+    @Test
+    fun searchTracksMatchesSpokenMissVersusCatalogMs() = runTest {
+        val db = populatedDatabase()
+        val tree = CatalogBrowseTree(db)
+
+        val results = tree.searchTracks(query = "Miss Jackson by Outkast")
+
+        assertEquals(listOf("track-ms-jackson"), results.map { it.id })
+    }
+
+    @Test
+    fun searchTracksMatchesWhenShortHonorificTokenIsDropped() = runTest {
+        val db = populatedDatabase()
+        val tree = CatalogBrowseTree(db)
+
+        // Assistant sometimes drops "Ms"/"Miss"; significant tokens should still win.
+        val results = tree.searchTracks(query = "Jackson by Outkast")
+
+        assertEquals(listOf("track-ms-jackson"), results.map { it.id })
+    }
+
+    @Test
+    fun searchTracksMatchesPunctuatedTitleAgainstSpokenQuery() = runTest {
+        val db = populatedDatabase()
+        val tree = CatalogBrowseTree(db)
+
+        val results = tree.searchTracks(query = "ms jackson", title = "Ms Jackson", artist = "Outkast")
+
+        assertEquals(listOf("track-ms-jackson"), results.map { it.id })
     }
 
     @Test
@@ -136,8 +180,10 @@ class CatalogBrowseTreeSearchTest {
 
         db.catalogQueries.upsertArtist("artist-1", "Signal Garden", null, 1, 2, 0, null, null, null, null, null, 0)
         db.catalogQueries.upsertArtist("artist-2", "Solar Choir", null, 1, 1, 1, null, null, null, null, null, 0)
+        db.catalogQueries.upsertArtist("artist-3", "OutKast", null, 1, 1, 2, null, null, null, null, null, 0)
         db.catalogQueries.upsertAlbum("album-quiet", "Quiet Hours", "Signal Garden", 2025, null, 0, null, null, null, null, null, 0)
         db.catalogQueries.upsertAlbum("album-bright", "Moonwink", "Solar Choir", 2024, null, 1, null, null, null, null, null, 0)
+        db.catalogQueries.upsertAlbum("album-stankonia", "Stankonia", "OutKast", 2000, null, 2, null, null, null, null, null, 0)
         db.catalogQueries.upsertPlaylist("playlist-night", "Night Drive", 2, null, null, 0, null, 0)
         upsertTrack(
             db = db,
@@ -166,9 +212,19 @@ class CatalogBrowseTreeSearchTest {
             dateAddedMs = 100,
             parentAlbumId = "album-bright",
         )
+        upsertTrack(
+            db = db,
+            id = "track-ms-jackson",
+            title = "Ms. Jackson",
+            artist = "OutKast",
+            album = "Stankonia",
+            dateAddedMs = 400,
+            parentAlbumId = "album-stankonia",
+        )
         db.catalogQueries.upsertTrackParent("album-quiet", "track-moon", 0, null)
         db.catalogQueries.upsertTrackParent("album-quiet", "track-river", 1, null)
         db.catalogQueries.upsertTrackParent("album-bright", "track-sun", 0, null)
+        db.catalogQueries.upsertTrackParent("album-stankonia", "track-ms-jackson", 0, null)
         db.catalogQueries.upsertTrackParent("playlist-night", "track-river", 0, null)
         db.catalogQueries.upsertTrackParent("playlist-night", "track-moon", 1, null)
         return db

--- a/composeApp/src/desktopTest/kotlin/com/phoebe/app/ui/PlaybackClickTargetDesktopTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/phoebe/app/ui/PlaybackClickTargetDesktopTest.kt
@@ -719,6 +719,118 @@ class PlaybackClickTargetDesktopTest {
 
         assertEquals(45_000L, seekPositionMs)
     }
+
+    @OptIn(ExperimentalTestApi::class, ExperimentalComposeUiApi::class)
+    @Test
+    fun desktopProgressLineDragSeeksToReleasedPositionWithoutIntermediateSeeks() = runDesktopComposeUiTest(width = 420, height = 80) {
+        val seekHistory = mutableListOf<Long>()
+
+        setContent {
+            PhoebeTheme {
+                Box(Modifier.size(420.dp, 80.dp)) {
+                    ProgressLine(
+                        positionMs = 0L,
+                        bufferedPositionMs = 0L,
+                        durationMs = 60_000L,
+                        waveformSeed = "desktop-progress-drag",
+                        modifier = Modifier.size(width = 400.dp, height = 48.dp),
+                        onSeek = { seekHistory += it },
+                        barHeight = 20.dp,
+                    )
+                }
+            }
+        }
+
+        onNodeWithContentDescription("Playback progress, 0:00 of 1:00").performTouchInput {
+            down(Offset(width * 0.25f, 10f))
+            moveTo(Offset(width * 0.50f, 10f))
+            up()
+        }
+
+        assertEquals(listOf(30_000L), seekHistory)
+    }
+
+    @OptIn(ExperimentalTestApi::class, ExperimentalComposeUiApi::class)
+    @Test
+    fun desktopProgressLineDragToEndClampsBeforeDuration() = runDesktopComposeUiTest(width = 420, height = 80) {
+        var seekPositionMs: Long? = null
+
+        setContent {
+            PhoebeTheme {
+                Box(Modifier.size(420.dp, 80.dp)) {
+                    ProgressLine(
+                        positionMs = 0L,
+                        bufferedPositionMs = 0L,
+                        durationMs = 60_000L,
+                        waveformSeed = "desktop-progress-drag-end",
+                        modifier = Modifier.size(width = 400.dp, height = 48.dp),
+                        onSeek = { seekPositionMs = it },
+                        barHeight = 20.dp,
+                    )
+                }
+            }
+        }
+
+        onNodeWithContentDescription("Playback progress, 0:00 of 1:00").performTouchInput {
+            down(Offset(width * 0.25f, 10f))
+            moveTo(Offset(width * 1.5f, 10f))
+            up()
+        }
+
+        assertEquals(59_500L, seekPositionMs)
+    }
+
+    /**
+     * A cold origin race can buffer for many seconds. The play button is the control the user
+     * reaches for during a slow start, so it has to keep accepting taps — togglePlayPause()
+     * cancels a load in progress.
+     */
+    @OptIn(ExperimentalTestApi::class, ExperimentalComposeUiApi::class)
+    @Test
+    fun desktopPlayButtonStillAcceptsTapsWhileBuffering() = runDesktopComposeUiTest(width = 120, height = 120) {
+        var toggles = 0
+
+        setContent {
+            PhoebeTheme {
+                Box(Modifier.size(120.dp)) {
+                    PlayButton(
+                        isPlaying = false,
+                        isBuffering = true,
+                        size = 56.dp,
+                        onClick = { toggles++ },
+                    )
+                }
+            }
+        }
+
+        onNodeWithContentDescription("Stop loading").performClick()
+
+        assertEquals(1, toggles)
+    }
+
+    @OptIn(ExperimentalTestApi::class, ExperimentalComposeUiApi::class)
+    @Test
+    fun desktopPlayButtonStaysInertWhenNoTrackIsLoaded() = runDesktopComposeUiTest(width = 120, height = 120) {
+        var toggles = 0
+
+        setContent {
+            PhoebeTheme {
+                Box(Modifier.size(120.dp)) {
+                    PlayButton(
+                        isPlaying = false,
+                        isBuffering = true,
+                        size = 56.dp,
+                        onClick = { toggles++ },
+                        enabled = false,
+                    )
+                }
+            }
+        }
+
+        onNodeWithContentDescription("Stop loading").performClick()
+
+        assertEquals(0, toggles)
+    }
 }
 
 private data class PlaybackRequest(

--- a/iosApp/iosApp/IosCastCoordinator.swift
+++ b/iosApp/iosApp/IosCastCoordinator.swift
@@ -146,7 +146,9 @@ final class IosCastCoordinator: NSObject {
         metadata.setString(descriptor.title, forKey: kGCKMetadataKeyTitle)
         metadata.setString(descriptor.artist, forKey: kGCKMetadataKeyArtist)
         metadata.setString(descriptor.album, forKey: kGCKMetadataKeyAlbumTitle)
-        if let thumb = descriptor.thumbUrl, let thumbUrl = URL(string: thumb) {
+        if let thumb = descriptor.thumbUrl,
+           (thumb.hasPrefix("http://") || thumb.hasPrefix("https://")),
+           let thumbUrl = URL(string: thumb) {
             metadata.addImage(GCKImage(url: thumbUrl, width: 600, height: 600))
         }
 

--- a/playback/build.gradle.kts
+++ b/playback/build.gradle.kts
@@ -89,6 +89,7 @@ kotlin {
         }
         desktopMain {
             dependencies {
+                implementation(project(":ui:core"))
                 implementation("org.jetbrains.compose.desktop:desktop-jvm-$composeDesktopTarget:${libs.versions.compose.get()}")
                 implementation(libs.jnativehook)
                 implementation(libs.jna)

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAudioPlayer.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAudioPlayer.kt
@@ -295,7 +295,6 @@ class AndroidAudioPlayer(
         stopPositionSyncLoop()
         stopBufferingTimeout()
         stopRetry()
-        loadedPlatformQueue = null
         pendingPlatformSeek = null
         pendingPlatformQueueRebase = null
         androidGaplessPrepareGeneration = -1
@@ -312,6 +311,11 @@ class AndroidAudioPlayer(
                     stop()
                     clearMediaItems()
                 }
+                // Forget the playlist only once it is actually gone. play() silences output
+                // before every load, including same-queue skips, and runPlatformLoad cancels
+                // this job before it runs — clearing the record synchronously above made
+                // skipToInQueueOnPlatform miss its own playlist and full-reload every skip.
+                loadedPlatformQueue = null
             }
         }
     }

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAutoBrowseTree.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAutoBrowseTree.kt
@@ -78,7 +78,7 @@ internal class AndroidAutoBrowseTree(
             else -> browseFolderItem(
                 mediaId = mediaId,
                 title = title,
-                artworkUri = thumbUrl?.let { Uri.parse(it) },
+                artworkUri = thumbUrl?.toBrowseArtworkUri(),
             )
         }
 

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidCastController.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidCastController.kt
@@ -988,7 +988,9 @@ private class AndroidCastController : CastController {
             putString(MediaMetadata.KEY_TITLE, descriptor.title)
             putString(MediaMetadata.KEY_ARTIST, descriptor.artist)
             putString(MediaMetadata.KEY_ALBUM_TITLE, descriptor.album)
-            descriptor.thumbUrl?.let { addImage(com.google.android.gms.common.images.WebImage(android.net.Uri.parse(it))) }
+            descriptor.thumbUrl?.takeIf { it.isCastReceiverLoadableUrl() }?.let {
+                addImage(com.google.android.gms.common.images.WebImage(android.net.Uri.parse(it)))
+            }
         }
         return MediaInfo.Builder(descriptor.castUrl)
             .setStreamType(

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidPlaybackHttp.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidPlaybackHttp.kt
@@ -1,8 +1,11 @@
 package com.phoebe.app.player
 
 import android.content.Context
+import androidx.media3.common.util.BitmapLoader
 import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSourceBitmapLoader
 import androidx.media3.datasource.okhttp.OkHttpDataSource
+import androidx.media3.session.CacheBitmapLoader
 import okhttp3.Dns
 import okhttp3.OkHttpClient
 import java.net.Inet4Address
@@ -15,6 +18,11 @@ import java.util.concurrent.TimeUnit
  * while OkHttp still reaches the LAN Plex server. Do **not** bind sockets to the underlying
  * Wi-Fi [android.net.Network]: Tailscale sets `bypassable=false`, so `Network.bindSocket`
  * throws EPERM for VPN-included UIDs.
+ *
+ * MediaSession defaults to [DataSourceBitmapLoader] over DefaultHttpDataSource — that is why
+ * Android Auto Now Playing can show title/artist (from metadata) while album art stays blank
+ * even after thumbs are bound to absolute URLs. Route bitmap loads through the same OkHttp
+ * client as ExoPlayer.
  */
 internal object AndroidPlaybackHttp {
     private val ipv4PreferredDns = Dns { hostname ->
@@ -38,4 +46,12 @@ internal object AndroidPlaybackHttp {
     fun dataSourceFactory(context: Context): DataSource.Factory =
         OkHttpDataSource.Factory(sharedClient)
             .setUserAgent("Phoebe")
+
+    /** Bitmap loader for [androidx.media3.session.MediaLibrarySession] / Android Auto Now Playing. */
+    fun sessionBitmapLoader(context: Context): BitmapLoader {
+        val executor = checkNotNull(DataSourceBitmapLoader.DEFAULT_EXECUTOR_SERVICE.get()) {
+            "Media3 bitmap executor unavailable"
+        }
+        return CacheBitmapLoader(DataSourceBitmapLoader(executor, dataSourceFactory(context)))
+    }
 }

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidPlaybackRuntime.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidPlaybackRuntime.kt
@@ -1,5 +1,6 @@
 package com.phoebe.app.player
 
+import com.phoebe.app.data.ArtworkOriginHolder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -10,10 +11,14 @@ import kotlinx.coroutines.sync.withLock
 object AndroidPlaybackRuntime {
     private val installScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val installMutex = Mutex()
+    private val originMutex = Mutex()
 
     @Volatile
     var catalogBrowseSource: CatalogBrowseSource? = null
         private set
+
+    @Volatile
+    private var dependencies: PlaybackRuntimeDependencies? = null
 
     private var dependenciesFactory: (suspend () -> PlaybackRuntimeDependencies)? = null
 
@@ -22,6 +27,7 @@ object AndroidPlaybackRuntime {
     }
 
     fun install(dependencies: PlaybackRuntimeDependencies) {
+        this.dependencies = dependencies
         catalogBrowseSource = CatalogBrowseSourceImpl(
             database = dependencies.database,
             catalogRepository = dependencies.catalogRepository,
@@ -44,6 +50,35 @@ object AndroidPlaybackRuntime {
             val factory = dependenciesFactory ?: error("Android playback runtime has not been installed.")
             install(factory())
             checkNotNull(catalogBrowseSource)
+        }
+    }
+
+    /**
+     * Bind a live media-server base for this process, or null if none could be probed.
+     *
+     * Android Auto browses and plays without ever starting Compose, so `AppState` — the only
+     * thing that normally publishes [ArtworkOriginHolder] — has not run. Without this, browse
+     * items carry relative `/library/...` URIs: no artwork, and "Source error" on play.
+     */
+    suspend fun ensureLiveOriginNow(): String? {
+        ArtworkOriginHolder.liveOrigin?.let { return it }
+        val deps = dependencies ?: run {
+            ensureInstalledNow()
+            dependencies
+        } ?: return null
+        // One race at a time; PlexConnectionResolver coalesces, but this also keeps a run of
+        // browse callbacks from each paying the probe deadline.
+        return originMutex.withLock {
+            ArtworkOriginHolder.liveOrigin
+                ?: runCatching { deps.ensureLivePlaybackOrigin() }.getOrNull()
+        }
+    }
+
+    /** Fire-and-forget origin warm-up, with [onBound] invoked only when this call binds one. */
+    fun warmLiveOrigin(onBound: () -> Unit = {}) {
+        if (ArtworkOriginHolder.liveOrigin != null) return
+        installScope.launch {
+            if (ensureLiveOriginNow() != null) onBound()
         }
     }
 }

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/BrowseMediaItems.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/BrowseMediaItems.kt
@@ -4,6 +4,10 @@ import android.net.Uri
 import android.os.Bundle
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import com.phoebe.app.data.ArtworkAuthHolder
+import com.phoebe.app.data.ArtworkOriginHolder
+import com.phoebe.app.data.bindPlexUrl
+import com.phoebe.app.data.isPlexMediaPathOrUrl
 import com.phoebe.app.domain.Album
 import com.phoebe.app.domain.Artist
 import com.phoebe.app.domain.Playlist
@@ -53,7 +57,7 @@ internal fun browseTrackItem(track: Track): MediaItem {
                 .setIsBrowsable(false)
                 .setIsPlayable(true)
                 .setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)
-                .apply { track.thumbUrl?.let { setArtworkUri(it.toAndroidUri()) } }
+                .apply { track.thumbUrl?.toBrowseArtworkUri()?.let { setArtworkUri(it) } }
                 .build(),
         )
         .build()
@@ -89,21 +93,21 @@ internal fun Artist.toBrowseItem(): MediaItem =
     browseFolderItem(
         mediaId = BrowseMediaIds.artist(id),
         title = title,
-        artworkUri = thumbUrl?.toAndroidUri(),
+        artworkUri = thumbUrl?.toBrowseArtworkUri(),
     )
 
 internal fun Album.toBrowseItem(): MediaItem =
     browseFolderItem(
         mediaId = BrowseMediaIds.album(id),
         title = title,
-        artworkUri = thumbUrl?.toAndroidUri(),
+        artworkUri = thumbUrl?.toBrowseArtworkUri(),
     )
 
 internal fun Playlist.toBrowseItem(): MediaItem =
     browseFolderItem(
         mediaId = BrowseMediaIds.playlist(id),
         title = title,
-        artworkUri = thumbUrl?.toAndroidUri(),
+        artworkUri = thumbUrl?.toBrowseArtworkUri(),
     )
 
 internal const val InAppPlaybackExtra: String = "com.phoebe.app.IN_APP_PLAYBACK"
@@ -127,3 +131,21 @@ private fun Track.descriptionForCarDisplay(): String =
         .joinToString(" - ")
 
 private fun String.toAndroidUri(): Uri = Uri.parse(this)
+
+/**
+ * Artwork URI the Android Auto host (a different process) can actually fetch.
+ *
+ * The catalog stores host-less Plex thumb paths — `/library/metadata/123/thumb/456` — that the
+ * in-app image loader binds to the live base at request time. Handing that string straight to
+ * `Uri.parse` yields a relative URI with no scheme or authority, which is why every Android Auto
+ * row (and MediaSession Now Playing bitmap load) rendered blank. Bind it here instead; a browse
+ * item with no artwork beats a broken one.
+ */
+internal fun String.toBrowseArtworkUri(): Uri? {
+    val raw = trim().takeIf { it.isNotBlank() } ?: return null
+    if (!raw.isPlexMediaPathOrUrl()) {
+        return raw.takeIf { Uri.parse(it).scheme != null }?.toAndroidUri()
+    }
+    val base = ArtworkOriginHolder.liveOrigin?.trimEnd('/')?.takeIf { it.isNotBlank() } ?: return null
+    return bindPlexUrl(raw, base, ArtworkAuthHolder.plexToken.orEmpty()).toAndroidUri()
+}

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/PlaybackService.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/PlaybackService.kt
@@ -23,6 +23,7 @@ import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionResult
 import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.ListenableFuture
+import com.phoebe.app.data.ArtworkOriginHolder
 import com.phoebe.app.domain.Track
 import com.phoebe.app.platform.PhoebeLog
 import kotlinx.coroutines.CoroutineScope
@@ -31,11 +32,16 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.ConcurrentHashMap
 
 class PlaybackService : MediaLibraryService() {
 
     private var mediaLibrarySession: MediaLibrarySession? = null
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    /** Browse parents served before an origin existed, so their artwork came back empty. */
+    private val unboundBrowseParents: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
     private val servicePlayerListener = object : Player.Listener {
         override fun onIsPlayingChanged(isPlaying: Boolean) {
             AndroidPlaybackBridge.updateServicePlayerState()
@@ -102,6 +108,10 @@ class PlaybackService : MediaLibraryService() {
             params: LibraryParams?,
         ): ListenableFuture<LibraryResult<MediaItem>> {
             val rootParams = androidAutoRootParams(params)
+            // Android Auto can browse before Compose ever starts, so nothing has published a
+            // live Plex base yet. Warm one off the critical path and re-announce the tree once
+            // it binds, so thumbs stop resolving to host-less paths.
+            AndroidPlaybackRuntime.warmLiveOrigin(onBound = ::notifyBrowseTreeChanged)
             return listenableFuture("onGetLibraryRoot") {
                 val source = AndroidPlaybackRuntime.ensureInstalledNow()
                 runCatching {
@@ -136,6 +146,12 @@ class PlaybackService : MediaLibraryService() {
             pageSize: Int,
             params: LibraryParams?,
         ): ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> {
+            // Browsing must not stall behind an origin probe, so serve what the catalog has and
+            // re-announce this parent once a base binds — until then its thumbs are unusable.
+            if (ArtworkOriginHolder.liveOrigin == null) {
+                unboundBrowseParents += parentId
+                AndroidPlaybackRuntime.warmLiveOrigin(onBound = ::notifyBrowseTreeChanged)
+            }
             return listenableFuture("onGetChildren") {
                 val source = AndroidPlaybackRuntime.ensureInstalledNow()
                 val children = source.getChildren(parentId).paged(page, pageSize)
@@ -210,7 +226,8 @@ class PlaybackService : MediaLibraryService() {
             }
             return listenableFuture("onAddMediaItems") {
                 val source = AndroidPlaybackRuntime.ensureInstalledNow()
-                source.resolveTracks(mediaItems).map { playbackMediaItem(it) }
+                AndroidPlaybackRuntime.ensureLiveOriginNow()
+                source.resolveTracks(mediaItems).map { playbackMediaItem(it) }.requireBoundUris()
             }
         }
 
@@ -226,6 +243,11 @@ class PlaybackService : MediaLibraryService() {
             }
             return listenableFuture("onSetMediaItems") {
                 val source = AndroidPlaybackRuntime.ensureInstalledNow()
+                // Bind an origin *before* any URI is built. The in-app player waits on
+                // PlaybackOriginResolver for exactly this; Android Auto had no equivalent, so a
+                // car-only process handed ExoPlayer `/library/parts/...` and it reported
+                // "Source error".
+                AndroidPlaybackRuntime.ensureLiveOriginNow()
                 PhoebeLog.d(TAG) {
                     "onSetMediaItems package=${controller.packageName} count=${mediaItems.size} item=${mediaItems.firstOrNull()?.debugSummary()}"
                 }
@@ -243,6 +265,9 @@ class PlaybackService : MediaLibraryService() {
                 }
                 val expanded = expandMediaItems(source, mediaItems, startIndex)
                 if (expanded != null) {
+                    // Validate before adopting: a queue the app mirrors but the player cannot
+                    // open would leave the in-app UI showing a track that never starts.
+                    val items = expanded.items.requireBoundUris()
                     val tracks = expanded.tracks
                     if (tracks.isNotEmpty()) {
                         AndroidPlaybackBridge.onAdoptQueue?.invoke(
@@ -251,13 +276,13 @@ class PlaybackService : MediaLibraryService() {
                             true,
                         )
                     }
-                    MediaItemsWithStartPosition(expanded.items, expanded.startIndex, startPositionMs)
+                    MediaItemsWithStartPosition(items, expanded.startIndex, startPositionMs)
                 } else {
                     val tracks = source.resolveTracks(mediaItems)
                     if (tracks.isEmpty()) {
                         throw UnsupportedOperationException("No playable media items resolved for request.")
                     }
-                    val resolved = tracks.map { playbackMediaItem(it) }
+                    val resolved = tracks.map { playbackMediaItem(it) }.requireBoundUris()
                     AndroidPlaybackBridge.onAdoptQueue?.invoke(
                         tracks,
                         startIndex.coerceIn(tracks.indices),
@@ -303,6 +328,7 @@ class PlaybackService : MediaLibraryService() {
 
         mediaLibrarySession = MediaLibrarySession.Builder(this, sessionPlayer, librarySessionCallback)
             .setSessionActivity(openAppIntent)
+            .setBitmapLoader(AndroidPlaybackHttp.sessionBitmapLoader(this))
             .setCustomLayout(likeButtonLayout())
             .setMediaButtonPreferences(likeButtonLayout())
             .build()
@@ -354,7 +380,7 @@ class PlaybackService : MediaLibraryService() {
         val tracks = source.searchTracks(query, extras)
         if (tracks.isEmpty()) return null
 
-        val items = tracks.map { playbackMediaItem(it) }
+        val items = tracks.map { playbackMediaItem(it) }.requireBoundUris()
         val resolvedStartIndex = startIndex.takeIf { it in items.indices } ?: 0
         AndroidPlaybackBridge.onAdoptQueue?.invoke(tracks, resolvedStartIndex, true)
         return MediaItemsWithStartPosition(items, resolvedStartIndex, startPositionMs)
@@ -367,13 +393,18 @@ class PlaybackService : MediaLibraryService() {
             val source = withContext(Dispatchers.Default) {
                 AndroidPlaybackRuntime.ensureInstalledNow()
             }
+            AndroidPlaybackRuntime.ensureLiveOriginNow()
             val tracks = withContext(Dispatchers.IO) {
                 source.searchTracks(query, extras)
             }
             PhoebeLog.d(TAG) { "playFromSearchIntent query=$query count=${tracks.size}" }
             if (tracks.isEmpty()) return@launch
 
-            val items = tracks.map { playbackMediaItem(it) }
+            val items = runCatching { tracks.map { playbackMediaItem(it) }.requireBoundUris() }
+                .getOrElse { error ->
+                    PhoebeLog.d(TAG) { "playFromSearchIntent query=$query unplayable: ${error.message}" }
+                    return@launch
+                }
             AndroidPlaybackBridge.onAdoptQueue?.invoke(tracks, 0, true)
             mediaLibrarySession?.player?.run {
                 setMediaItems(items, 0, C.TIME_UNSET)
@@ -397,6 +428,21 @@ class PlaybackService : MediaLibraryService() {
             val layout = likeButtonLayout(resolved)
             session.setCustomLayout(layout)
             session.setMediaButtonPreferences(layout)
+        }
+    }
+
+    /** Re-announce every parent served while thumbs were still unbindable. */
+    private fun notifyBrowseTreeChanged() {
+        val session = mediaLibrarySession ?: return
+        val parents = unboundBrowseParents.toList() + BrowseMediaIds.ROOT
+        unboundBrowseParents.clear()
+        serviceScope.launch {
+            val source = runCatching { AndroidPlaybackRuntime.ensureInstalledNow() }.getOrNull()
+                ?: return@launch
+            parents.distinct().forEach { parentId ->
+                val count = runCatching { source.getChildren(parentId).size }.getOrNull() ?: return@forEach
+                session.notifyChildrenChanged(parentId, count, null)
+            }
         }
     }
 
@@ -484,6 +530,23 @@ class PlaybackService : MediaLibraryService() {
                 .build()
         }
     }
+}
+
+/**
+ * Fail the session request instead of handing ExoPlayer a URI it cannot open.
+ *
+ * A host-less `/library/parts/...` survives every emptiness check but has no authority, so
+ * ExoPlayer reinterprets it as a local file and surfaces a bare "Source error" in the car with
+ * nothing in the log tying it to a missing origin. A failed future gives the user a real message.
+ */
+internal fun List<MediaItem>.requireBoundUris(): List<MediaItem> {
+    val unbound = firstOrNull { item ->
+        val uri = item.localConfiguration?.uri?.toString().orEmpty()
+        uri.isBlank() || isUnboundServerPath(uri)
+    } ?: return this
+    throw UnsupportedOperationException(
+        "Music server is unreachable; no origin bound for \"${unbound.mediaMetadata.title}\".",
+    )
 }
 
 internal data class ExpandedPlaybackItems(

--- a/playback/src/androidUnitTest/kotlin/com/phoebe/app/player/BrowseMediaItemsTest.kt
+++ b/playback/src/androidUnitTest/kotlin/com/phoebe/app/player/BrowseMediaItemsTest.kt
@@ -6,6 +6,8 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.session.SessionResult
+import com.phoebe.app.data.ArtworkAuthHolder
+import com.phoebe.app.data.ArtworkOriginHolder
 import com.phoebe.app.domain.Track
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
@@ -13,6 +15,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -118,6 +121,65 @@ class BrowseMediaItemsTest {
         assertNull(expanded)
     }
 
+    /**
+     * Android Auto renders artwork in its own process, so a catalog-relative thumb path has to
+     * be bound to the live base and token before it leaves the service.
+     */
+    @Test
+    fun browseArtworkBindsRelativePlexThumbsToTheLiveOrigin() = withPlexOrigin("https://pms.test:32400", "abc123") {
+        val item = browseTrackItem(plexTrack())
+
+        assertEquals(
+            "https://pms.test:32400/library/metadata/42/thumb/1700000000?X-Plex-Token=abc123",
+            item.mediaMetadata.artworkUri.toString(),
+        )
+    }
+
+    @Test
+    fun browseArtworkIsOmittedRatherThanLeftRelativeWhenNoOriginIsBound() =
+        withPlexOrigin(origin = null, token = null) {
+            assertNull(browseTrackItem(plexTrack()).mediaMetadata.artworkUri)
+        }
+
+    @Test
+    fun browseArtworkPassesThroughAbsoluteNonPlexUrls() = withPlexOrigin(origin = null, token = null) {
+        val item = browseTrackItem(
+            plexTrack().copy(thumbUrl = "https://cdn.example.test/art.jpg"),
+        )
+
+        assertEquals("https://cdn.example.test/art.jpg", item.mediaMetadata.artworkUri.toString())
+    }
+
+    @Test
+    fun playbackUriBindsRelativePlexStreamPathToTheLiveOrigin() =
+        withPlexOrigin("https://pms.test:32400", "abc123") {
+            val item = browseTrackItem(plexTrack())
+
+            assertEquals(
+                "https://pms.test:32400/library/parts/99/file.flac?X-Plex-Token=abc123",
+                item.localConfiguration?.uri.toString(),
+            )
+        }
+
+    /**
+     * Without an origin the URI stays host-less; ExoPlayer treats that as a local file and the
+     * car shows a bare "Source error". Fail the session request instead.
+     */
+    @Test
+    fun unboundPlaybackUriFailsTheRequestInsteadOfReachingExoPlayer() =
+        withPlexOrigin(origin = null, token = null) {
+            val items = listOf(browseTrackItem(plexTrack()))
+
+            assertFailsWith<UnsupportedOperationException> { items.requireBoundUris() }
+        }
+
+    @Test
+    fun boundPlaybackUrisPassThroughUnchanged() = withPlexOrigin("https://pms.test:32400", "abc123") {
+        val items = listOf(browseTrackItem(plexTrack()))
+
+        assertEquals(items, items.requireBoundUris())
+    }
+
     @Test
     fun externalNextCommandUsesPhoebeQueueWhenPlatformWindowHasNoNext() {
         var localNextCalls = 0
@@ -179,6 +241,31 @@ class BrowseMediaItemsTest {
         assertEquals(1, castNextCalls)
     }
 
+}
+
+/** A catalog row as Plex stores it: host-less part key and thumb, no token. */
+private fun plexTrack(): Track = Track(
+    id = "plex:1234",
+    title = "Foam",
+    artist = "Divine Sweater",
+    album = "Down Deep",
+    durationMs = 188_000,
+    streamUrl = "/library/parts/99/file.flac",
+    downloadUrl = "/library/parts/99/file.flac",
+    thumbUrl = "/library/metadata/42/thumb/1700000000",
+)
+
+private fun withPlexOrigin(origin: String?, token: String?, body: () -> Unit) {
+    val previousOrigin = ArtworkOriginHolder.liveOrigin
+    val previousToken = ArtworkAuthHolder.plexToken
+    ArtworkOriginHolder.update(origin)
+    ArtworkAuthHolder.update(token)
+    try {
+        body()
+    } finally {
+        ArtworkOriginHolder.update(previousOrigin)
+        ArtworkAuthHolder.update(previousToken)
+    }
 }
 
 private class FakeCatalogBrowseSource(

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/CastMediaDescriptor.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/CastMediaDescriptor.kt
@@ -1,5 +1,9 @@
 package com.phoebe.app.player
 
+import com.phoebe.app.data.ArtworkAuthHolder
+import com.phoebe.app.data.ArtworkOriginHolder
+import com.phoebe.app.data.bindPlexUrl
+import com.phoebe.app.data.isPlexMediaPathOrUrl
 import com.phoebe.app.domain.Track
 import io.ktor.http.Url
 
@@ -40,8 +44,9 @@ fun Track.toCastMediaDescriptor(): CastMediaDescriptor {
     // Plex queues intentionally retain host-free paths so a network change cannot leave stale
     // origins behind. Cast receivers need an absolute URL, so bind the path only for this
     // request using the same live origin and token as local playback.
-    val boundTrack = boundToLivePlaybackOrigin()
+    val boundTrack = copy(localUri = null).boundToLivePlaybackOrigin()
     val castUrl = boundTrack.chromecastMediaUrl()
+    val castThumbUrl = boundTrack.chromecastArtworkUrl(castUrl)
     return CastMediaDescriptor(
         trackId = id,
         title = title.ifBlank { "Chromecast audio" },
@@ -52,11 +57,37 @@ fun Track.toCastMediaDescriptor(): CastMediaDescriptor {
         castUrl = castUrl,
         contentType = boundTrack.chromecastContentType(castUrl),
         downloadUrl = boundTrack.downloadUrl,
-        thumbUrl = thumbUrl,
+        thumbUrl = castThumbUrl,
         filepath = filepath,
         audioCodec = audioCodec,
         isLiveStream = isLiveCastStream(castUrl),
     )
+}
+
+/**
+ * Resolve an absolute, receiver-loadable HTTP(S) artwork URL for Chromecast displays.
+ * Relative Plex paths or token-less URLs are bound using the active stream origin and token.
+ * Non-remote artwork (like local file/content URIs) returns null so the receiver avoids
+ * attempting to load an unresolvable URL that renders an empty square.
+ */
+fun Track.chromecastArtworkUrl(castUrl: String? = null): String? {
+    val raw = thumbUrl?.trim()?.takeIf { it.isNotBlank() }
+        ?: localArtworkUri?.trim()?.takeIf { it.isCastReceiverLoadableUrl() }
+        ?: return null
+    if (!raw.isPlexMediaPathOrUrl()) {
+        return raw.takeIf { it.isCastReceiverLoadableUrl() }
+    }
+    val effectiveCastUrl = castUrl?.takeIf { it.isNotBlank() } ?: streamUrl
+    val origin = playbackOriginOf(effectiveCastUrl)
+        ?: ArtworkOriginHolder.liveOrigin?.trimEnd('/')?.takeIf { it.isNotBlank() }
+        ?: playbackOriginOf(streamUrl)
+        ?: return raw.takeIf { it.isCastReceiverLoadableUrl() }
+    val token = effectiveCastUrl.substringAfter("X-Plex-Token=", "").substringBefore('&').takeIf { it.isNotBlank() }
+        ?: ArtworkAuthHolder.plexToken?.takeIf { it.isNotBlank() }
+        ?: streamUrl.substringAfter("X-Plex-Token=", "").substringBefore('&').takeIf { it.isNotBlank() }
+        .orEmpty()
+    val bound = bindPlexUrl(raw, origin, token)
+    return bound.takeIf { it.isCastReceiverLoadableUrl() }
 }
 
 /** Radio stations have no duration to seek within, and HLS playlists are live by construction. */

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/CatalogBrowseTree.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/CatalogBrowseTree.kt
@@ -367,29 +367,76 @@ class CatalogBrowseTree(
     private fun String.matchesVoiceQuery(query: String): Boolean {
         val value = normalizedForVoiceSearch()
         val target = query.normalizedForVoiceSearch()
-        return target.isNotBlank() && (value == target || value.contains(target))
+        if (target.isBlank()) return false
+        if (value == target || value.contains(target)) return true
+        val tokens = query.voiceSearchTokens()
+        return tokens.isNotEmpty() && tokens.all { value.containsVoiceToken(it) }
     }
 
-    /** Returns matching track ids, best match first. */
+    /**
+     * Rank tracks for a spoken query.
+     *
+     * Voice queries are noisy: filler words, title/artist split across fields, and
+     * spoken forms that disagree with catalog text ("Miss" vs "Ms."). Score by
+     * phrase match first, then by how many query tokens land in any metadata field
+     * (with short abbreviation aliases). Significant tokens (length ≥ 3) should
+     * mostly match; tiny tokens like "ms" may miss without killing the result.
+     */
     private fun List<SelectTrackSearchIndex>.rankedByVoiceQuery(
         query: String,
         fields: (SelectTrackSearchIndex) -> List<VoiceSearchField>,
     ): List<String> {
         val normalizedQuery = query.normalizedForVoiceSearch()
-        val tokens = normalizedQuery.split(' ').filter { it.isNotBlank() }
-        if (normalizedQuery.isBlank()) return emptyList()
+        val tokens = query.voiceSearchTokens()
+        if (normalizedQuery.isBlank() || tokens.isEmpty()) return emptyList()
+        val phrase = tokens.joinToString(" ")
+        val significantTokens = tokens.filter { it.length >= SignificantTokenMinLength }
         return asSequence()
             .mapNotNull { track ->
-                val score = fields(track).maxOfOrNull { field ->
-                    val normalizedField = field.value.normalizedForVoiceSearch()
+                val fieldList = fields(track).map { field ->
+                    field to field.value.normalizedForVoiceSearch()
+                }
+                val phraseScore = fieldList.maxOfOrNull { (field, value) ->
                     when {
-                        normalizedField == normalizedQuery -> 400 + field.weight
-                        normalizedField.startsWith(normalizedQuery) -> 300 + field.weight
-                        normalizedField.contains(normalizedQuery) -> 200 + field.weight
-                        tokens.all { token -> normalizedField.contains(token) } -> 100 + field.weight
+                        value == normalizedQuery || value == phrase -> 400 + field.weight
+                        value.startsWith(phrase) || value.startsWith(normalizedQuery) ->
+                            300 + field.weight
+                        value.contains(phrase) || value.contains(normalizedQuery) ->
+                            200 + field.weight
                         else -> 0
                     }
                 } ?: 0
+
+                val tokenFieldWeights = tokens.map { token ->
+                    fieldList.maxOfOrNull { (field, value) ->
+                        if (value.containsVoiceToken(token)) field.weight else 0
+                    } ?: 0
+                }
+                val matchedTokens = tokenFieldWeights.count { it > 0 }
+                val matchedSignificant = significantTokens.count { token ->
+                    fieldList.any { (_, value) -> value.containsVoiceToken(token) }
+                }
+                val coverage = matchedTokens.toDouble() / tokens.size
+                val significantCoverage =
+                    if (significantTokens.isEmpty()) {
+                        1.0
+                    } else {
+                        matchedSignificant.toDouble() / significantTokens.size
+                    }
+                val tokenScore = when {
+                    matchedTokens == 0 -> 0
+                    // One-shot queries must hit; multi-token voice can drop a short/aliased token.
+                    tokens.size == 1 && matchedTokens != 1 -> 0
+                    significantTokens.isNotEmpty() && significantCoverage < MinSignificantTokenCoverage -> 0
+                    tokens.size >= 2 && matchedTokens < MinMatchedTokensForMultiWord -> 0
+                    coverage < MinTokenCoverage && significantCoverage < 1.0 -> 0
+                    else -> {
+                        val perfectBonus = if (matchedTokens == tokens.size) 40 else 0
+                        50 + tokenFieldWeights.sum() + matchedTokens * 15 + perfectBonus
+                    }
+                }
+
+                val score = maxOf(phraseScore, tokenScore)
                 if (score > 0) track to score else null
             }
             .sortedWith(
@@ -408,6 +455,19 @@ class CatalogBrowseTree(
             .trim()
             .replace(WhitespaceRegex, " ")
 
+    private fun String.voiceSearchTokens(): List<String> =
+        normalizedForVoiceSearch()
+            .split(' ')
+            .filter { it.isNotBlank() && it !in VoiceFillerWords }
+
+    private fun String.containsVoiceToken(token: String): Boolean {
+        if (contains(token)) return true
+        return voiceTokenAliases(token).any { alias -> alias != token && contains(alias) }
+    }
+
+    private fun voiceTokenAliases(token: String): List<String> =
+        VoiceTokenAliasGroups.firstOrNull { token in it }?.toList().orEmpty()
+
     private data class VoiceSearchField(val value: String, val weight: Int)
 
     private companion object {
@@ -415,7 +475,27 @@ class CatalogBrowseTree(
         private const val FieldWeightArtist = 30
         private const val FieldWeightAlbum = 20
         private const val FieldWeightGenre = 10
+        private const val SignificantTokenMinLength = 3
+        private const val MinMatchedTokensForMultiWord = 2
+        private const val MinTokenCoverage = 0.6
+        private const val MinSignificantTokenCoverage = 0.67
         private val NonAlphanumericRegex = Regex("[^a-z0-9]+")
         private val WhitespaceRegex = Regex("\\s+")
+        /** Spoken glue that must not be required to appear inside a single metadata field. */
+        private val VoiceFillerWords = setOf(
+            "a", "an", "and", "album", "artist", "by", "from", "music", "of", "on", "play",
+            "please", "playlist", "some", "song", "songs", "the", "to", "track", "tracks",
+        )
+        /**
+         * Spoken ↔ catalog abbreviation groups. Matching any member counts as matching
+         * the others (e.g. Assistant says "Miss", library stores "Ms.").
+         */
+        private val VoiceTokenAliasGroups = listOf(
+            setOf("ms", "miss"),
+            setOf("mrs", "missus", "missis"),
+            setOf("mr", "mister"),
+            setOf("dr", "doctor"),
+            setOf("st", "saint"),
+        )
     }
 }

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/CatalogBrowseTree.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/CatalogBrowseTree.kt
@@ -462,7 +462,10 @@ class CatalogBrowseTree(
 
     private fun String.containsVoiceToken(token: String): Boolean {
         if (contains(token)) return true
-        return voiceTokenAliases(token).any { alias -> alias != token && contains(alias) }
+        // Compare aliases against whole normalized tokens, not substrings: a short alias like
+        // "ms" (for "miss") must not match inside an unrelated word such as "Dreams".
+        val fieldTokens = split(' ')
+        return voiceTokenAliases(token).any { alias -> alias != token && fieldTokens.contains(alias) }
     }
 
     private fun voiceTokenAliases(token: String): List<String> =

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackRuntimeDependencies.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackRuntimeDependencies.kt
@@ -8,4 +8,18 @@ interface PlaybackRuntimeDependencies {
     val database: PhoebeDatabase
     val catalogRepository: CatalogRepository
     val sessionRepository: SessionRepository
+
+    /**
+     * Probe and publish the live media-server base for a headless process.
+     *
+     * The catalog stores host-less Plex paths and the origin is bound at request time from
+     * [com.phoebe.app.data.ArtworkOriginHolder]. That holder is normally filled by `AppState`,
+     * which only exists once Compose starts — but Android Auto binds [PlaybackService] without
+     * ever launching the Activity. Nothing then binds an origin, so every stream URI stays a
+     * relative `/library/parts/...` path (ExoPlayer: "Source error") and every thumb stays an
+     * unloadable relative URI.
+     *
+     * Returns the live base, or null when there is no Plex session to resolve one for.
+     */
+    suspend fun ensureLivePlaybackOrigin(): String? = null
 }

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackUrlOrigins.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/PlaybackUrlOrigins.kt
@@ -156,8 +156,14 @@ fun Track.boundToLivePlaybackOrigin(
     } else {
         downloadUrl
     }
-    if (stream == streamUrl && download == downloadUrl) return this
-    return copy(streamUrl = stream, downloadUrl = download)
+    val rawThumb = thumbUrl
+    val thumb = if (!rawThumb.isNullOrBlank() && rawThumb.isPlexMediaPathOrUrl()) {
+        bindPlexUrl(rawThumb, base, token)
+    } else {
+        rawThumb
+    }
+    if (stream == streamUrl && download == downloadUrl && thumb == thumbUrl) return this
+    return copy(streamUrl = stream, downloadUrl = download, thumbUrl = thumb)
 }
 
 /**
@@ -169,10 +175,12 @@ fun Track.withRelativePlexPlaybackPaths(): Track {
     if (!localUri.isNullOrBlank()) return this
     val stream = plexAssetPath(streamUrl) ?: streamUrl
     val download = plexAssetPath(downloadUrl) ?: downloadUrl
-    if (stream == streamUrl && download == downloadUrl && playbackFallbackUrls.isEmpty()) return this
+    val thumb = thumbUrl?.let { plexAssetPath(it) ?: it }
+    if (stream == streamUrl && download == downloadUrl && thumb == thumbUrl && playbackFallbackUrls.isEmpty()) return this
     return copy(
         streamUrl = stream,
         downloadUrl = download,
+        thumbUrl = thumb,
         playbackFallbackUrls = emptyList(),
     )
 }
@@ -344,9 +352,14 @@ fun List<Track>.withFreshPlaybackUrls(
     liveOrigin: String? = null,
 ): List<Track> {
     if (session == null || isEmpty()) return this
+    // The origin ranking is a property of the session and the current network, not of any one
+    // track. Computing it per entry meant tapping "play album" ran a ConnectivityManager probe
+    // and a full connection-list sort once per track on the UI thread before playback state
+    // could even update — the tap felt dead for as long as the queue was long.
+    val origins = freshPlaybackOrigins(session, liveOrigin)
     var changed = false
     val refreshed = map { track ->
-        val next = track.withFreshPlaybackUrls(session, liveOrigin)
+        val next = track.withFreshPlaybackUrls(session, origins)
         if (next !== track) changed = true
         next
     }
@@ -356,17 +369,26 @@ fun List<Track>.withFreshPlaybackUrls(
 fun Track.withFreshPlaybackUrls(
     session: PlexSession,
     liveOrigin: String? = null,
-): Track {
+): Track = withFreshPlaybackUrls(session, freshPlaybackOrigins(session, liveOrigin))
+
+/** Ranked playback origins for [session] on the current network, shared across a whole queue. */
+private fun freshPlaybackOrigins(session: PlexSession, liveOrigin: String?): List<String> {
     val identity = currentNetworkIdentity()
     val demoteLocalOrigins = StreamingPlaybackPolicyHolder.settings.shouldDemoteLocalOrigins(
         identity.demotesLocalOrigins,
     ) || session.selectedServer?.let { identity.shouldSkipAdvertisedLan(it) } == true
     val preferred = liveOrigin?.trimEnd('/')?.takeIf { it.isNotBlank() }
-    val origins = playbackOriginCandidates(
+    return playbackOriginCandidates(
         server = session.selectedServer,
         preferredOrigin = preferred,
         demoteLocalOrigins = demoteLocalOrigins,
     )
+}
+
+private fun Track.withFreshPlaybackUrls(
+    session: PlexSession,
+    origins: List<String>,
+): Track {
     if (session.providerType == MediaProviderType.Plex &&
         (streamUrl.isPlexMediaPathOrUrl() || downloadUrl.isPlexMediaPathOrUrl())
     ) {

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
@@ -100,6 +100,14 @@ abstract class SimpleAudioPlayer(
 
     protected fun isPlayRequestCurrent(generation: Int): Boolean = generation == playGeneration
 
+    protected fun invalidatePreparedPlayback() {
+        preparedPlayGeneration = -1
+        openPlaybackOrigin = null
+    }
+
+    protected open fun hasActivePlatformPlayback(): Boolean =
+        preparedPlayGeneration == playGeneration && mutableState.value.playbackErrorMessage == null
+
     override fun play(queue: List<Track>, startIndex: Int) {
         if (queue.isEmpty()) return
         val previous = mutableState.value
@@ -121,9 +129,9 @@ abstract class SimpleAudioPlayer(
         // buffers with nothing open yet, and sticky-binding alone must not resume into silence.
         val canResumeSameTrack = sameCurrentTrack &&
             !currentTrackEnded &&
-            track != null &&
+            previous.playbackErrorMessage == null &&
             !trackNeedsLiveOriginBind(track) &&
-            preparedPlayGeneration == playGeneration
+            hasActivePlatformPlayback()
         if (canResumeSameTrack) {
             if (previous.isPlaying && !previous.isBuffering && playWhenReady) {
                 return
@@ -148,16 +156,30 @@ abstract class SimpleAudioPlayer(
         playWhenReady = true
         val generation = playGeneration
         stopProgressTicker()
-        if (!sameQueue) {
-            stopCurrentPlaybackImmediately()
+        // Always silence current output before opening the next item. Skipping this for
+        // same-queue next/prev left ffmpeg/Java Sound playing until async dispose caught up.
+        stopCurrentPlaybackImmediately()
+        // Same unfinished track (reload after stall/failure/resume) must keep the playhead.
+        // Resetting to 0 made pause→play and mid-track recoveries restart the song.
+        val keepPositionMs = if (sameCurrentTrack && !currentTrackEnded) {
+            previous.positionMs.coerceAtLeast(0L).let { position ->
+                val duration = track?.durationMs ?: previous.durationMs
+                if (duration > 0L) position.coerceAtMost(duration) else position
+            }
+        } else {
+            0L
         }
         mutableState.value = previous.copy(
             queue = playbackQueue,
             currentIndex = if (track == null) -1 else index,
             isPlaying = false,
             isBuffering = track != null,
-            positionMs = 0L,
-            bufferedPositionMs = 0L,
+            positionMs = keepPositionMs,
+            bufferedPositionMs = if (keepPositionMs > 0L) {
+                maxOf(previous.bufferedPositionMs, keepPositionMs)
+            } else {
+                0L
+            },
             durationMs = track?.durationMs ?: 0L,
             playbackErrorMessage = null,
         )
@@ -344,10 +366,12 @@ abstract class SimpleAudioPlayer(
         openPlaybackOrigin = playbackOriginOf(initialUri)
         preparedPlayGeneration = generation
         startPlaybackStartupWatchdog(generation)
-        if (sameQueue) {
+        val startPositionMs = mutableState.value.positionMs.coerceAtLeast(0L)
+        // Same-queue skips start at 0; mid-track reloads must open with the preserved playhead.
+        if (sameQueue && startPositionMs <= 0L) {
             skipToInQueueOnPlatform(queue, index, track, generation)
         } else {
-            playQueueOnPlatform(queue, index, track, generation)
+            playQueueOnPlatform(queue, index, track, generation, startPositionMs = startPositionMs)
         }
     }
 
@@ -442,9 +466,13 @@ abstract class SimpleAudioPlayer(
         )
         setOutputVolume(effectiveOutputVolume())
         if (track != null) {
-            if (resolvedInitialPlaybackUriOrNull(track) == null) {
+            val initialUri = resolvedInitialPlaybackUriOrNull(track)
+            if (initialUri == null) {
                 failNoPlayableSource(track, generation)
             } else {
+                notePlaybackUri(initialUri, generation)
+                openPlaybackOrigin = playbackOriginOf(initialUri)
+                preparedPlayGeneration = generation
                 playQueueOnPlatform(queue, index, track, generation)
                 if (boundedPositionMs > 0L) {
                     seek(boundedPositionMs)
@@ -464,6 +492,7 @@ abstract class SimpleAudioPlayer(
         playWhenReady = false
         stopProgressTicker()
         stopCurrentPlaybackImmediately()
+        invalidatePreparedPlayback()
         val boundedPositionMs = positionMs.coerceAtLeast(0L).let { position ->
             val duration = track?.durationMs ?: 0L
             if (duration > 0L) position.coerceAtMost(duration) else position
@@ -488,7 +517,14 @@ abstract class SimpleAudioPlayer(
             mutableState.value = state.copy(isPlaying = false, isBuffering = false)
             cancelGaplessPrepare()
             pause()
-            stopCurrentPlaybackImmediately()
+            // Cold loads with nothing open should cancel; mid-track stalls must keep the
+            // platform player so resume continues from the same playhead.
+            if (!hasActivePlatformPlayback()) {
+                stopCurrentPlaybackImmediately()
+                invalidatePreparedPlayback()
+            } else {
+                stopProgressTicker()
+            }
             return
         }
         if (state.isPlaying) {
@@ -500,17 +536,17 @@ abstract class SimpleAudioPlayer(
             return
         }
         val track = state.currentTrack
-        // After an unreachable cold start the queue still holds relative Plex paths. Resume
-        // (and desktop reloadOnResume → playTrack) would open those unbound; re-play instead.
-        if (track != null &&
-            trackNeedsLiveOriginBind(track) &&
-            state.currentIndex in state.queue.indices
-        ) {
+        // If playback previously failed, or the platform player has not been prepared yet,
+        // or the track still needs origin binding, re-enter full playback instead of resuming into void.
+        val shouldRestartPlayback = track != null &&
+            state.currentIndex in state.queue.indices &&
+            (!hasActivePlatformPlayback() || trackNeedsLiveOriginBind(track))
+        if (shouldRestartPlayback) {
             play(state.queue, state.currentIndex)
             return
         }
         playWhenReady = true
-        mutableState.value = state.copy(isPlaying = true)
+        mutableState.value = state.copy(isPlaying = true, playbackErrorMessage = null)
         resume()
         startProgressTicker()
     }
@@ -539,6 +575,7 @@ abstract class SimpleAudioPlayer(
 
     override fun stopPlayback() {
         playGeneration++
+        invalidatePreparedPlayback()
         playWhenReady = false
         stickyPlaybackOrigin = null
         clearCrossfadeRequestState()
@@ -778,21 +815,22 @@ abstract class SimpleAudioPlayer(
         val current = mutableState.value
         val effectivePlaying = isPlaying && playWhenReady
         val effectiveDurationMs = if (durationMs > 0L) durationMs else current.durationMs
+        val effectivePositionMs = positionMs
         val effectiveBufferedPositionMs = bufferedPositionMs
-            .coerceAtLeast(positionMs)
-            .coerceAtLeast(current.bufferedPositionMs)
+            .coerceAtLeast(effectivePositionMs)
             .let { buffered ->
+                // Allow the buffer bar to move backward across seeks; only floor to playhead.
                 if (effectiveDurationMs > 0L) buffered.coerceAtMost(effectiveDurationMs) else buffered
             }
         val effectiveBuffering = isBuffering &&
             playWhenReady &&
             (forceBuffering ||
                 !hasPlaybackReadyBuffer(
-                    positionMs = positionMs,
+                    positionMs = effectivePositionMs,
                     bufferedPositionMs = effectiveBufferedPositionMs,
                     durationMs = effectiveDurationMs,
                 ))
-        if (current.positionMs == positionMs &&
+        if (current.positionMs == effectivePositionMs &&
             current.bufferedPositionMs == effectiveBufferedPositionMs &&
             current.durationMs == effectiveDurationMs &&
             current.isPlaying == effectivePlaying &&
@@ -801,7 +839,7 @@ abstract class SimpleAudioPlayer(
             return
         }
         mutableState.value = current.copy(
-            positionMs = positionMs,
+            positionMs = effectivePositionMs,
             bufferedPositionMs = effectiveBufferedPositionMs,
             durationMs = effectiveDurationMs,
             isPlaying = effectivePlaying,
@@ -812,8 +850,8 @@ abstract class SimpleAudioPlayer(
         } else {
             stopProgressTicker()
         }
-        maybeStartCrossfadeAtPosition(generation, positionMs)
-        maybeStartGaplessAtPosition(generation, positionMs)
+        maybeStartCrossfadeAtPosition(generation, effectivePositionMs)
+        maybeStartGaplessAtPosition(generation, effectivePositionMs)
     }
 
     protected fun publishAudioAnalysis(frame: AudioAnalysisFrame) {
@@ -915,6 +953,7 @@ abstract class SimpleAudioPlayer(
         if (cancelPlayIntent) {
             playWhenReady = false
         }
+        invalidatePreparedPlayback()
         stopPlaybackStartupWatchdog()
         val current = mutableState.value
         mutableState.value = current.copy(
@@ -929,6 +968,7 @@ abstract class SimpleAudioPlayer(
 
     protected fun markPlaybackWaitingForUserGesture(generation: Int = playGeneration) {
         if (!isPlayRequestCurrent(generation)) return
+        invalidatePreparedPlayback()
         stopPlaybackStartupWatchdog()
         val current = mutableState.value
         mutableState.value = current.copy(

--- a/playback/src/commonTest/kotlin/com/phoebe/app/CastControllerTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/CastControllerTest.kt
@@ -392,4 +392,127 @@ class CastControllerTest {
 
         assertTrue(original.matchesCastMedia(remote, descriptor.castUrl))
     }
+
+    @Test
+    fun relativePlexArtworkIsBoundToReceiverLoadableUrl() {
+        val liveOrigin = "https://plex.example:32400"
+        ArtworkOriginHolder.update(liveOrigin)
+        ArtworkAuthHolder.update("token")
+        try {
+            val track = Track(
+                id = "plex:track:1",
+                title = "One",
+                artist = "Artist",
+                album = "Album",
+                durationMs = 60_000,
+                streamUrl = "/library/parts/1/file.mp3",
+                downloadUrl = "/library/parts/1/file.mp3",
+                thumbUrl = "/library/metadata/1/thumb/2",
+            )
+
+            val descriptor = track.toCastMediaDescriptor()
+            assertEquals(
+                "$liveOrigin/library/metadata/1/thumb/2?X-Plex-Token=token",
+                descriptor.thumbUrl,
+            )
+            assertTrue(descriptor.thumbUrl.orEmpty().isCastReceiverLoadableUrl())
+        } finally {
+            ArtworkOriginHolder.clear()
+            ArtworkAuthHolder.clear()
+        }
+    }
+
+    @Test
+    fun plexArtworkResolvesOriginAndTokenFromStreamUrlIfArtworkOriginHolderEmpty() {
+        ArtworkOriginHolder.clear()
+        ArtworkAuthHolder.clear()
+        val track = Track(
+            id = "plex:track:1",
+            title = "One",
+            artist = "Artist",
+            album = "Album",
+            durationMs = 60_000,
+            streamUrl = "https://192-168-1-50.abc.plex.direct:32400/library/parts/1/file.mp3?X-Plex-Token=fresh-token",
+            downloadUrl = "",
+            thumbUrl = "/library/metadata/1/thumb/2",
+        )
+        val descriptor = track.toCastMediaDescriptor()
+        assertEquals(
+            "https://192-168-1-50.abc.plex.direct:32400/library/metadata/1/thumb/2?X-Plex-Token=fresh-token",
+            descriptor.thumbUrl,
+        )
+        assertTrue(descriptor.thumbUrl.orEmpty().isCastReceiverLoadableUrl())
+    }
+
+    @Test
+    fun downloadedPlexTrackBindsArtworkForCast() {
+        val liveOrigin = "https://plex.example:32400"
+        ArtworkOriginHolder.update(liveOrigin)
+        ArtworkAuthHolder.update("token")
+        try {
+            val downloadedTrack = Track(
+                id = "plex:track:1",
+                title = "One",
+                artist = "Artist",
+                album = "Album",
+                durationMs = 60_000,
+                streamUrl = "/library/parts/1/file.mp3",
+                downloadUrl = "",
+                localUri = "file:///music/one.mp3",
+                localArtworkUri = "file:///music/one.jpg",
+                thumbUrl = "/library/metadata/1/thumb/2",
+            )
+
+            val descriptor = downloadedTrack.toCastMediaDescriptor()
+            assertEquals(
+                "$liveOrigin/library/metadata/1/thumb/2?X-Plex-Token=token",
+                descriptor.thumbUrl,
+            )
+            assertTrue(descriptor.thumbUrl.orEmpty().isCastReceiverLoadableUrl())
+            assertEquals(
+                "$liveOrigin/library/parts/1/file.mp3?X-Plex-Token=token",
+                descriptor.castUrl,
+            )
+        } finally {
+            ArtworkOriginHolder.clear()
+            ArtworkAuthHolder.clear()
+        }
+    }
+
+    @Test
+    fun localFileArtworkIsNotPassedToCastReceiver() {
+        val track = Track(
+            id = "local:1",
+            title = "One",
+            artist = "Artist",
+            album = "Album",
+            durationMs = 60_000,
+            streamUrl = "https://example.com/audio.mp3",
+            downloadUrl = "",
+            localArtworkUri = "file:///local/cover.jpg",
+            thumbUrl = "file:///local/cover.jpg",
+        )
+        val descriptor = track.toCastMediaDescriptor()
+        assertEquals(null, descriptor.thumbUrl)
+    }
+
+    @Test
+    fun remoteNonPlexArtworkKeepsRemoteUrl() {
+        val track = Track(
+            id = "jellyfin:1",
+            title = "One",
+            artist = "Artist",
+            album = "Album",
+            durationMs = 60_000,
+            streamUrl = "https://jellyfin.example/audio.mp3",
+            downloadUrl = "",
+            thumbUrl = "https://jellyfin.example/Items/1/Images/Primary?api_key=token",
+        )
+        val descriptor = track.toCastMediaDescriptor()
+        assertEquals(
+            "https://jellyfin.example/Items/1/Images/Primary?api_key=token",
+            descriptor.thumbUrl,
+        )
+        assertTrue(descriptor.thumbUrl.orEmpty().isCastReceiverLoadableUrl())
+    }
 }

--- a/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
@@ -12,6 +12,7 @@ import com.phoebe.app.player.ColdOriginResolveSustainedDelayMs
 import com.phoebe.app.player.MaxTriedPlaybackUris
 import com.phoebe.app.player.PlaybackFailure
 import com.phoebe.app.player.PlaybackFailureClassifier
+import com.phoebe.app.player.PlaybackFailureKind
 import com.phoebe.app.player.PlaybackOriginResolver
 import com.phoebe.app.player.PlaybackOriginResolverHolder
 import com.phoebe.app.player.SimpleAudioPlayer
@@ -670,6 +671,28 @@ class PlayerStateTest {
         assertEquals(1, player.queueSkips)
     }
 
+    /**
+     * play() silences platform output before every load, including same-queue skips, so a
+     * half-disposed engine cannot keep playing under the next track. A platform that reacts to
+     * that hook by discarding its loaded playlist synchronously loses the skip path entirely and
+     * full-reloads on every next/previous — so the stop must land before, not instead of, the skip.
+     */
+    @Test
+    fun sameQueueSkipSilencesOutputBeforeReusingThePlatformQueue() {
+        val player = QueueAwareTestPlayer()
+        val tracks = listOf(
+            Track("t1", "One", "Artist", "Album", 60_000, "http://a", ""),
+            Track("t2", "Two", "Artist", "Album", 90_000, "http://b", ""),
+        )
+
+        player.play(tracks, 0)
+        player.finishPendingLoad()
+        player.play(tracks, 1)
+        player.finishPendingLoad()
+
+        assertEquals(listOf("stop", "load", "stop", "skip"), player.platformCalls)
+    }
+
     @Test
     fun endOfQueueStopsPlayback() {
         val player = TestPlayer()
@@ -796,7 +819,7 @@ class PlayerStateTest {
     }
 
     @Test
-    fun bufferedPositionDoesNotMoveBackwardForCurrentTrack() {
+    fun bufferedPositionFollowsPlatformAndStaysAtLeastPlayhead() {
         val player = PlatformStateTestPlayer()
         val tracks = listOf(
             Track("t1", "One", "Artist", "Album", 60_000, "http://a", ""),
@@ -804,9 +827,13 @@ class PlayerStateTest {
 
         player.play(tracks, 0)
         player.platformPlayback(positionMs = 10_000, durationMs = 60_000, bufferedPositionMs = 50_000)
+        // After a seek-like jump, trust the platform buffer instead of keeping a stale high-water mark.
         player.platformPlayback(positionMs = 20_000, durationMs = 60_000, bufferedPositionMs = 30_000)
 
-        assertEquals(50_000, player.state.value.bufferedPositionMs)
+        assertEquals(30_000, player.state.value.bufferedPositionMs)
+
+        player.platformPlayback(positionMs = 25_000, durationMs = 60_000, bufferedPositionMs = 10_000)
+        assertEquals(25_000, player.state.value.bufferedPositionMs)
     }
 
     @Test
@@ -1618,6 +1645,165 @@ class PlayerStateTest {
     }
 
     @Test
+    fun togglePlayPauseAfterPlaybackFailureRestartsPlaybackInsteadOfEnteringZombiePlayingState() = runTest {
+        val player = OpenedUriTestPlayer(this)
+        val track = Track(
+            id = "navidrome:1",
+            title = "Song",
+            artist = "Artist",
+            album = "Album",
+            durationMs = 240_000,
+            streamUrl = "http://192.168.4.26:30043/rest/stream.view?id=1",
+            downloadUrl = "",
+        )
+        player.play(listOf(track), 0)
+        runCurrent()
+        assertEquals(1, player.openedUris.size)
+        assertTrue(player.state.value.isBuffering)
+
+        // Simulate startup failure (e.g. timeout / unreachable origin)
+        player.failPendingLoad(
+            PlaybackFailure(
+                kind = PlaybackFailureKind.Unreachable,
+                message = "failed to connect to playback origin",
+                streamUri = track.streamUrl,
+            ),
+        )
+        runCurrent()
+
+        assertEquals(
+            "Can't reach the music server. Check your connection and try again.",
+            player.state.value.playbackErrorMessage,
+        )
+        assertFalse(player.state.value.isPlaying)
+        assertFalse(player.state.value.isBuffering)
+
+        // When the user taps play/pause after failure:
+        player.togglePlayPause()
+        runCurrent()
+
+        // It must NOT set isPlaying = true while doing nothing; it must restart playback (buffering, clearing error)
+        assertFalse(player.state.value.isPlaying, "Must not flip to isPlaying=true before platform connects")
+        assertTrue(player.state.value.isBuffering, "Must transition to buffering while reconnecting")
+        assertNull(player.state.value.playbackErrorMessage, "Error message must be cleared on retry")
+        assertEquals(2, player.openedUris.size, "Must re-request stream from platform player")
+
+        // Once platform is ready, now it is playing
+        player.finishPendingLoad()
+        runCurrent()
+        assertTrue(player.state.value.isPlaying)
+        assertFalse(player.state.value.isBuffering)
+    }
+
+    @Test
+    fun togglePlayPauseWhenPausedResumesInstantlyWithoutReOpeningUri() = runTest {
+        val player = OpenedUriTestPlayer(this)
+        val track = Track(
+            id = "navidrome:1",
+            title = "Song",
+            artist = "Artist",
+            album = "Album",
+            durationMs = 240_000,
+            streamUrl = "http://192.168.4.26:30043/rest/stream.view?id=1",
+            downloadUrl = "",
+        )
+        player.play(listOf(track), 0)
+        player.finishPendingLoad()
+        runCurrent()
+        assertTrue(player.state.value.isPlaying)
+        assertEquals(1, player.openedUris.size)
+
+        // User pauses
+        player.togglePlayPause()
+        runCurrent()
+        assertFalse(player.state.value.isPlaying)
+        assertFalse(player.state.value.isBuffering)
+
+        // User resumes - must resume without re-opening
+        player.togglePlayPause()
+        runCurrent()
+        assertTrue(player.state.value.isPlaying)
+        assertFalse(player.state.value.isBuffering)
+        assertEquals(1, player.openedUris.size, "Normal resume must not re-open stream URI")
+    }
+
+    @Test
+    fun replayingSameUnfinishedTrackPreservesPlayhead() = runTest {
+        val player = OpenedUriTestPlayer(this)
+        val track = Track(
+            id = "navidrome:1",
+            title = "Song",
+            artist = "Artist",
+            album = "Album",
+            durationMs = 240_000,
+            streamUrl = "http://192.168.4.26:30043/rest/stream.view?id=1",
+            downloadUrl = "",
+        )
+        player.play(listOf(track), 0)
+        player.finishPendingLoad()
+        runCurrent()
+        player.applyPlatformPosition(45_000L)
+        assertEquals(45_000L, player.state.value.positionMs)
+
+        player.togglePlayPause()
+        runCurrent()
+        assertFalse(player.state.value.isPlaying)
+        assertEquals(45_000L, player.state.value.positionMs)
+
+        player.invalidatePreparedForTest()
+        player.togglePlayPause()
+        runCurrent()
+
+        assertEquals(45_000L, player.state.value.positionMs, "Reload must keep the mid-track playhead")
+        assertEquals(45_000L, player.lastStartPositionMs, "Platform open must seek to preserved playhead")
+        assertEquals(2, player.openedUris.size)
+    }
+
+    @Test
+    fun platformPlayheadIsSourceOfTruthEvenWhenItJumpsBackward() {
+        val player = PlatformStateTestPlayer()
+        val tracks = listOf(
+            Track("t1", "One", "Artist", "Album", 60_000, "http://a", ""),
+        )
+        player.play(tracks, 0)
+        player.platformPlayback(positionMs = 45_000, durationMs = 60_000, bufferedPositionMs = 50_000)
+        assertEquals(45_000, player.state.value.positionMs)
+
+        // Seeks restart the decoder at the target; a temporary 0 from a new stream must be
+        // allowed through so the UI can converge on the real playhead.
+        player.platformPlayback(positionMs = 12_000, durationMs = 60_000, bufferedPositionMs = 12_000)
+        assertEquals(12_000, player.state.value.positionMs)
+    }
+
+    @Test
+    fun pauseDuringMidTrackStallKeepsPreparedPlaybackForResume() {
+        val player = PlatformStateTestPlayer()
+        val tracks = listOf(
+            Track("t1", "One", "Artist", "Album", 60_000, "http://a", ""),
+        )
+        player.play(tracks, 0)
+        player.platformPlayback(
+            positionMs = 30_000,
+            durationMs = 60_000,
+            bufferedPositionMs = 30_400,
+            isPlaying = false,
+            isBuffering = true,
+            forceBuffering = true,
+        )
+        assertTrue(player.state.value.isBuffering)
+        assertEquals(30_000, player.state.value.positionMs)
+
+        player.togglePlayPause()
+        assertFalse(player.state.value.isBuffering)
+        assertFalse(player.state.value.isPlaying)
+        assertEquals(30_000, player.state.value.positionMs)
+
+        player.togglePlayPause()
+        assertTrue(player.state.value.isPlaying)
+        assertEquals(30_000, player.state.value.positionMs)
+    }
+
+    @Test
     fun coldResolveKeepsTryingUntilOriginAppearsWithoutManualRetry() = runTest {
         var origin: String? = null
         var resolveCalls = 0
@@ -1772,6 +1958,7 @@ private class OpenedUriTestPlayer(
     scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
 ) : SimpleAudioPlayer(scope) {
     val openedUris = mutableListOf<String>()
+    var lastStartPositionMs: Long = -1L
 
     override fun playUri(uri: String) {
         openedUris += uri
@@ -1785,15 +1972,34 @@ private class OpenedUriTestPlayer(
         generation: Int,
         startPositionMs: Long,
     ) {
+        lastStartPositionMs = startPositionMs
         openedUris += StreamingPlaybackPolicyHolder.resolvePlaybackUri(track)
     }
 
     override fun skipToInQueueOnPlatform(queue: List<Track>, startIndex: Int, track: Track, generation: Int) {
+        lastStartPositionMs = 0L
         openedUris += StreamingPlaybackPolicyHolder.resolvePlaybackUri(track)
     }
 
     fun finishPendingLoad() {
         markPlaybackReady(generation = activePlayGeneration)
+    }
+
+    fun failPendingLoad(failure: PlaybackFailure) {
+        publishPlaybackFailure(failure, generation = activePlayGeneration)
+    }
+
+    fun applyPlatformPosition(positionMs: Long) {
+        applyPlatformPlayback(
+            positionMs = positionMs,
+            durationMs = state.value.durationMs,
+            isPlaying = true,
+            bufferedPositionMs = positionMs,
+        )
+    }
+
+    fun invalidatePreparedForTest() {
+        invalidatePreparedPlayback()
     }
 }
 
@@ -1875,8 +2081,13 @@ private class QueueAwareTestPlayer(
 ) : SimpleAudioPlayer(scope) {
     var fullLoads = 0
     var queueSkips = 0
+    val platformCalls = mutableListOf<String>()
 
     override fun playUri(uri: String) = Unit
+
+    override fun stopCurrentPlaybackImmediately() {
+        platformCalls += "stop"
+    }
 
     override fun playQueueOnPlatform(
         queue: List<Track>,
@@ -1886,10 +2097,12 @@ private class QueueAwareTestPlayer(
         startPositionMs: Long,
     ) {
         fullLoads++
+        platformCalls += "load"
     }
 
     override fun skipToInQueueOnPlatform(queue: List<Track>, startIndex: Int, track: Track, generation: Int) {
         queueSkips++
+        platformCalls += "skip"
     }
 
     fun finishPendingLoad() {

--- a/playback/src/commonTest/kotlin/com/phoebe/app/player/PlaybackUrlRefreshTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/player/PlaybackUrlRefreshTest.kt
@@ -156,6 +156,39 @@ class PlaybackUrlRefreshTest {
         assertEquals(track, refreshed)
     }
 
+    /**
+     * The queue overload resolves the origin ranking once and reuses it, instead of probing the
+     * network per entry on the UI thread. Every entry must still come out exactly as the
+     * single-track overload would produce it.
+     */
+    @Test
+    fun queueRefreshMatchesPerTrackRefreshForEveryEntry() {
+        val session = PlexSession(
+            token = "fresh-password",
+            userName = "fresh-user",
+            providerType = MediaProviderType.Navidrome,
+        )
+        val tracks = listOf(
+            playbackTrack(
+                streamUrl = "https://navidrome.example/rest/stream.view?id=1&u=old&p=old",
+                downloadUrl = "https://navidrome.example/rest/download.view?id=1",
+            ),
+            playbackTrack(
+                streamUrl = "https://navidrome.example/rest/stream.view?id=2",
+                downloadUrl = "https://navidrome.example/rest/download.view?id=2&u=old&p=old",
+            ),
+            playbackTrack(
+                streamUrl = "file:///music/local.mp3",
+                downloadUrl = "",
+            ),
+        )
+
+        assertEquals(
+            tracks.map { it.withFreshPlaybackUrls(session) },
+            tracks.withFreshPlaybackUrls(session),
+        )
+    }
+
     private fun playbackTrack(
         streamUrl: String,
         downloadUrl: String,

--- a/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
+++ b/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
@@ -366,8 +366,12 @@ class DesktopAudioPlayer(
         val stream = sampledStream
         sampledStream = null
         sampledStreamSource = null
-        runCatching { sampledClip?.stop() }
+        // Capture and close the clip so native mixer lines/buffers are released; dropping the
+        // reference without close() leaked them across repeated Clip-backed playback.
+        val clip = sampledClip
         sampledClip = null
+        runCatching { clip?.stop() }
+        runCatching { clip?.close() }
         runCatching { stream?.stop() }
         JavaFxRuntime.runLater {
             runCatching { player?.pause() }

--- a/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
+++ b/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopAudioPlayer.kt
@@ -83,7 +83,7 @@ class DesktopAudioPlayer(
         }
     }
 
-    private var player: MediaPlayer? = null
+    @Volatile private var player: MediaPlayer? = null
     private var lastPlaybackUiSyncAtMs = 0L
     private var javaFxProgressProbeStop: AtomicBoolean? = null
     private var javaFxVisualizerTap: JavaFxVisualizerPcmTap? = null
@@ -115,6 +115,9 @@ class DesktopAudioPlayer(
     private var pendingManualSeekGeneration = -1
     private var pendingManualSeekPositionMs = 0L
     private var pendingManualSeekUntilMs = 0L
+    @Volatile private var javaFxProgressLastRawPositionMs = 0L
+    @Volatile private var javaFxProgressFallbackBasePositionMs = 0L
+    @Volatile private var javaFxProgressFallbackBaseAtNs = 0L
     private var javaFxStartupWatchdogStop: AtomicBoolean? = null
     private var pendingPlaybackFailure: PlaybackFailure? = null
     private var reloadOnResume = false
@@ -167,7 +170,10 @@ class DesktopAudioPlayer(
         val closeLineOnStop: Boolean = true,
     ) {
         val stopped = AtomicBoolean(false)
-        val pendingWrites = LinkedBlockingQueue<ByteArray>()
+        // Bound the queue so ffmpeg (which can decode at 1000x) cannot dump the whole
+        // track into RAM and EOF the pump within a second — that used to stop playback
+        // immediately via finally { stop() } while audio was still queued.
+        val pendingWrites = LinkedBlockingQueue<ByteArray>(SampledStreamPendingWriteChunks)
         @Volatile
         var writtenPcmBytes: Long = stream.format.pcmBytesForDurationMs(startPositionMs)
         @Volatile
@@ -194,8 +200,14 @@ class DesktopAudioPlayer(
             if (writeWorker != null) return
             writeWorker = Thread(
                 {
-                    while (!stopped.get() || pendingWrites.isNotEmpty()) {
+                    // Exit as soon as stop is requested — never drain the queue after skip/pause-teardown.
+                    while (!stopped.get()) {
+                        if (paused) {
+                            Thread.sleep(25L)
+                            continue
+                        }
                         val chunk = pendingWrites.poll(50L, TimeUnit.MILLISECONDS) ?: continue
+                        if (stopped.get()) break
                         val written = runCatching { line.write(chunk, 0, chunk.size) }.getOrDefault(0)
                         if (written > 0) {
                             writtenPcmBytes += written.toLong()
@@ -207,6 +219,12 @@ class DesktopAudioPlayer(
             ).apply {
                 isDaemon = true
                 start()
+            }
+        }
+
+        fun enqueuePcm(chunk: ByteArray) {
+            while (!stopped.get()) {
+                if (pendingWrites.offer(chunk, 50L, TimeUnit.MILLISECONDS)) return
             }
         }
 
@@ -226,15 +244,16 @@ class DesktopAudioPlayer(
             lineTransferred = true
             stopped.set(true)
             paused = false
+            pendingWrites.clear()
             runCatching { stream.close() }
             runCatching { onStop?.invoke() }
         }
 
         fun stop() {
+            // Silence first, then clean up. Joining the writer before stopping the line used to
+            // keep playing ~2s of queued PCM after next/previous.
             stopped.set(true)
             paused = false
-            writeWorker?.join(2_000L)
-            writeWorker = null
             pendingWrites.clear()
             if (closeLineOnStop && !lineTransferred) {
                 runCatching { line.stop() }
@@ -243,6 +262,8 @@ class DesktopAudioPlayer(
             }
             runCatching { stream.close() }
             runCatching { onStop?.invoke() }
+            writeWorker?.join(200L)
+            writeWorker = null
         }
 
         fun pause() {
@@ -250,7 +271,10 @@ class DesktopAudioPlayer(
                 pausedAtNs = System.nanoTime()
                 paused = true
             }
-            runCatching { line.stop() }
+            // Do not call SourceDataLine.stop() here. On macOS (and often Windows) a stopped
+            // Java Sound line cannot be restarted reliably — resume becomes silence and the
+            // next play tap reloads the track from 0. The pump already stops feeding while
+            // paused, so the line underruns into silence without tearing it down.
         }
 
         fun resume() {
@@ -262,7 +286,11 @@ class DesktopAudioPlayer(
                 pausedAtNs = null
                 paused = false
             }
-            runCatching { line.start() }
+            runCatching {
+                if (!line.isRunning) {
+                    line.start()
+                }
+            }
         }
     }
 
@@ -335,8 +363,12 @@ class DesktopAudioPlayer(
     override fun stopCurrentPlaybackImmediately() {
         stopJavaFxProgressProbe()
         stopJavaFxVisualizerTap()
+        val stream = sampledStream
+        sampledStream = null
+        sampledStreamSource = null
         runCatching { sampledClip?.stop() }
-        runCatching { sampledStream?.stop() }
+        sampledClip = null
+        runCatching { stream?.stop() }
         JavaFxRuntime.runLater {
             runCatching { player?.pause() }
             runCatching { fadingOutPlayer?.pause() }
@@ -669,23 +701,51 @@ class DesktopAudioPlayer(
                 runCatching { clip.start() }
                 return@execute
             }
-            if (reloadOnResume) {
+            if (reloadOnResume || pendingPlaybackFailure != null || state.value.playbackErrorMessage != null) {
                 reloadCurrentTrack()
                 return@execute
             }
             JavaFxRuntime.runLater {
                 val mediaPlayer = player
-                if (mediaPlayer == null || mediaPlayer.error != null) {
+                val isDisposedOrBroken = mediaPlayer == null ||
+                    mediaPlayer.error != null ||
+                    mediaPlayer.status == MediaPlayer.Status.HALTED ||
+                    mediaPlayer.status == MediaPlayer.Status.DISPOSED
+                if (isDisposedOrBroken) {
                     playbackExecutor.execute { reloadCurrentTrack() }
-                } else {
-                    mediaPlayer.play()
+                    return@runLater
                 }
+                // STOPPED often follows a spurious end-of-media or a stalled pause. Prefer
+                // seeking back to the remembered playhead over reloading from 0.
+                if (mediaPlayer.status == MediaPlayer.Status.STOPPED) {
+                    val resumeMs = state.value.positionMs.coerceAtLeast(0L).toDouble()
+                    runCatching {
+                        if (resumeMs > 0.0) {
+                            mediaPlayer.seek(javafx.util.Duration.millis(resumeMs))
+                        }
+                        mediaPlayer.play()
+                    }.onFailure {
+                        playbackExecutor.execute { reloadCurrentTrack() }
+                    }
+                    return@runLater
+                }
+                mediaPlayer.play()
             }
         }
     }
 
+    override fun hasActivePlatformPlayback(): Boolean {
+        if (!super.hasActivePlatformPlayback()) return false
+        if (reloadOnResume || pendingPlaybackFailure != null) return false
+        val fxPlayer = player
+        val fxActive = fxPlayer != null && fxPlayer.error == null
+        return fxActive || sampledStream != null || sampledClip != null
+    }
+
     private fun reloadCurrentTrack() {
         reloadOnResume = false
+        pendingPlaybackFailure = null
+        disposeJavaFxBlocking(DesktopPlaybackStartupPolicy.JavaFxStartupDisposeTimeoutMs)
         val current = state.value
         val index = current.currentIndex
         // Go through SimpleAudioPlayer.play so unbound `/library/parts/...` paths re-enter
@@ -700,15 +760,29 @@ class DesktopAudioPlayer(
 
     override fun seek(positionMs: Long) {
         val generation = activePlayGeneration
+        val boundedPositionMs = positionMs.coerceAtLeast(0L)
+        // Arm settle on the caller thread before async work so progress probes cannot
+        // overwrite seekTo()'s UI position with a stale 0:00 clock.
+        pendingManualSeekGeneration = generation
+        pendingManualSeekPositionMs = boundedPositionMs
+        pendingManualSeekUntilMs = System.currentTimeMillis() + ManualSeekPlatformSettleMs
+        javaFxProgressLastRawPositionMs = boundedPositionMs
+        javaFxProgressFallbackBasePositionMs = boundedPositionMs
+        javaFxProgressFallbackBaseAtNs = System.nanoTime()
+        javaFxVisualizerPositionMs = boundedPositionMs
+        javaFxVisualizerPositionAtNs = System.nanoTime()
         playbackExecutor.execute {
             if (!isPlayRequestCurrent(generation)) return@execute
             pendingManualSeekGeneration = generation
-            pendingManualSeekPositionMs = positionMs.coerceAtLeast(0L)
+            pendingManualSeekPositionMs = boundedPositionMs
             pendingManualSeekUntilMs = System.currentTimeMillis() + ManualSeekPlatformSettleMs
+            cancelGaplessPrepareOnPlatform(generation)
             val stream = sampledStream
             if (stream != null) {
                 val source = sampledStreamSource
-                if (source != null && restartSampledStreamAt(source, pendingManualSeekPositionMs, generation)) {
+                if (source != null && restartSampledStreamAt(source, boundedPositionMs, generation)) {
+                    // Keep settle armed until the *new* stream (startPositionMs ≈ target) syncs.
+                    // Clearing here let the dying stream push the old playhead back into UI.
                     return@execute
                 }
                 runCatching { stream.line.flush() }
@@ -719,16 +793,14 @@ class DesktopAudioPlayer(
                 runCatching {
                     val wasPlaying = clip.isActive
                     clip.stop()
-                    clip.microsecondPosition = positionMs.coerceAtLeast(0L) * 1000L
+                    clip.microsecondPosition = boundedPositionMs * 1000L
                     if (wasPlaying) clip.start()
                 }
             } else {
                 JavaFxRuntime.runLater {
                     if (!isPlayRequestCurrent(generation)) return@runLater
-                    player?.seek(javafx.util.Duration.millis(positionMs.toDouble()))
+                    player?.seek(javafx.util.Duration.millis(boundedPositionMs.toDouble()))
                 }
-                javaFxVisualizerPositionMs = positionMs.coerceAtLeast(0L)
-                javaFxVisualizerPositionAtNs = System.nanoTime()
                 javaFxVisualizerTap?.restart()
             }
         }
@@ -1057,9 +1129,7 @@ class DesktopAudioPlayer(
                     incoming.setMute(false)
                     incoming.volume = effectiveOutputVolume().toDouble().coerceIn(0.0, 1.0)
                     incoming.setOnEndOfMedia {
-                        if (isPlayRequestCurrent(generation) && player === incoming) {
-                            advanceAfterPlatformTrackEnded(generation)
-                        }
+                        handleJavaFxEndOfMedia(incoming, generation)
                     }
                     attachJavaFxSpectrumListener(incoming)
                     attachJavaFxPlaybackListeners(incoming, generation) { player === incoming }
@@ -1418,9 +1488,7 @@ class DesktopAudioPlayer(
                     }
                     incoming.volume = effectiveOutputVolume().toDouble().coerceIn(0.0, 1.0)
                     incoming.setOnEndOfMedia {
-                        if (isPlayRequestCurrent(generation) && player === incoming) {
-                            advanceAfterPlatformTrackEnded(generation)
-                        }
+                        handleJavaFxEndOfMedia(incoming, generation)
                     }
                     attachJavaFxSpectrumListener(incoming)
                     attachJavaFxPlaybackListeners(incoming, generation) { player === incoming }
@@ -1706,6 +1774,7 @@ class DesktopAudioPlayer(
     ) {
         PhoebeLog.d("DesktopAudioPlayer") { failure.logLine() }
         diagnostics.playbackError(PlaybackEnginePath.JavaFxMediaPlayer, failure.logLine())
+        disposeJavaFxBlocking(DesktopPlaybackStartupPolicy.JavaFxStartupDisposeTimeoutMs)
         if (failure.isInfrastructureFailure && !failure.shouldTryAlternateEngine) {
             pendingPlaybackFailure = failure
             finishPlaybackFailed(failure, generation)
@@ -1715,11 +1784,9 @@ class DesktopAudioPlayer(
             PhoebeLog.d("DesktopAudioPlayer") {
                 "skipping alternate engine after JavaFX timeout on local-only origin"
             }
-            disposeJavaFxBlocking(DesktopPlaybackStartupPolicy.JavaFxStartupDisposeTimeoutMs)
             finishPlaybackFailed(failure, generation)
             return
         }
-        disposeJavaFxBlocking(DesktopPlaybackStartupPolicy.JavaFxStartupDisposeTimeoutMs)
         if (failure.shouldTryAlternateEngine) {
             PhoebeLog.d("DesktopAudioPlayer") {
                 "trying alternate engine after JavaFX startup failure"
@@ -1927,9 +1994,7 @@ class DesktopAudioPlayer(
                         failStartup(javaFxErrorFailure(mediaPlayer.error, uri))
                     }
                     mediaPlayer.setOnEndOfMedia {
-                        if (isPlayRequestCurrent(generation) && player === mediaPlayer) {
-                            advanceAfterPlatformTrackEnded(generation)
-                        }
+                        handleJavaFxEndOfMedia(mediaPlayer, generation)
                     }
                     media.setOnError {
                         failStartup(javaFxErrorFailure(media.error, uri))
@@ -1960,6 +2025,11 @@ class DesktopAudioPlayer(
                         mediaReady.set(true)
                         cancelJavaFxStartupWatchdog()
                         schedulePlayingWatchdog()
+                        if (pendingManualSeekGeneration == generation && pendingManualSeekPositionMs > 0L) {
+                            mediaPlayer.seek(
+                                javafx.util.Duration.millis(pendingManualSeekPositionMs.toDouble()),
+                            )
+                        }
                         syncJavaFxPlayback(mediaPlayer, generation, isBuffering = false)
                         attachJavaFxPlaybackListeners(mediaPlayer, generation) { player === mediaPlayer }
                         if (playWhenReady && isPlayRequestCurrent(generation)) {
@@ -2344,7 +2414,23 @@ class DesktopAudioPlayer(
         }
         syncSampledStreamPlayback(playback, generation)
         startSampledStreamPump(playback, bufferSize, generation)
+        startSampledStreamProgressProbe(playback, generation)
         return true
+    }
+
+    private fun startSampledStreamProgressProbe(
+        playback: StreamingSampledPlayback,
+        generation: Int,
+    ) {
+        Thread({
+            while (isPlayRequestCurrent(generation) && sampledStream === playback && !playback.stopped.get()) {
+                syncSampledStreamPlayback(playback, generation)
+                Thread.sleep(250L)
+            }
+        }, "Phoebe-sampled-stream-progress").apply {
+            isDaemon = true
+            start()
+        }
     }
 
     private fun prepareGaplessSampledStream(
@@ -2711,16 +2797,31 @@ class DesktopAudioPlayer(
     ) {
         Thread({
             val buffer = ByteArray(VisualizerStreamChunkBytes)
+            var decoderEnded = false
             try {
                 while (isPlayRequestCurrent(generation) && sampledStream === playback && !playback.stopped.get()) {
                     waitIfSampledStreamPaused(playback)
                     val read = playback.stream.read(buffer, 0, buffer.size)
-                    if (read < 0) break
+                    if (read < 0) {
+                        decoderEnded = true
+                        break
+                    }
                     if (read == 0) continue
                     writeSampledStreamBuffer(playback, buffer, read, generation)
                     syncSampledStreamPlayback(playback, generation)
                 }
-                if (isPlayRequestCurrent(generation) && sampledStream === playback && !playback.stopped.get()) {
+                if (decoderEnded &&
+                    isPlayRequestCurrent(generation) &&
+                    sampledStream === playback &&
+                    !playback.stopped.get()
+                ) {
+                    waitForSampledStreamAudibleDrain(playback, generation)
+                    if (!isPlayRequestCurrent(generation) ||
+                        sampledStream !== playback ||
+                        playback.stopped.get()
+                    ) {
+                        return@Thread
+                    }
                     if (!commitPreparedGapless(generation)) {
                         runCatching { playback.line.drain() }
                         advanceAfterPlatformTrackEnded(generation)
@@ -2741,6 +2842,39 @@ class DesktopAudioPlayer(
         }, "Phoebe-sampled-stream-playback").apply {
             isDaemon = true
             start()
+        }
+    }
+
+    /**
+     * ffmpeg often finishes decoding far ahead of realtime. After stdout EOF, keep the
+     * write worker alive until the audible playhead catches the queued PCM (or the known
+     * duration), instead of tearing the line down immediately.
+     */
+    private fun waitForSampledStreamAudibleDrain(
+        playback: StreamingSampledPlayback,
+        generation: Int,
+    ) {
+        val durationMs = state.value.durationMs
+        var idleMs = 0L
+        while (isPlayRequestCurrent(generation) && sampledStream === playback && !playback.stopped.get()) {
+            if (playback.paused) {
+                Thread.sleep(50L)
+                continue
+            }
+            syncSampledStreamPlayback(playback, generation)
+            val queued = playback.pendingWrites.isNotEmpty()
+            val positionMs = playback.playbackPositionMs()
+            val nearEnd = durationMs <= 0L ||
+                positionMs >= (durationMs - SampledStreamEndAdvanceToleranceMs).coerceAtLeast(0L)
+            val lineIdle = !playback.line.isActive && !playback.line.isRunning
+            if (!queued && (nearEnd || (lineIdle && idleMs >= 500L))) {
+                PhoebeLog.d("DesktopAudioPlayer") {
+                    "sampled-stream drain complete at ${positionMs}ms (duration ${durationMs}ms, nearEnd=$nearEnd)"
+                }
+                return
+            }
+            idleMs = if (!queued && lineIdle) idleMs + 50L else 0L
+            Thread.sleep(50L)
         }
     }
 
@@ -2775,7 +2909,7 @@ class DesktopAudioPlayer(
             )
         }
         playback.decodedPcmBytes += length.coerceAtLeast(0)
-        playback.pendingWrites.offer(buffer.copyOf(length))
+        playback.enqueuePcm(buffer.copyOf(length))
         if (!playback.reportedEnergy) {
             val rms = pcmRms(buffer.copyOf(length), playback.stream.format)
             if (rms > 0.0 && rms.isFinite()) {
@@ -2826,32 +2960,39 @@ class DesktopAudioPlayer(
 
     private fun syncSampledStreamPlayback(playback: StreamingSampledPlayback, generation: Int) {
         if (!isPlayRequestCurrent(generation) || sampledStream !== playback) return
-        val decodedPositionMs = playback.stream.format.durationMsForPcmBytes(playback.writtenPcmBytes)
-        val durationMs = state.value.durationMs
-        val lastWriteElapsedMs = (System.nanoTime() - playback.lastWriteAtNs) / 1_000_000L
-        val linePlaying = playback.line.isActive || playback.line.isRunning || (lastWriteElapsedMs < 1200L)
-        val audiblePositionMs = if (!playback.paused && linePlaying) {
-            playback.playbackPositionMs()
-        } else {
-            (playback.line.microsecondPosition / 1_000L).coerceAtLeast(0L)
-        }
-        val manualSeekSettling = isManualSeekSettling(generation)
-        val stabilizedPositionMs = stabilizedPlatformPositionMs(audiblePositionMs, generation)
-        val positionMs = stabilizedPositionMs
-            .let { position ->
-                if (manualSeekSettling) {
-                    position
-                } else {
-                    position.coerceAtMost(decodedPositionMs.takeIf { it > 0L } ?: audiblePositionMs)
-                }
+        val durationMs = state.value.durationMs.takeIf { it > 0L } ?: playback.fullyBufferedDurationMs ?: 0L
+        val seekTargetMs = pendingManualSeekPositionMs
+        val settling = pendingManualSeekGeneration == generation
+        // While a seek is in flight, only the restarted stream (same startPosition) may
+        // drive the playhead. The previous stream must not yank UI back to the old time.
+        if (settling) {
+            val streamIsSeekTarget =
+                kotlin.math.abs(playback.startPositionMs - seekTargetMs) <= ManualSeekPlatformSettleToleranceMs
+            if (!streamIsSeekTarget) {
+                applyPlatformPlayback(
+                    positionMs = seekTargetMs,
+                    durationMs = durationMs,
+                    isPlaying = playWhenReady && !playback.paused,
+                    isBuffering = true,
+                    bufferedPositionMs = seekTargetMs,
+                    generation = generation,
+                    forceBuffering = true,
+                )
+                return
             }
-            .let { position -> if (durationMs > 0L) position.coerceAtMost(durationMs) else position }
-        val decodedBufferedMs = maxOf(positionMs, decodedPositionMs)
+            pendingManualSeekGeneration = -1
+        }
+        val positionMs = playback.playbackPositionMs().let { position ->
+            if (durationMs > 0L) position.coerceIn(0L, durationMs) else position.coerceAtLeast(0L)
+        }
+        val decodedPositionMs = playback.stream.format.durationMsForPcmBytes(playback.writtenPcmBytes)
+        val lastWriteElapsedMs = (System.nanoTime() - playback.lastWriteAtNs) / 1_000_000L
+        val linePlaying = playback.line.isActive || playback.line.isRunning || (lastWriteElapsedMs < 1_200L)
         val bufferedPositionMs = playback.fullyBufferedDurationMs
             ?.takeIf { it > 0L }
-            ?: decodedBufferedMs
+            ?: maxOf(positionMs, decodedPositionMs)
         diagnostics.playbackProgress(PlaybackEnginePath.SampledStream, positionMs, durationMs)
-        if (linePlaying) {
+        if (linePlaying && !playback.paused) {
             diagnostics.platformPlaying(PlaybackEnginePath.SampledStream, positionMs, durationMs)
         }
         if (!playback.reportedOutput && linePlaying && playback.writtenPcmBytes > 0L) {
@@ -2864,11 +3005,11 @@ class DesktopAudioPlayer(
         applyPlatformPlayback(
             positionMs = positionMs,
             durationMs = durationMs,
-            isPlaying = !playback.paused && linePlaying && !isStarting,
+            isPlaying = !playback.paused && (linePlaying || isStarting) && !isStarved,
             isBuffering = isBuffering,
             bufferedPositionMs = bufferedPositionMs,
             generation = generation,
-            forceBuffering = isBuffering,
+            forceBuffering = isStarved,
         )
     }
 
@@ -3384,10 +3525,16 @@ class DesktopAudioPlayer(
         stopJavaFxProgressProbe()
         val stop = AtomicBoolean(false)
         javaFxProgressProbeStop = stop
+        if (isManualSeekSettling(generation)) {
+            javaFxProgressLastRawPositionMs = pendingManualSeekPositionMs
+            javaFxProgressFallbackBasePositionMs = pendingManualSeekPositionMs
+            javaFxProgressFallbackBaseAtNs = System.nanoTime()
+        } else {
+            javaFxProgressLastRawPositionMs = 0L
+            javaFxProgressFallbackBasePositionMs = 0L
+            javaFxProgressFallbackBaseAtNs = System.nanoTime()
+        }
         Thread({
-            var lastRawPositionMs = 0L
-            var fallbackBasePositionMs = 0L
-            var fallbackBaseAtNs = System.nanoTime()
             while (!stop.get() && isPlayRequestCurrent(generation)) {
                 val latch = CountDownLatch(1)
                 JavaFxRuntime.runLater {
@@ -3400,15 +3547,25 @@ class DesktopAudioPlayer(
                         val playing = mediaPlayer.status == MediaPlayer.Status.PLAYING
                         updateJavaFxVisualizerPlayhead(mediaPlayer)
                         val nowNs = System.nanoTime()
-                        if (rawPositionMs > lastRawPositionMs || !playing) {
-                            lastRawPositionMs = rawPositionMs
-                            fallbackBasePositionMs = rawPositionMs
-                            fallbackBaseAtNs = nowNs
+                        val settling = isManualSeekSettling(generation)
+                        if (settling) {
+                            javaFxProgressLastRawPositionMs = pendingManualSeekPositionMs
+                            javaFxProgressFallbackBasePositionMs = pendingManualSeekPositionMs
+                            javaFxProgressFallbackBaseAtNs = nowNs
+                        } else if (rawPositionMs > javaFxProgressLastRawPositionMs ||
+                            rawPositionMs < javaFxProgressLastRawPositionMs - 1_000L ||
+                            !playing
+                        ) {
+                            javaFxProgressLastRawPositionMs = rawPositionMs
+                            javaFxProgressFallbackBasePositionMs = rawPositionMs
+                            javaFxProgressFallbackBaseAtNs = nowNs
                         }
-                        val fallbackPositionMs = if (playing) {
-                            val elapsedMs = (nowNs - fallbackBaseAtNs).coerceAtLeast(0L) / 1_000_000L
+                        val fallbackPositionMs = if (settling) {
+                            pendingManualSeekPositionMs
+                        } else if (playing) {
+                            val elapsedMs = (nowNs - javaFxProgressFallbackBaseAtNs).coerceAtLeast(0L) / 1_000_000L
                             val durationMs = javafxDurationMs(mediaPlayer.media.duration)
-                            maxOf(rawPositionMs, fallbackBasePositionMs + elapsedMs).let { position ->
+                            maxOf(rawPositionMs, javaFxProgressFallbackBasePositionMs + elapsedMs).let { position ->
                                 if (durationMs > 0L) position.coerceAtMost(durationMs) else position
                             }
                         } else {
@@ -3444,13 +3601,30 @@ class DesktopAudioPlayer(
         fallbackPositionMs: Long? = null,
     ) {
         if (!isPlayRequestCurrent(generation)) return
-        val platformPositionMs = stabilizedPlatformPositionMs(javafxDurationMs(mediaPlayer.currentTime), generation)
-        val positionMs = maxOf(platformPositionMs, fallbackPositionMs ?: platformPositionMs)
+        val rawPlatformPositionMs = javafxDurationMs(mediaPlayer.currentTime)
+        val settling = isManualSeekSettling(generation)
+        val platformPositionMs = if (settling) {
+            pendingManualSeekPositionMs
+        } else {
+            stabilizedPlatformPositionMs(rawPlatformPositionMs, generation)
+        }
+        val positionMs = if (settling) {
+            pendingManualSeekPositionMs
+        } else {
+            maxOf(platformPositionMs, fallbackPositionMs ?: platformPositionMs)
+        }
+        if (settling &&
+            kotlin.math.abs(rawPlatformPositionMs - pendingManualSeekPositionMs) <= ManualSeekPlatformSettleToleranceMs
+        ) {
+            pendingManualSeekGeneration = -1
+        }
         val durationMs = javafxDurationMs(mediaPlayer.media.duration)
         val platformBufferedMs = javafxDurationMs(mediaPlayer.bufferProgressTime).coerceAtLeast(positionMs)
         val bufferedMs = if (fullyBufferedPlayback && durationMs > 0L) durationMs else platformBufferedMs
         val playing = mediaPlayer.status == MediaPlayer.Status.PLAYING
-        maybeHotStartGaplessJavaFx(mediaPlayer, generation, positionMs, durationMs)
+        if (!settling) {
+            maybeHotStartGaplessJavaFx(mediaPlayer, generation, positionMs, durationMs)
+        }
         val current = state.value
         val nowMs = System.currentTimeMillis()
         val playbackFlagsChanged = playing != current.isPlaying || isBuffering != current.isBuffering
@@ -3580,13 +3754,21 @@ class DesktopAudioPlayer(
 
     private fun stabilizedPlatformPositionMs(platformPositionMs: Long, generation: Int): Long {
         if (pendingManualSeekGeneration != generation) return platformPositionMs
-        val nowMs = System.currentTimeMillis()
-        if (nowMs > pendingManualSeekUntilMs) {
+        val targetPositionMs = pendingManualSeekPositionMs
+        if (kotlin.math.abs(platformPositionMs - targetPositionMs) <= ManualSeekPlatformSettleToleranceMs) {
             pendingManualSeekGeneration = -1
             return platformPositionMs
         }
-        val targetPositionMs = pendingManualSeekPositionMs
-        if (kotlin.math.abs(platformPositionMs - targetPositionMs) <= ManualSeekPlatformSettleToleranceMs) {
+        val nowMs = System.currentTimeMillis()
+        if (nowMs > pendingManualSeekUntilMs) {
+            // JavaFX often keeps reporting 0:00 for seconds after a seek. Snapping the UI back
+            // to that stale clock made the timeline look stuck and undid scrubbing.
+            val platformStillStale = targetPositionMs >= ManualSeekPlatformSettleToleranceMs &&
+                platformPositionMs + ManualSeekPlatformSettleToleranceMs < targetPositionMs
+            if (platformStillStale) {
+                pendingManualSeekUntilMs = nowMs + ManualSeekPlatformSettleMs
+                return targetPositionMs
+            }
             pendingManualSeekGeneration = -1
             return platformPositionMs
         }
@@ -3594,7 +3776,25 @@ class DesktopAudioPlayer(
     }
 
     private fun isManualSeekSettling(generation: Int): Boolean =
-        pendingManualSeekGeneration == generation && System.currentTimeMillis() <= pendingManualSeekUntilMs
+        pendingManualSeekGeneration == generation
+
+    private fun handleJavaFxEndOfMedia(mediaPlayer: MediaPlayer, generation: Int) {
+        if (!isPlayRequestCurrent(generation) || player !== mediaPlayer) return
+        val currentMs = javafxDurationMs(mediaPlayer.currentTime)
+        val durationMs = javafxDurationMs(mediaPlayer.media.duration).takeIf { it > 0L }
+            ?: state.value.durationMs.takeIf { it > 0L }
+        val settling = isManualSeekSettling(generation)
+        if (DesktopPlaybackStartupPolicy.shouldIgnoreJavaFxEndOfMedia(currentMs, durationMs, settling)) {
+            PhoebeLog.d("DesktopAudioPlayer") {
+                "ignoring spurious onEndOfMedia at ${currentMs}ms (duration ${durationMs}ms, settling=$settling)"
+            }
+            if (playWhenReady && mediaPlayer.status != MediaPlayer.Status.PLAYING) {
+                mediaPlayer.play()
+            }
+            return
+        }
+        advanceAfterPlatformTrackEnded(generation)
+    }
 
     private fun trackDurationOrClipDuration(generation: Int, clip: Clip): Long {
         val stateDuration = state.value.durationMs.takeIf { it > 0L }
@@ -3725,9 +3925,13 @@ class DesktopAudioPlayer(
         const val JavaFxDisposeSettleMs = 250L
         const val PlaybackUiSyncIntervalMs = 250L
         const val SampledClipEndToleranceMs = 20L
+        /** Ignore premature ffmpeg EOF unless the playhead is this close to known duration. */
+        const val SampledStreamEndAdvanceToleranceMs = 2_500L
         const val RemoteAudioProbeBufferBytes = 128 * 1024
         const val StreamingPcmBufferBytes = 16 * 1024
         const val VisualizerStreamChunkBytes = 4 * 1024
+        /** ~2s of 4KB chunks at 44.1kHz stereo — enough for smooth writes, small enough to backpressure ffmpeg. */
+        const val SampledStreamPendingWriteChunks = 88
         const val StreamingLineBufferSeconds = 0.06f
         const val LinuxStreamingLineBufferSeconds = 0.35f
         const val MaxStreamingLineBufferBytes = 1024 * 1024
@@ -4024,12 +4228,26 @@ private fun normalizedPcmSample(bytes: ByteArray, offset: Int, sampleBytes: Int,
 internal object DesktopPlaybackStartupPolicy {
     const val JavaFxFailureFallbackDelayMs = 3_000L
     const val JavaFxRemoteReadyTimeoutMs = 10_000L
-    const val JavaFxLocalPreflightTimeoutMs = 400L
+    const val JavaFxLocalPreflightTimeoutMs = 2_000L
     const val JavaFxStartupDisposeTimeoutMs = 1_500L
+    const val JavaFxLocalStreamingReadyTimeoutMs = 8_000L
+    const val JavaFxSpuriousEndOfMediaToleranceMs = 2_500L
+
+    fun shouldIgnoreJavaFxEndOfMedia(
+        currentMs: Long,
+        durationMs: Long?,
+        isManualSeekSettling: Boolean,
+    ): Boolean {
+        if (isManualSeekSettling) return true
+        if (durationMs != null && durationMs > 3_000L && currentMs < durationMs - JavaFxSpuriousEndOfMediaToleranceMs) {
+            return true
+        }
+        return false
+    }
 
     fun javaFxMediaReadyTimeoutMs(uri: String): Long = when {
         !isRemoteUri(uri) -> JavaFxFailureFallbackDelayMs
-        isLocalOnlyPlaybackOrigin(uri) -> JavaFxFailureFallbackDelayMs
+        isLocalOnlyPlaybackOrigin(uri) -> JavaFxLocalStreamingReadyTimeoutMs
         else -> JavaFxRemoteReadyTimeoutMs
     }
 

--- a/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopCastController.kt
+++ b/playback/src/desktopMain/kotlin/com/phoebe/app/player/DesktopCastController.kt
@@ -2,14 +2,12 @@ package com.phoebe.app.player
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -41,16 +39,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposePanel
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.phoebe.app.domain.Track
 import com.phoebe.app.platform.PhoebeLog
 import com.phoebe.app.platform.PlatformStorage
+import com.phoebe.app.ui.PhoebeIcon
+import com.phoebe.app.ui.PhoebeIconView
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -1617,40 +1614,7 @@ private fun CastDeviceGlyph() {
 
 @Composable
 private fun MiniCastGlyph(tint: Color) {
-    Canvas(modifier = Modifier.size(18.dp)) {
-        val strokeWidth = (size.minDimension * 0.075f).coerceAtLeast(1.25f)
-        val stroke = Stroke(width = strokeWidth)
-        val inset = strokeWidth / 2f
-        drawRoundRect(
-            color = tint,
-            topLeft = Offset(inset, size.height * 0.16f),
-            size = Size(size.width - strokeWidth, size.height * 0.58f),
-            style = stroke,
-        )
-        drawCircle(
-            color = tint,
-            radius = size.minDimension * 0.055f,
-            center = Offset(size.width * 0.22f, size.height * 0.84f),
-        )
-        drawArc(
-            color = tint,
-            startAngle = -90f,
-            sweepAngle = 90f,
-            useCenter = false,
-            topLeft = Offset(size.width * 0.08f, size.height * 0.54f),
-            size = Size(size.width * 0.36f, size.height * 0.36f),
-            style = stroke,
-        )
-        drawArc(
-            color = tint,
-            startAngle = -90f,
-            sweepAngle = 90f,
-            useCenter = false,
-            topLeft = Offset(size.width * -0.02f, size.height * 0.42f),
-            size = Size(size.width * 0.58f, size.height * 0.58f),
-            style = stroke,
-        )
-    }
+    PhoebeIconView(PhoebeIcon.Cast, tint = tint, modifier = Modifier.size(20.dp))
 }
 
 internal fun desktopCastIsFinishedIdleReason(idleReasonName: String?): Boolean =
@@ -1695,7 +1659,7 @@ private fun DesktopCastMedia.toMetadata(): Map<String, Any> =
         put(CastV2Media.METADATA_TITLE, title)
         put(CastV2Media.METADATA_ARTIST, artist)
         put(CastV2Media.METADATA_ALBUM_NAME, album)
-        thumbUrl?.let { url ->
+        thumbUrl?.takeIf { it.isCastReceiverLoadableUrl() }?.let { url ->
             put(CastV2Media.METADATA_IMAGES, listOf(mapOf("url" to url)))
         }
     }

--- a/playback/src/desktopTest/kotlin/com/phoebe/app/player/DesktopPlaybackStartupPolicyTest.kt
+++ b/playback/src/desktopTest/kotlin/com/phoebe/app/player/DesktopPlaybackStartupPolicyTest.kt
@@ -149,7 +149,7 @@ class DesktopPlaybackStartupPolicyTest {
     @Test
     fun javaFxReadyTimeoutStaysShortOnLanAndLocalFiles() {
         assertEquals(
-            DesktopPlaybackStartupPolicy.JavaFxFailureFallbackDelayMs,
+            DesktopPlaybackStartupPolicy.JavaFxLocalStreamingReadyTimeoutMs,
             DesktopPlaybackStartupPolicy.javaFxMediaReadyTimeoutMs(
                 "https://172-16-1-2.abc.plex.direct:32400/library/parts/1/file.mp3",
             ),
@@ -585,6 +585,64 @@ class DesktopPlaybackStartupPolicyTest {
             ?: DesktopPlaybackStartupPolicy.sampledPlaybackExtensionFromSuffix(
                 case.filepath.orEmpty().substringAfterLast('.', missingDelimiterValue = ""),
             )
+
+    @Test
+    fun javaFxSpuriousEndOfMediaIsIgnoredDuringSeekSettling() {
+        assertTrue(
+            DesktopPlaybackStartupPolicy.shouldIgnoreJavaFxEndOfMedia(
+                currentMs = 50_000L,
+                durationMs = 180_000L,
+                isManualSeekSettling = true,
+            ),
+        )
+    }
+
+    @Test
+    fun javaFxSpuriousEndOfMediaIsIgnoredWhenCurrentPositionIsFarFromEnd() {
+        assertTrue(
+            DesktopPlaybackStartupPolicy.shouldIgnoreJavaFxEndOfMedia(
+                currentMs = 60_000L,
+                durationMs = 180_000L,
+                isManualSeekSettling = false,
+            ),
+        )
+    }
+
+    @Test
+    fun javaFxLegitimateEndOfMediaNearDurationIsNotIgnored() {
+        assertFalse(
+            DesktopPlaybackStartupPolicy.shouldIgnoreJavaFxEndOfMedia(
+                currentMs = 179_000L,
+                durationMs = 180_000L,
+                isManualSeekSettling = false,
+            ),
+        )
+        assertFalse(
+            DesktopPlaybackStartupPolicy.shouldIgnoreJavaFxEndOfMedia(
+                currentMs = 180_000L,
+                durationMs = 180_000L,
+                isManualSeekSettling = false,
+            ),
+        )
+    }
+
+    @Test
+    fun javaFxEndOfMediaWithUnknownDurationIsNotIgnored() {
+        assertFalse(
+            DesktopPlaybackStartupPolicy.shouldIgnoreJavaFxEndOfMedia(
+                currentMs = 12_000L,
+                durationMs = null,
+                isManualSeekSettling = false,
+            ),
+        )
+        assertFalse(
+            DesktopPlaybackStartupPolicy.shouldIgnoreJavaFxEndOfMedia(
+                currentMs = 12_000L,
+                durationMs = 0L,
+                isManualSeekSettling = false,
+            ),
+        )
+    }
 
     private fun streamingExtension(case: RemoteStartupCase): String? =
         DesktopPlaybackStartupPolicy.streamingSampledExtensionFromSuffix(case.audioCodec.orEmpty())

--- a/playback/src/wasmJsMain/kotlin/com/phoebe/app/player/WebCastController.kt
+++ b/playback/src/wasmJsMain/kotlin/com/phoebe/app/player/WebCastController.kt
@@ -549,7 +549,7 @@ private fun CastMediaDescriptor.toWebCastMedia(): WebCastMedia =
         title = title,
         artist = artist,
         album = album,
-        imageUrl = thumbUrl,
+        imageUrl = thumbUrl?.takeIf { it.isCastReceiverLoadableUrl() },
         durationMs = durationMs,
         streamUrl = streamUrl,
         downloadUrl = downloadUrl,
@@ -853,7 +853,7 @@ private external fun webCastConnected(): Boolean
 	                metadata.title = item.title || "Chromecast audio";
 	                metadata.artist = item.artist || "";
 	                metadata.albumName = item.album || "";
-	                if (item.imageUrl) {
+	                if (item.imageUrl && (item.imageUrl.startsWith("http://") || item.imageUrl.startsWith("https://"))) {
 	                    metadata.images = typeof globalThis.chrome?.cast?.Image === "function"
 	                        ? [new globalThis.chrome.cast.Image(item.imageUrl)]
 	                        : [{ url: item.imageUrl }];

--- a/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/PhoebePlaybackControls.kt
+++ b/ui/media/src/commonMain/kotlin/com/phoebe/app/ui/PhoebePlaybackControls.kt
@@ -120,7 +120,7 @@ fun PlayButton(
     val iconSize = if (size > 52.dp) 24.dp else 21.dp
     val spinnerSize = iconSize + 2.dp
     val contentDescription = when {
-        isBuffering -> "Loading"
+        isBuffering -> "Stop loading"
         isPlaying -> "Pause"
         else -> "Play"
     }
@@ -140,7 +140,10 @@ fun PlayButton(
             )
             .clip(CircleShape)
             .background(gradient)
-            .clickable(enabled = enabled && !isBuffering, onClick = onClick)
+            // Stays tappable while buffering: togglePlayPause() cancels a load in progress, and
+            // a cold origin race can buffer for many seconds. Disabling here left the one control
+            // the user reaches for during a slow start completely inert.
+            .clickable(enabled = enabled, onClick = onClick)
             .semantics { this.contentDescription = contentDescription },
         contentAlignment = Alignment.Center,
     ) {
@@ -344,36 +347,51 @@ fun ProgressLine(
     val safeDuration = max(durationMs, 1L)
     val latestOnSeek = rememberUpdatedState(onSeek)
     var scrubPositionMs by remember { mutableStateOf<Long?>(null) }
+    // Keep showing the tapped time until the player clock catches up — seeks restart the
+    // decoder and can take a beat, but the UI should feel instant.
+    var committedSeekMs by remember { mutableStateOf<Long?>(null) }
     val isScrubbing = scrubPositionMs != null
-    val displayPositionMs = scrubPositionMs ?: positionMs
+    val displayPositionMs = scrubPositionMs
+        ?: committedSeekMs
+        ?: positionMs
     val progressFrac = (displayPositionMs.toFloat() / safeDuration).coerceIn(0f, 1f)
     val bufferedFrac = (bufferedPositionMs.toFloat() / safeDuration).coerceIn(progressFrac, 1f)
 
     LaunchedEffect(waveformSeed, durationMs) {
         scrubPositionMs = null
+        committedSeekMs = null
+    }
+    LaunchedEffect(positionMs, committedSeekMs) {
+        val pending = committedSeekMs ?: return@LaunchedEffect
+        // seekTo() writes the target optimistically, then a dying decoder can briefly push the
+        // old playhead back — keep the scrubbed time until the live clock stays near the target.
+        if (kotlin.math.abs(positionMs - pending) > 750L) return@LaunchedEffect
+        delay(320L)
+        if (committedSeekMs == pending && kotlin.math.abs(positionMs - pending) <= 750L) {
+            committedSeekMs = null
+        }
     }
 
     val seekModifier = if (onSeek != null && durationMs > 0L) {
         Modifier.pointerInput(durationMs) {
             fun offsetToMs(x: Float): Long {
                 val frac = (x / size.width).coerceIn(0f, 1f)
-                return (durationMs * frac).toLong()
+                val rawMs = (durationMs * frac).toLong()
+                val maxSeekMs = (durationMs - 500L).coerceAtLeast(0L)
+                return rawMs.coerceIn(0L, maxSeekMs)
             }
             awaitEachGesture {
                 val down = awaitFirstDown()
                 down.consume()
                 var scrubMs = offsetToMs(down.position.x)
-                val committedMs = scrubMs
                 scrubPositionMs = scrubMs
-                latestOnSeek.value?.invoke(scrubMs)
                 val pointerId = down.id
                 while (true) {
                     val event = awaitPointerEvent()
-                    val change = event.changes.firstOrNull { it.id == pointerId } ?: break
-                    if (!change.pressed) {
-                        if (scrubMs != committedMs) {
-                            latestOnSeek.value?.invoke(scrubMs)
-                        }
+                    val change = event.changes.firstOrNull { it.id == pointerId }
+                    if (change == null || !change.pressed) {
+                        committedSeekMs = scrubMs
+                        latestOnSeek.value?.invoke(scrubMs)
                         scrubPositionMs = null
                         break
                     }


### PR DESCRIPTION
## Summary
Improves cross-platform playback reliability and Android Auto browsing, plus cast artwork resolution and voice-search ranking.

### Playback robustness (desktop, shared engine)
- Preserve the playhead across pause→resume and mid-track reloads instead of restarting from 0.
- Bound the PCM pump queue and stop draining after `stop()` so skip/next no longer plays ~2s of queued audio; silence before cleanup.
- Avoid `SourceDataLine.stop()` on pause (couldn't reliably resume on macOS); underrun into silence instead.
- Arm manual-seek settle before async work so the progress probe can't overwrite a fresh seek with a stale 0:00 clock.
- Invalidate prepared playback when tearing down so resume can't re-enter a dead platform player.

### Android Auto origin binding (headless)
- `PlaybackService` now probes and binds a live Plex origin even when Compose never starts, so stream URIs and artwork resolve instead of surfacing "Source error".
- Cache origin ranking across a whole queue (was one `ConnectivityManager` probe + sort per track).
- Fail session requests that would hand ExoPlayer a host-less `/library/parts/...` URI with a clear message.

### Cast artwork
- Resolve cast thumbnails to an absolute receiver-loadable HTTP(S) URL; skip non-HTTP artwork so receivers don't render empty squares.
- Guard iOS `GCKImage` creation to HTTP(S) only.

### Voice search
- Rank by phrase match plus significant-token coverage with spoken↔catalog abbreviation aliases (Ms/Miss, Dr/Doctor, St/Saint) and filler-word filtering.

## Tests
- New/updated coverage: `PlayerStateTest`, `CastControllerTest`, `PlaybackUrlRefreshTest`, `CatalogBrowseTreeSearchTest`, `PlaybackClickTargetDesktopTest`, `BrowseMediaItemsTest`, `DesktopPlaybackStartupPolicyTest`.
- CI runs desktop tests, Android host + instrumented tests, wasm tests, screenshot verification, iOS build, backend tests, and web screenshots/E2E.

## Known risks
- Large behavioral change in the desktop audio engine; validated by desktop test suite + screenshot verification.
- Android Auto origin probing adds an async network probe on first browse; off the critical path.