### PR TITLE
Stream Library Radio playback and harden Chromecast queue handoff

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
@@ -2684,6 +2684,12 @@ class AppState(
             ) {
                 requestNavigation(AppNavigationRequest.Player)
                 if (fillsWholeLibrary) {
+                    if (dependencies.castController.state.value.isConnected) {
+                        // Cast only loads the short seed window to the receiver. Seed the paused
+                        // local player with the same tracks so the background fill grows it into the
+                        // full library; the cast window reload then adopts that longer queue.
+                        dependencies.audioPlayer.suspendPlayback(tracks, 0, 0L)
+                    }
                     scheduleLibraryRadioFill(tracks)
                 }
             }
@@ -3276,6 +3282,7 @@ class AppState(
     }
 
     fun clearQueue() {
+        cancelLibraryRadioFill()
         markKeepPlayingQueueEditedByUser()
         if (mutableMusicAssistantRemotePlayback.value != null) {
             mutableMusicAssistantRemotePlayback.value = null
@@ -3285,6 +3292,7 @@ class AppState(
     }
 
     private fun stopPlayback() {
+        cancelLibraryRadioFill()
         mutableMusicAssistantRemotePlayback.value = null
         dependencies.playbackTransportService.stopPlayback()
     }

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
@@ -60,6 +60,7 @@ import com.phoebe.app.domain.isFromLocalFolder
 import com.phoebe.app.domain.isMusicAssistant
 import com.phoebe.app.domain.isNavidrome
 import com.phoebe.app.domain.isPlex
+import com.phoebe.app.domain.isPlexLibraryTrack
 import com.phoebe.app.domain.playlistEntryKey
 import com.phoebe.app.domain.serverAuthToken
 import com.phoebe.app.domain.supportsCollectionEntry
@@ -82,6 +83,7 @@ import com.phoebe.app.data.PlayHistoryRankedEntries
 import com.phoebe.app.data.PlexPlayHistorySyncResult
 import com.phoebe.app.data.PlexClient
 import com.phoebe.app.data.defaultPlexRadioStations
+import com.phoebe.app.data.plexLibraryStationSlug
 import com.phoebe.app.playlists.PlaylistExportFormat
 import com.phoebe.app.player.MusicAssistantRemotePlayback
 import com.phoebe.app.player.PlaybackOriginResolver
@@ -402,6 +404,7 @@ class AppState(
     private var topTracksMixWarmSignature: String? = null
     private var topTracksMixBuildSignature: String? = null
     private var topTracksMixBuildDeferred: Deferred<List<Track>>? = null
+    private var libraryRadioFillJob: Job? = null
     private val prefetchedArtistIds = mutableSetOf<String>()
     private val prefetchedAlbumIds = mutableSetOf<String>()
     private val prefetchedMixBuilderArtistIds = mutableSetOf<String>()
@@ -426,6 +429,7 @@ class AppState(
     fun dispose() {
         if (disposed) return
         disposed = true
+        cancelLibraryRadioFill()
         listOfNotNull(
             catalogRefreshJob,
             playHistorySyncJob,
@@ -2647,10 +2651,17 @@ class AppState(
     fun playRadioStation(station: PlexRadioStation) = scope.launch {
         val radioId = station.key
         if (radioId in mutableRadioStartingIds.value) return@launch
+        val fillsWholeLibrary = station.isWholeLibraryStation()
+        cancelLibraryRadioFill()
         mutableRadioStartingIds.update { it + radioId }
         try {
             val tracks = runCatching {
-                dependencies.catalogRepository.playRadioStation(session.value, station)
+                dependencies.catalogRepository.playRadioStation(
+                    session = session.value,
+                    station = station,
+                    // Seed small so playback starts fast; the rest of the library is appended below.
+                    maxTracks = if (fillsWholeLibrary) LibraryRadioSeedTrackLimit else null,
+                )
             }.getOrElse { error ->
                 surfaceTransientNotice(error.message ?: "Couldn't start ${station.title}.")
                 return@launch
@@ -2672,10 +2683,38 @@ class AppState(
                 )
             ) {
                 requestNavigation(AppNavigationRequest.Player)
+                if (fillsWholeLibrary) {
+                    scheduleLibraryRadioFill(tracks)
+                }
             }
         } finally {
             mutableRadioStartingIds.update { it - radioId }
         }
+    }
+
+    /**
+     * Library Radio starts from a short Plex station seed, then finishes assembling the full
+     * on-device queue in small background batches. Chromecast projects that full queue itself.
+     */
+    private fun scheduleLibraryRadioFill(seedTracks: List<Track>) {
+        if (seedTracks.isEmpty()) return
+        cancelLibraryRadioFill()
+        libraryRadioFillJob = scope.launch {
+            val catalogTracks = dependencies.catalogRepository.catalog.value
+            val remaining = withContext(Dispatchers.Default) {
+                libraryRadioFillCandidates(catalogTracks, seedTracks)
+            }
+            if (remaining.isEmpty()) return@launch
+            for (chunk in remaining.chunked(LibraryRadioFillChunkSize)) {
+                appendToQueue(chunk)
+                delay(LibraryRadioFillChunkDelayMs)
+            }
+        }
+    }
+
+    private fun cancelLibraryRadioFill() {
+        libraryRadioFillJob?.cancel()
+        libraryRadioFillJob = null
     }
 
     fun playArtistRadio(artist: Artist) = scope.launch {
@@ -3064,6 +3103,7 @@ class AppState(
         clearShuffle: Boolean = false,
         preserveQueueContext: Boolean = false,
     ): Boolean {
+        cancelLibraryRadioFill()
         collectionMixGeneration++
         val playbackTracks = tracks.withFreshPlaybackUrls(session.value, currentPlaybackOrigin())
         if (playbackTracks.isEmpty()) return false
@@ -3085,7 +3125,7 @@ class AppState(
         }
         if (dependencies.castController.state.value.isConnected) {
             mutableMusicAssistantRemotePlayback.value = null
-            val support = dependencies.castController.canLoadQueue(playbackTracks)
+            val support = dependencies.castController.canLoadQueue(playbackTracks, startIndex)
             if (!support.isSupported) {
                 mutableMessage.value = support.message ?: "This queue can't be cast to Chromecast."
                 return false
@@ -4510,6 +4550,27 @@ internal fun mixQueueStillActiveForAppend(
     return true
 }
 
+/** True for the Plex station that draws on the whole music library rather than a slice of it. */
+internal fun PlexRadioStation.isWholeLibraryStation(): Boolean =
+    category == PlexRadioStationCategory.Library &&
+        key.plexLibraryStationSlug().lowercase() in WholeLibraryStationSlugs
+
+/** Every playable Plex song the catalog knows about, minus the seed queue, in shuffled order. */
+internal fun libraryRadioFillCandidates(
+    catalog: CatalogSnapshot,
+    seedTracks: List<Track>,
+    random: Random = Random.Default,
+): List<Track> {
+    val seedIds = seedTracks.mapTo(mutableSetOf()) { it.id }
+    return catalog.tracksByParent.values
+        .asSequence()
+        .flatten()
+        .filter { it.isPlexLibraryTrack() && it.hasPlayableSource() && it.id !in seedIds }
+        .distinctBy { it.id }
+        .toList()
+        .shuffled(random)
+}
+
 internal fun mixAppendCandidates(fullMix: List<Track>, existingQueue: List<Track>): List<Track> {
     val existingIds = existingQueue.mapTo(mutableSetOf()) { it.id }
     return fullMix.filter { existingIds.add(it.id) }
@@ -4585,6 +4646,14 @@ private const val KeepPlayingRecentTrackLimit = 25
 private const val PopularMixSeedTrackLimit = 50
 private const val PopularMixTrackLimit = 500
 private const val PopularMixShuffleChunkSize = 50
+
+/** Plex slugs (named and numeric) for the library-wide station. */
+private val WholeLibraryStationSlugs = setOf("library", "1")
+
+/** Songs pulled from Plex before Library Radio starts playing; the rest is appended in the background. */
+private const val LibraryRadioSeedTrackLimit = 100
+private const val LibraryRadioFillChunkSize = 500
+private const val LibraryRadioFillChunkDelayMs = 100L
 private const val MixProviderLoadTimeoutMs = 20_000L
 private const val ArtistMusicBrainzArtworkTimeoutMs = 35_000L
 

--- a/composeApp/src/commonTest/kotlin/com/phoebe/app/LibraryRadioFillTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/phoebe/app/LibraryRadioFillTest.kt
@@ -1,0 +1,73 @@
+package com.phoebe.app
+
+import com.phoebe.app.domain.CatalogSnapshot
+import com.phoebe.app.domain.PlexRadioStation
+import com.phoebe.app.domain.PlexRadioStationCategory
+import com.phoebe.app.domain.Track
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LibraryRadioFillTest {
+    @Test
+    fun wholeLibraryStationMatchesNamedAndNumericLibrarySlugs() {
+        assertTrue(station("/library/sections/3/stations/library").isWholeLibraryStation())
+        assertTrue(station("/library/sections/3/stations/1?type=10").isWholeLibraryStation())
+        assertFalse(station("/library/sections/3/stations/deepCuts").isWholeLibraryStation())
+        assertFalse(station("/library/sections/3/stations/timeTravel").isWholeLibraryStation())
+        assertFalse(
+            station("/library/sections/3/stations/library", PlexRadioStationCategory.Artist)
+                .isWholeLibraryStation(),
+        )
+    }
+
+    @Test
+    fun fillCandidatesCoverThePlexLibraryMinusTheSeedQueue() {
+        val seed = listOf(track("plex:seed1"), track("plex:seed2"))
+        val catalog = CatalogSnapshot(
+            tracksByParent = mapOf(
+                "plex:album1" to listOf(track("plex:seed1"), track("plex:a"), track("plex:b")),
+                "plex:album2" to listOf(track("plex:b"), track("plex:c")),
+                "local_1:album3" to listOf(track("local_1:d")),
+                "plex:album4" to listOf(track("plex:e", streamUrl = "")),
+            ),
+        )
+
+        val candidates = libraryRadioFillCandidates(catalog, seed, Random(7))
+
+        assertEquals(listOf("plex:a", "plex:b", "plex:c").sorted(), candidates.map { it.id }.sorted())
+    }
+
+    @Test
+    fun fillCandidatesAreEmptyWhenTheCatalogOnlyHoldsTheSeed() {
+        val seed = listOf(track("plex:seed1"))
+        val catalog = CatalogSnapshot(tracksByParent = mapOf("plex:album1" to seed))
+
+        assertEquals(emptyList(), libraryRadioFillCandidates(catalog, seed, Random(7)))
+    }
+
+    private fun station(
+        key: String,
+        category: PlexRadioStationCategory = PlexRadioStationCategory.Library,
+    ): PlexRadioStation =
+        PlexRadioStation(
+            id = "station",
+            title = "Library Radio",
+            subtitle = "",
+            key = key,
+            category = category,
+        )
+
+    private fun track(id: String, streamUrl: String = "https://plex.example/$id"): Track =
+        Track(
+            id = id,
+            title = id,
+            artist = "Artist",
+            album = "Album",
+            durationMs = 1_000L,
+            streamUrl = streamUrl,
+            downloadUrl = "",
+        )
+}

--- a/data/catalog/src/commonMain/kotlin/com/phoebe/app/data/CatalogRepository.kt
+++ b/data/catalog/src/commonMain/kotlin/com/phoebe/app/data/CatalogRepository.kt
@@ -4788,12 +4788,17 @@ class CatalogRepository(
         return mergePlexLibraryRadioStations(stations, defaults)
     }
 
-    suspend fun playRadioStation(session: PlexSession?, station: PlexRadioStation): List<Track> {
+    /** [maxTracks] caps the initial station play queue; null keeps the full Plex window. */
+    suspend fun playRadioStation(
+        session: PlexSession?,
+        station: PlexRadioStation,
+        maxTracks: Int? = null,
+    ): List<Track> {
         val server = session?.selectedServer ?: return emptyList()
         session.selectedLibrary ?: return emptyList()
         val token = session.serverAuthToken() ?: return emptyList()
         val machineId = resolveMachineIdentifier(server, token)
-        return plexClient.createStationPlayQueue(server, token, machineId, station.key)
+        return plexClient.createStationPlayQueue(server, token, machineId, station.key, maxTracks)
             .map { it.withPlexPrefix() }
             .also { tracks -> publishRadioTracksInBackground(tracks) }
     }

--- a/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexClient.kt
+++ b/data/providers/plex/src/commonMain/kotlin/com/phoebe/app/data/PlexClient.kt
@@ -607,16 +607,21 @@ class PlexClient private constructor(
         return station
     }
 
+    /**
+     * [maxTracks] trims how much of the station play queue is pulled up front. Callers that keep
+     * filling the queue afterwards (Library Radio) ask for a small seed so playback starts sooner.
+     */
     suspend fun createStationPlayQueue(
         server: PlexServer,
         token: String,
         machineIdentifier: String,
         stationKey: String,
+        maxTracks: Int? = null,
     ): List<Track> {
         var lastError: Throwable? = null
         for (key in plexLibraryStationKeysToTry(stationKey)) {
             val metadata = runCatching {
-                postStationPlayQueue(server, token, machineIdentifier, key)
+                postStationPlayQueue(server, token, machineIdentifier, key, maxTracks)
             }.getOrElse { error ->
                 lastError = error
                 PhoebeLog.d("PlexClient") { "createStationPlayQueue failed for $key: ${error.message}" }
@@ -635,6 +640,7 @@ class PlexClient private constructor(
         token: String,
         machineIdentifier: String,
         stationKey: String,
+        maxTracks: Int?,
     ): List<PlexMetadataDto> {
         val uri = "server://$machineIdentifier/$LibraryIdentifier${stationKey.normalizedStationKey()}"
         var lastError: Throwable? = null
@@ -670,7 +676,7 @@ class PlexClient private constructor(
                 null
             } ?: continue
             rememberApiBase(server.id, base)
-            return expandedPlayQueueMetadata(base, token, response.mediaContainer)
+            return expandedPlayQueueMetadata(base, token, response.mediaContainer, maxTracks)
         }
         throw lastError ?: IllegalStateException("Plex radio returned no playable songs.")
     }
@@ -679,14 +685,16 @@ class PlexClient private constructor(
         base: String,
         token: String,
         initial: PlexMediaContainer,
+        maxTracks: Int?,
     ): List<PlexMetadataDto> {
-        val playQueueId = initial.playQueueId ?: return initial.metadata.cappedPlayQueueMetadata()
+        val cap = (maxTracks ?: PlexPlayQueueMaxWindowSize).coerceIn(1, PlexPlayQueueMaxWindowSize)
+        val playQueueId = initial.playQueueId ?: return initial.metadata.cappedPlayQueueMetadata(cap)
         val totalCount = initial.playQueueTotalCount ?: initial.totalSize
         val requestedWindow = (totalCount ?: PlexPlayQueueDefaultWindowSize)
             .coerceAtLeast(initial.metadata.size)
-            .coerceAtLeast(PlexPlayQueueDefaultWindowSize)
-            .coerceAtMost(PlexPlayQueueMaxWindowSize)
-        if (requestedWindow <= initial.metadata.size) return initial.metadata.cappedPlayQueueMetadata()
+            .coerceAtLeast(minOf(PlexPlayQueueDefaultWindowSize, cap))
+            .coerceAtMost(cap)
+        if (requestedWindow <= initial.metadata.size) return initial.metadata.cappedPlayQueueMetadata(cap)
         val expanded = runCatching {
             fetchPlayQueueWindow(
                 base = base,
@@ -705,14 +713,14 @@ class PlexClient private constructor(
         }.getOrNull()
         val expandedMetadata = expanded?.mediaContainer?.metadata.orEmpty()
         return when {
-            expandedMetadata.size > initial.metadata.size -> expandedMetadata.cappedPlayQueueMetadata()
-            expandedMetadata.isNotEmpty() && initial.metadata.isEmpty() -> expandedMetadata.cappedPlayQueueMetadata()
-            else -> initial.metadata.cappedPlayQueueMetadata()
+            expandedMetadata.size > initial.metadata.size -> expandedMetadata.cappedPlayQueueMetadata(cap)
+            expandedMetadata.isNotEmpty() && initial.metadata.isEmpty() -> expandedMetadata.cappedPlayQueueMetadata(cap)
+            else -> initial.metadata.cappedPlayQueueMetadata(cap)
         }
     }
 
-    private fun List<PlexMetadataDto>.cappedPlayQueueMetadata(): List<PlexMetadataDto> =
-        take(PlexPlayQueueMaxWindowSize)
+    private fun List<PlexMetadataDto>.cappedPlayQueueMetadata(cap: Int): List<PlexMetadataDto> =
+        take(cap)
 
     private suspend fun fetchPlayQueueWindow(
         base: String,

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidCastController.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidCastController.kt
@@ -49,6 +49,7 @@ private data class CastLoadRequest(
     val requestData: MediaLoadRequestData,
     val receiverQueueSize: Int,
     val estimatedBytes: Int,
+    val receiverQueue: List<Track>,
 )
 
 private data class AppQueueSnapshot(
@@ -59,6 +60,12 @@ private data class AppQueueSnapshot(
 private data class RemoteQueueEntry(
     val track: Track,
     val castUrl: String?,
+)
+
+/** The receiver only has this bounded slice; app indexes still point into the full device queue. */
+private data class ReceiverQueueWindow(
+    val startIndex: Int,
+    val tracks: List<Track>,
 )
 
 private class AndroidCastController : CastController {
@@ -73,6 +80,7 @@ private class AndroidCastController : CastController {
     private var pendingHandoff: PendingCastHandoff? = null
     private var expectedRemoteHandoff: PendingCastHandoff? = null
     private var appQueueSnapshot: AppQueueSnapshot? = null
+    private var activeReceiverQueueWindow: ReceiverQueueWindow? = null
     private var loadRequestId = 0L
     private var lastLoadReceiverQueueSize = 0
     private var mediaErrorRetryCount = 0
@@ -87,8 +95,10 @@ private class AndroidCastController : CastController {
     )
     override val state: StateFlow<CastState> = mutableState
 
-    override fun canLoadQueue(queue: List<Track>): CastQueueSupport =
-        queue.chromecastQueueSupport()
+    override fun canLoadQueue(queue: List<Track>): CastQueueSupport = canLoadQueue(queue, startIndex = 0)
+
+    override fun canLoadQueue(queue: List<Track>, startIndex: Int): CastQueueSupport =
+        castReceiverQueueWindow(queue, startIndex).chromecastQueueSupport()
 
     private val remoteMediaClientListener = object : RemoteMediaClient.Callback() {
         override fun onStatusUpdated() {
@@ -212,7 +222,7 @@ private class AndroidCastController : CastController {
         startPositionMs: Long = 0L,
         maxReceiverItems: Int = CAST_MAX_RECEIVER_QUEUE_ITEMS,
     ) {
-        val support = canLoadQueue(queue)
+        val support = canLoadQueue(queue, startIndex)
         if (!support.isSupported) {
             mutableState.update { it.copy(message = support.message) }
             return
@@ -258,6 +268,10 @@ private class AndroidCastController : CastController {
             )
         }
         val loadRequest = buildCastLoadRequest(queue, index, positionMs, maxItems = maxReceiverItems)
+        activeReceiverQueueWindow = ReceiverQueueWindow(
+            startIndex = index,
+            tracks = loadRequest.receiverQueue,
+        )
         lastLoadReceiverQueueSize = loadRequest.receiverQueueSize
         PhoebeLog.d(TAG) {
             "loading cast queue startId=${track.id} codec=${track.audioCodec} startIndex=$index receiverItems=${loadRequest.receiverQueueSize}/${queue.size} bytes=${loadRequest.estimatedBytes} budget=$CAST_LOAD_MESSAGE_BYTE_BUDGET requestId=$requestId"
@@ -420,6 +434,7 @@ private class AndroidCastController : CastController {
             reconnectJob?.cancel()
             reconnectJob = null
             appQueueSnapshot = null
+            activeReceiverQueueWindow = null
             if (pending != null) {
                 restoreLocalPlayback(pending)
             }             else if (previous.isConnected && previous.queue.isNotEmpty() && previous.currentIndex in previous.queue.indices) {
@@ -432,12 +447,18 @@ private class AndroidCastController : CastController {
             }
             positionJob?.cancel()
             positionJob = null
+            // The local player owns playback again, so this queue is history. Keeping it would
+            // make the next cast hand off this queue instead of whatever is playing by then.
             mutableState.update {
                 it.copy(
                     isConnected = false,
                     deviceName = null,
+                    queue = emptyList(),
+                    currentIndex = -1,
                     isPlaying = false,
                     isBuffering = false,
+                    positionMs = 0L,
+                    durationMs = 0L,
                     message = null,
                 )
             }
@@ -467,13 +488,22 @@ private class AndroidCastController : CastController {
         val remoteTrack = client.currentItem?.media?.toTrack() ?: client.mediaInfo?.toTrack()
         val remoteCastUrl = client.currentItem?.media?.contentId ?: client.mediaInfo?.contentId
         val receiverHasMedia = client.mediaInfo != null || queueItems.isNotEmpty() || remoteTrack != null
-        val knownQueue = appQueueSnapshot?.queue?.takeIf { it.isNotEmpty() }
+        val rememberedQueue = appQueueSnapshot?.queue?.takeIf { it.isNotEmpty() }
             ?: pendingHandoff?.queue?.takeIf { it.isNotEmpty() }
             ?: previous.queue
-        val remoteQueueEntries = queueItems.mapNotNull { item ->
-            val track = item.media?.toTrack() ?: return@mapNotNull null
+        val rememberedIndex = appQueueSnapshot?.currentIndex
+            ?: pendingHandoff?.index
+            ?: previous.currentIndex
+        // Library Mix keeps its complete queue in the local player. If its background fill grew
+        // while Cast was playing, adopt that longer queue by checking one stable anchor only.
+        val knownQueue = deviceQueueExtension(rememberedQueue, rememberedIndex)
+        val receiverWindow = activeReceiverQueueWindow
+        val remoteQueueEntries = queueItems.mapIndexedNotNull { receiverIndex, item ->
+            val track = item.media?.toTrack() ?: return@mapIndexedNotNull null
             RemoteQueueEntry(
-                track = knownQueue.firstOrNull { it.matchesCastMedia(track, item.media?.contentId) } ?: track,
+                track = receiverWindow?.tracks?.getOrNull(receiverIndex)
+                    ?.takeIf { it.matchesCastMedia(track, item.media?.contentId) }
+                    ?: track,
                 castUrl = item.media?.contentId,
             )
         }
@@ -500,20 +530,34 @@ private class AndroidCastController : CastController {
             deactivateEmptyReceiver()
             return
         }
-        val currentQueueItemKnownIndex = currentQueueItem?.media?.let { media ->
-            val track = media.toTrack()
-            knownQueue.indexOfFirst { it.matchesCastMedia(track, media.contentId) }.takeIf { index -> index >= 0 }
+        if (!receiverHasMedia) {
+            // A session that just connected answers with no status at all. Falling through would
+            // read that silence as "the remembered queue, at index 0" and stamp it into
+            // appQueueSnapshot — which is then what the handoff below casts, instead of the song
+            // that is actually playing.
+            return
         }
-        val remoteMediaKnownIndex = remoteTrack?.let { track ->
-            knownQueue.indexOfFirst { it.matchesCastMedia(track, remoteCastUrl) }.takeIf { index -> index >= 0 }
+        val currentQueueItemWindowIndex = remoteQueueIndex?.takeIf { receiverIndex ->
+            val expected = receiverWindow?.tracks?.getOrNull(receiverIndex) ?: return@takeIf false
+            val media = currentQueueItem?.media ?: return@takeIf false
+            expected.matchesCastMedia(media.toTrack(), media.contentId)
         }
-        val knownQueueTrackIndex = currentQueueItemKnownIndex ?: remoteMediaKnownIndex
-        val remoteQueueMatchesKnown = remoteQueueEntries.isNotEmpty() &&
-            knownQueue.isNotEmpty() &&
-            remoteQueueEntries.all { entry ->
-                knownQueue.any { it.matchesCastMedia(entry.track, entry.castUrl) }
+        val remoteMediaWindowIndex = remoteTrack?.let { track ->
+            receiverWindow?.tracks?.indexOfFirst { expected ->
+                expected.matchesCastMedia(track, remoteCastUrl)
+            }?.takeIf { receiverIndex -> receiverIndex >= 0 }
+        }
+        val knownQueueTrackIndex = (currentQueueItemWindowIndex ?: remoteMediaWindowIndex)
+            ?.let { receiverIndex -> receiverWindow?.startIndex?.plus(receiverIndex) }
+            ?.takeIf { it in knownQueue.indices }
+        val remoteQueueMatchesWindow = receiverWindow != null &&
+            queueItems.isNotEmpty() &&
+            queueItems.indices.all { receiverIndex ->
+                val expected = receiverWindow.tracks.getOrNull(receiverIndex) ?: return@all false
+                val media = queueItems[receiverIndex].media ?: return@all false
+                expected.matchesCastMedia(media.toTrack(), media.contentId)
             }
-        val preservingKnownQueue = knownQueueTrackIndex != null || remoteQueueMatchesKnown
+        val preservingKnownQueue = knownQueueTrackIndex != null || remoteQueueMatchesWindow
         val queue = when {
             preservingKnownQueue -> knownQueue
             remoteQueue.isNotEmpty() -> remoteQueue
@@ -523,9 +567,6 @@ private class AndroidCastController : CastController {
         val currentIndex = when {
             queue.isEmpty() -> previous.currentIndex
             preservingKnownQueue -> knownQueueTrackIndex
-                ?: remoteTrack?.let { track ->
-                    queue.indexOfFirst { it.matchesCastMedia(track, remoteCastUrl) }.takeIf { index -> index >= 0 }
-                }
                 ?: appQueueSnapshot?.currentIndex?.takeIf { it in queue.indices }
                 ?: previous.currentIndex.takeIf { it in queue.indices }
                 ?: 0
@@ -630,10 +671,19 @@ private class AndroidCastController : CastController {
         }
     }
 
+    private fun deviceQueueExtension(rememberedQueue: List<Track>, rememberedIndex: Int): List<Track> {
+        val localQueue = audioPlayer?.state?.value?.queue ?: return rememberedQueue
+        val anchor = rememberedQueue.getOrNull(rememberedIndex) ?: return rememberedQueue
+        return localQueue.takeIf { queue ->
+            queue.size > rememberedQueue.size && queue.getOrNull(rememberedIndex)?.id == anchor.id
+        } ?: rememberedQueue
+    }
+
     private fun deactivateEmptyReceiver() {
         positionJob?.cancel()
         positionJob = null
         appQueueSnapshot = null
+        activeReceiverQueueWindow = null
         mediaErrorRetryCount = 0
         mediaErrorTrackId = null
         mutableState.update {
@@ -807,12 +857,20 @@ private class AndroidCastController : CastController {
                 if (expectedRemoteHandoff?.requestId == requestId) {
                     expectedRemoteHandoff = null
                 }
+                // Same reason as the disconnect path: playback is local again, so the failed
+                // attempt must not anchor the next handoff.
+                appQueueSnapshot = null
+                activeReceiverQueueWindow = null
                 restoreLocalPlayback(handoff)
                 mutableState.update {
                     it.copy(
                         isConnected = false,
+                        queue = emptyList(),
+                        currentIndex = -1,
                         isPlaying = false,
                         isBuffering = false,
+                        positionMs = 0L,
+                        durationMs = 0L,
                         message = "$message Playing on this device.",
                     )
                 }
@@ -851,20 +909,36 @@ private class AndroidCastController : CastController {
         val rememberedQueue = snapshot?.queue?.takeIf { it.isNotEmpty() } ?: castState.queue
         val rememberedIndex = snapshot?.currentIndex ?: castState.currentIndex
         val local = audioPlayer?.state?.value
+        val source = decideCastHandoffSource(
+            hasLocalQueue = local != null && local.currentIndex in local.queue.indices,
+            isLocalPlaybackActive = local?.isPlaying == true ||
+                local?.isBuffering == true ||
+                AndroidPlaybackBridge.isServicePlaybackActive(),
+            hasRememberedCastQueue = rememberedQueue.isNotEmpty() && rememberedIndex in rememberedQueue.indices,
+        )
+        PhoebeLog.d(TAG) {
+            "handoff source=$source localIndex=${local?.currentIndex} localQueue=${local?.queue?.size} rememberedIndex=$rememberedIndex rememberedQueue=${rememberedQueue.size}"
+        }
         val queue: List<Track>
         val index: Int
         val positionMs: Long
-        if (rememberedQueue.isNotEmpty() && rememberedIndex in rememberedQueue.indices) {
-            queue = rememberedQueue
-            index = rememberedIndex
-            positionMs = castState.positionMs
-        } else {
-            if (local == null || local.currentIndex !in local.queue.indices) return
-            queue = local.queue
-            index = local.currentIndex
-            positionMs = local.positionMs
+        when (source) {
+            CastHandoffSource.None -> return
+            CastHandoffSource.RememberedCastQueue -> {
+                queue = rememberedQueue
+                index = rememberedIndex
+                // The stored position belongs to whatever the receiver last reported; it only
+                // applies when that is still the song we're about to hand off.
+                positionMs = castState.positionMs.takeIf { castState.currentIndex == index } ?: 0L
+            }
+            CastHandoffSource.LocalPlayer -> {
+                val localState = local ?: return
+                queue = localState.queue
+                index = localState.currentIndex
+                positionMs = localState.positionMs
+            }
         }
-        val support = canLoadQueue(queue)
+        val support = canLoadQueue(queue, index)
         if (!support.isSupported) {
             mutableState.update { it.copy(message = support.message) }
             return
@@ -879,28 +953,13 @@ private class AndroidCastController : CastController {
     ): MediaQueueItem? {
         val target = queue.getOrNull(appIndex) ?: return null
         val items = queueItems.orEmpty()
-        if (items.isEmpty()) return null
-        val firstMedia = items.first().media ?: return null
-        val windowStart = queue.indexOfFirst { track ->
-            track.matchesCastMedia(firstMedia.toTrack(), firstMedia.contentId)
-        }
-        if (windowStart >= 0) {
-            val receiverIndex = appIndex - windowStart
-            items.getOrNull(receiverIndex)?.let { item ->
-                val media = item.media ?: return@let null
-                if (target.matchesCastMedia(media.toTrack(), media.contentId)) return item
-            }
-        }
-        val matchingAppIndexes = queue.indices.filter { index ->
-            queue[index].matchesCastMedia(target, target.toCastMediaDescriptor().castUrl)
-        }
-        if (matchingAppIndexes.size == 1) {
-            return items.firstOrNull { item ->
-                val media = item.media ?: return@firstOrNull false
-                target.matchesCastMedia(media.toTrack(), media.contentId)
-            }
-        }
-        return null
+        val window = activeReceiverQueueWindow ?: return null
+        val receiverIndex = appIndex - window.startIndex
+        val expected = window.tracks.getOrNull(receiverIndex) ?: return null
+        if (expected.id != target.id) return null
+        val item = items.getOrNull(receiverIndex) ?: return null
+        val media = item.media ?: return null
+        return item.takeIf { target.matchesCastMedia(media.toTrack(), media.contentId) }
     }
 
     private fun jumpToReceiverAppIndex(
@@ -1021,20 +1080,22 @@ private class AndroidCastController : CastController {
         startPositionMs: Long,
         maxItems: Int = CAST_MAX_RECEIVER_QUEUE_ITEMS,
     ): CastLoadRequest {
-        val tail = queue.drop(startIndex)
+        val receiverWindow = castReceiverQueueWindow(queue, startIndex, maxItems)
         val itemCount = shrinkCastReceiverQueueItemCount(
-            tailSize = tail.size,
+            tailSize = receiverWindow.size,
             maxItems = maxItems,
             maxBytes = CAST_LOAD_MESSAGE_BYTE_BUDGET,
             estimatedBytesForCount = { count ->
-                buildMediaLoadRequest(tail.take(count), startPositionMs).estimatedByteSize()
+                buildMediaLoadRequest(receiverWindow.take(count), startPositionMs).estimatedByteSize()
             },
         ).coerceAtLeast(1)
-        val request = buildMediaLoadRequest(tail.take(itemCount), startPositionMs)
+        val receiverQueue = receiverWindow.take(itemCount)
+        val request = buildMediaLoadRequest(receiverQueue, startPositionMs)
         return CastLoadRequest(
             requestData = request,
             receiverQueueSize = itemCount,
             estimatedBytes = request.estimatedByteSize(),
+            receiverQueue = receiverQueue,
         )
     }
 

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/CastController.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/CastController.kt
@@ -39,6 +39,7 @@ data class CastQueueSupport(
 interface CastController {
     val state: StateFlow<CastState>
     fun canLoadQueue(queue: List<Track>): CastQueueSupport
+    fun canLoadQueue(queue: List<Track>, startIndex: Int): CastQueueSupport = canLoadQueue(queue)
     fun showDevicePicker()
     fun disconnect()
     fun loadQueue(queue: List<Track>, startIndex: Int = 0, startPositionMs: Long = 0L)
@@ -93,9 +94,8 @@ fun List<Track>.chromecastQueueSupport(): CastQueueSupport {
 }
 
 /**
- * Name the song holding the queue back. The receiver loads the whole queue, so one song with no
- * remote URL stops the cast — a blanket "this queue can't cast" reads as a bug when the other
- * ninety-nine songs are ordinary streams.
+ * Name the song holding the queue back. Callers may validate a receiver window rather than the
+ * entire device queue, so this identifies the first item in the attempted window.
  */
 private fun Track.chromecastQueueBlockedMessage(): String {
     val name = title.takeIf { it.isNotBlank() } ?: "This song"

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/CastPlaybackPolicy.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/CastPlaybackPolicy.kt
@@ -1,5 +1,7 @@
 package com.phoebe.app.player
 
+import com.phoebe.app.domain.Track
+
 /**
  * Cast protocol messages are capped at 64 KiB. Yesterday's Pixel 10 Pro session loaded
  * 80 queue items at ~122 KiB (`cast load failed status=13`) and then started local
@@ -93,6 +95,21 @@ fun shrinkCastReceiverQueueItemCount(
     return 1
 }
 
+/**
+ * Projects the full device queue to the small, contiguous window that is sent to Chromecast.
+ * `subList` deliberately avoids copying or traversing the rest of a large local queue.
+ */
+fun castReceiverQueueWindow(
+    queue: List<Track>,
+    startIndex: Int,
+    maxItems: Int = CAST_MAX_RECEIVER_QUEUE_ITEMS,
+): List<Track> {
+    if (queue.isEmpty()) return emptyList()
+    val start = startIndex.coerceIn(queue.indices)
+    val endExclusive = (start + maxItems.coerceAtLeast(1)).coerceAtMost(queue.size)
+    return queue.subList(start, endExclusive)
+}
+
 sealed interface CastIdleDecision {
     data object Ignore : CastIdleDecision
     data object AdvanceReceiverQueue : CastIdleDecision
@@ -126,6 +143,30 @@ fun decideCastIdleAction(
         }
         else -> CastIdleDecision.Ignore
     }
+}
+
+enum class CastHandoffSource {
+    LocalPlayer,
+    RememberedCastQueue,
+    None,
+}
+
+/**
+ * Which queue a freshly connected, empty receiver should be handed.
+ *
+ * Nothing is casting yet, so the local player is the live source of truth — including any songs
+ * skipped since the last cast. The remembered cast queue only wins when local playback is parked,
+ * because an interrupted session leaves the local player paused wherever the *previous* handoff
+ * started from and the receiver's last position is then the better anchor.
+ */
+fun decideCastHandoffSource(
+    hasLocalQueue: Boolean,
+    isLocalPlaybackActive: Boolean,
+    hasRememberedCastQueue: Boolean,
+): CastHandoffSource = when {
+    !hasRememberedCastQueue -> if (hasLocalQueue) CastHandoffSource.LocalPlayer else CastHandoffSource.None
+    hasLocalQueue && isLocalPlaybackActive -> CastHandoffSource.LocalPlayer
+    else -> CastHandoffSource.RememberedCastQueue
 }
 
 sealed interface CastSkipDecision {

--- a/playback/src/commonTest/kotlin/com/phoebe/app/player/CastPlaybackPolicyTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/player/CastPlaybackPolicyTest.kt
@@ -1,5 +1,6 @@
 package com.phoebe.app.player
 
+import com.phoebe.app.domain.Track
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -47,6 +48,32 @@ class CastPlaybackPolicyTest {
                 estimatedBytesForCount = { 0 },
             ),
         )
+    }
+
+    @Test
+    fun receiverWindowLeavesTheFullDeviceQueueIntact() {
+        val deviceQueue = List(16_000) { index ->
+            Track(
+                id = "track-$index",
+                title = "Track $index",
+                artist = "Artist",
+                album = "Album",
+                durationMs = 60_000L,
+                streamUrl = "https://example.com/$index.mp3",
+                downloadUrl = "",
+            )
+        }
+
+        val middleWindow = castReceiverQueueWindow(deviceQueue, startIndex = 7_000)
+        val tailWindow = castReceiverQueueWindow(deviceQueue, startIndex = 15_950)
+
+        assertEquals(80, middleWindow.size)
+        assertEquals("track-7000", middleWindow.first().id)
+        assertEquals("track-7079", middleWindow.last().id)
+        assertEquals(50, tailWindow.size)
+        assertEquals("track-15950", tailWindow.first().id)
+        assertEquals("track-15999", tailWindow.last().id)
+        assertEquals(16_000, deviceQueue.size)
     }
 
     @Test
@@ -207,6 +234,52 @@ class CastPlaybackPolicyTest {
         assertEquals(
             CastSkipDecision.None,
             decideCastSkipAction(targetIndex = 157, queueSize = 157, targetAlreadyOnReceiver = false),
+        )
+    }
+
+    @Test
+    fun castingWhilePlayingHandsOffTheSongPlayingNowNotTheRememberedQueue() {
+        // Play an artist, skip ahead a few songs, then cast: the local player is where playback
+        // actually is, so a queue left over from an earlier cast must not win.
+        assertEquals(
+            CastHandoffSource.LocalPlayer,
+            decideCastHandoffSource(
+                hasLocalQueue = true,
+                isLocalPlaybackActive = true,
+                hasRememberedCastQueue = true,
+            ),
+        )
+    }
+
+    @Test
+    fun interruptedCastSessionResumesFromTheReceiverPositionNotThePausedLocalPlayer() {
+        assertEquals(
+            CastHandoffSource.RememberedCastQueue,
+            decideCastHandoffSource(
+                hasLocalQueue = true,
+                isLocalPlaybackActive = false,
+                hasRememberedCastQueue = true,
+            ),
+        )
+    }
+
+    @Test
+    fun pausedLocalQueueStillCastsWhenNothingIsRemembered() {
+        assertEquals(
+            CastHandoffSource.LocalPlayer,
+            decideCastHandoffSource(
+                hasLocalQueue = true,
+                isLocalPlaybackActive = false,
+                hasRememberedCastQueue = false,
+            ),
+        )
+        assertEquals(
+            CastHandoffSource.None,
+            decideCastHandoffSource(
+                hasLocalQueue = false,
+                isLocalPlaybackActive = false,
+                hasRememberedCastQueue = false,
+            ),
         )
     }
 }


### PR DESCRIPTION
## Summary
- **Library Radio**: seeds a short Plex station window so playback starts fast, then fills the rest of the on-device queue in small background chunks from the full Plex catalog (minus the seed).
- **Chromecast**: projects only a bounded receiver window of the large queue; anchors app indexes to that window so status sync and skip/jump stay correct as the queue grows.
- **Cast handoff hardening**: a freshly connected, empty receiver prefers the live local player (incl. songs skipped since the last cast) over a leftover remembered queue; stale cast state is cleared on disconnect and failed load.

## Tests
- `LibraryRadioFillTest` (new): whole-library slug detection, fill candidate selection excluding seed.
- `CastPlaybackPolicyTest` (expanded): receiver window projection leaves device queue intact; handoff source selection.
- Local `:playback:desktopTest` and `:composeApp:desktopTest` pass for these suites.

## Risks
- Cast receiver windowing is a behavior change to cast queue loading; verified against unit tests, watch CI for the full matrix.