### PR TITLE
Fix shuffle no-op after finishing artist/queue

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/phoebe/app/AndroidPlaybackSmokeActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/phoebe/app/AndroidPlaybackSmokeActivity.kt
@@ -28,6 +28,7 @@ class AndroidPlaybackSmokeActivity : Activity() {
 
         val path = intent.getStringExtra(ExtraPath).orEmpty()
         val timeoutMs = intent.getLongExtra(ExtraTimeoutMs, DefaultTimeoutMs).takeIf { it > 0L } ?: DefaultTimeoutMs
+        val mode = intent.getStringExtra(ExtraMode).orEmpty().ifBlank { ModePlayback }
         val file = runCatching { resolveSmokeFile(path) }
             .getOrElse { error ->
                 logSmoke(
@@ -46,38 +47,107 @@ class AndroidPlaybackSmokeActivity : Activity() {
         val diagnostics = AndroidSmokeDiagnostics()
         val smokePlayer = AndroidAudioPlayer(diagnostics)
         player = smokePlayer
-        val track = file.toSmokeTrack()
         scope.launch {
             try {
-                diagnostics.markPlayRequested()
-                smokePlayer.play(listOf(track), 0)
-                val deadline = SystemClock.elapsedRealtime() + timeoutMs
-                while (SystemClock.elapsedRealtime() <= deadline) {
-                    val snapshot = diagnostics.snapshot()
-                    val firstAudioMs = snapshot.firstAudioMs
-                    if (firstAudioMs != null) {
-                        logSmoke(
-                            "PHOEBE_PLAYBACK_SMOKE_OK firstAudioMs=$firstAudioMs " +
-                                "engines=${snapshot.engines.asSmokeValue()} errors=${snapshot.errors.asSmokeValue()} " +
-                                "file=${file.absolutePath.asSmokeValue()}",
-                        )
-                        return@launch
-                    }
-                    delay(100L)
+                when (mode) {
+                    ModeShuffleLastTrack -> runShuffleLastTrackSmoke(smokePlayer, file, timeoutMs)
+                    else -> runPlaybackSmoke(smokePlayer, diagnostics, file, timeoutMs)
                 }
-
-                val snapshot = diagnostics.snapshot()
-                val state = smokePlayer.state.value
-                logSmoke(
-                    "PHOEBE_PLAYBACK_SMOKE_FAILED reason=timeout timeoutMs=$timeoutMs " +
-                        "engines=${snapshot.engines.asSmokeValue()} errors=${snapshot.errors.asSmokeValue()} " +
-                        "buffering=${state.isBuffering} playing=${state.isPlaying} errorSerial=${state.playbackErrorSerial} " +
-                        "file=${file.absolutePath.asSmokeValue()}",
-                )
             } finally {
                 smokePlayer.releaseForTests()
                 finishAndRemoveTask()
             }
+        }
+    }
+
+    private suspend fun runPlaybackSmoke(
+        smokePlayer: AndroidAudioPlayer,
+        diagnostics: AndroidSmokeDiagnostics,
+        file: File,
+        timeoutMs: Long,
+    ) {
+        val track = file.toSmokeTrack(id = "android-playback-smoke")
+        diagnostics.markPlayRequested()
+        smokePlayer.play(listOf(track), 0)
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (SystemClock.elapsedRealtime() <= deadline) {
+            val snapshot = diagnostics.snapshot()
+            val firstAudioMs = snapshot.firstAudioMs
+            if (firstAudioMs != null) {
+                logSmoke(
+                    "PHOEBE_PLAYBACK_SMOKE_OK firstAudioMs=$firstAudioMs " +
+                        "engines=${snapshot.engines.asSmokeValue()} errors=${snapshot.errors.asSmokeValue()} " +
+                        "file=${file.absolutePath.asSmokeValue()}",
+                )
+                return
+            }
+            delay(100L)
+        }
+
+        val snapshot = diagnostics.snapshot()
+        val state = smokePlayer.state.value
+        logSmoke(
+            "PHOEBE_PLAYBACK_SMOKE_FAILED reason=timeout timeoutMs=$timeoutMs " +
+                "engines=${snapshot.engines.asSmokeValue()} errors=${snapshot.errors.asSmokeValue()} " +
+                "buffering=${state.isBuffering} playing=${state.isPlaying} errorSerial=${state.playbackErrorSerial} " +
+                "file=${file.absolutePath.asSmokeValue()}",
+        )
+    }
+
+    private suspend fun runShuffleLastTrackSmoke(
+        smokePlayer: AndroidAudioPlayer,
+        file: File,
+        timeoutMs: Long,
+    ) {
+        val tracks = (1..5).map { index ->
+            file.toSmokeTrack(id = "android-shuffle-smoke-$index", title = "Smoke $index")
+        }
+        smokePlayer.play(tracks, tracks.lastIndex)
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (SystemClock.elapsedRealtime() <= deadline && smokePlayer.state.value.currentTrack?.id != tracks.last().id) {
+            delay(50L)
+        }
+        val before = smokePlayer.state.value
+        if (before.currentTrack?.id != tracks.last().id) {
+            logSmoke(
+                "PHOEBE_PLAYBACK_SMOKE_FAILED reason=shuffle-last-track-not-current " +
+                    "current=${before.currentTrack?.id.orEmpty().asSmokeValue()} timeoutMs=$timeoutMs",
+            )
+            return
+        }
+        if (before.upNext.isNotEmpty()) {
+            logSmoke(
+                "PHOEBE_PLAYBACK_SMOKE_FAILED reason=shuffle-last-track-unexpected-up-next " +
+                    "upNext=${before.upNext.size} timeoutMs=$timeoutMs",
+            )
+            return
+        }
+
+        smokePlayer.setShuffle(true)
+        // Android rebases the Media3 window asynchronously after onQueueEdited.
+        delay(500L)
+
+        val after = smokePlayer.state.value
+        val expectedIds = tracks.dropLast(1).map { it.id }.toSet()
+        val upNextIds = after.upNext.map { it.id }.toSet()
+        val ok = after.shuffle &&
+            after.currentTrack?.id == tracks.last().id &&
+            after.currentIndex == 0 &&
+            after.upNext.size == expectedIds.size &&
+            upNextIds == expectedIds
+        if (ok) {
+            logSmoke(
+                "PHOEBE_PLAYBACK_SMOKE_OK mode=shuffle-last-track " +
+                    "current=${after.currentTrack?.id.orEmpty().asSmokeValue()} upNext=${after.upNext.size} " +
+                    "file=${file.absolutePath.asSmokeValue()}",
+            )
+        } else {
+            logSmoke(
+                "PHOEBE_PLAYBACK_SMOKE_FAILED reason=shuffle-last-track-order " +
+                    "shuffle=${after.shuffle} current=${after.currentTrack?.id.orEmpty().asSmokeValue()} " +
+                    "currentIndex=${after.currentIndex} upNext=${after.upNext.map { it.id }.joinToString(",").asSmokeValue()} " +
+                    "timeoutMs=$timeoutMs",
+            )
         }
     }
 
@@ -86,11 +156,14 @@ class AndroidPlaybackSmokeActivity : Activity() {
         super.onDestroy()
     }
 
-    private fun File.toSmokeTrack(): Track {
+    private fun File.toSmokeTrack(
+        id: String,
+        title: String = name,
+    ): Track {
         val uri = toURI().toString()
         return Track(
-            id = "android-playback-smoke",
-            title = name,
+            id = id,
+            title = title,
             artist = "Phoebe Smoke",
             album = "Android Playback Smoke",
             durationMs = 60_000L,
@@ -117,6 +190,9 @@ class AndroidPlaybackSmokeActivity : Activity() {
     private companion object {
         const val ExtraPath = "phoebe.playbackSmoke.path"
         const val ExtraTimeoutMs = "phoebe.playbackSmoke.timeoutMs"
+        const val ExtraMode = "phoebe.playbackSmoke.mode"
+        const val ModePlayback = "playback"
+        const val ModeShuffleLastTrack = "shuffle-last-track"
         const val DefaultTimeoutMs = 30_000L
         const val LogTag = "PhoebePlaybackSmoke"
     }

--- a/composeApp/src/androidMain/kotlin/com/phoebe/app/AndroidPlaybackSmokeActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/phoebe/app/AndroidPlaybackSmokeActivity.kt
@@ -50,7 +50,7 @@ class AndroidPlaybackSmokeActivity : Activity() {
         scope.launch {
             try {
                 when (mode) {
-                    ModeShuffleLastTrack -> runShuffleLastTrackSmoke(smokePlayer, file, timeoutMs)
+                    ModeShuffleLastTrack -> runShuffleLastTrackSmoke(smokePlayer, diagnostics, file, timeoutMs)
                     else -> runPlaybackSmoke(smokePlayer, diagnostics, file, timeoutMs)
                 }
             } finally {
@@ -96,18 +96,30 @@ class AndroidPlaybackSmokeActivity : Activity() {
 
     private suspend fun runShuffleLastTrackSmoke(
         smokePlayer: AndroidAudioPlayer,
+        diagnostics: AndroidSmokeDiagnostics,
         file: File,
         timeoutMs: Long,
     ) {
         val tracks = (1..5).map { index ->
             file.toSmokeTrack(id = "android-shuffle-smoke-$index", title = "Smoke $index")
         }
+        diagnostics.markPlayRequested()
         smokePlayer.play(tracks, tracks.lastIndex)
         val deadline = SystemClock.elapsedRealtime() + timeoutMs
-        while (SystemClock.elapsedRealtime() <= deadline && smokePlayer.state.value.currentTrack?.id != tracks.last().id) {
+        while (SystemClock.elapsedRealtime() <= deadline) {
+            val ready = diagnostics.snapshot().firstAudioMs != null &&
+                smokePlayer.state.value.currentTrack?.id == tracks.last().id
+            if (ready) break
             delay(50L)
         }
         val before = smokePlayer.state.value
+        if (diagnostics.snapshot().firstAudioMs == null) {
+            logSmoke(
+                "PHOEBE_PLAYBACK_SMOKE_FAILED reason=shuffle-last-track-no-audio " +
+                    "current=${before.currentTrack?.id.orEmpty().asSmokeValue()} timeoutMs=$timeoutMs",
+            )
+            return
+        }
         if (before.currentTrack?.id != tracks.last().id) {
             logSmoke(
                 "PHOEBE_PLAYBACK_SMOKE_FAILED reason=shuffle-last-track-not-current " +
@@ -124,31 +136,60 @@ class AndroidPlaybackSmokeActivity : Activity() {
         }
 
         smokePlayer.setShuffle(true)
-        // Android rebases the Media3 window asynchronously after onQueueEdited.
-        delay(500L)
-
-        val after = smokePlayer.state.value
         val expectedIds = tracks.dropLast(1).map { it.id }.toSet()
-        val upNextIds = after.upNext.map { it.id }.toSet()
-        val ok = after.shuffle &&
+        var after = smokePlayer.state.value
+        val shuffleDeadline = SystemClock.elapsedRealtime() + 5_000L
+        while (SystemClock.elapsedRealtime() <= shuffleDeadline) {
+            after = smokePlayer.state.value
+            val reshuffled = after.shuffle &&
+                after.currentTrack?.id == tracks.last().id &&
+                after.currentIndex == 0 &&
+                after.upNext.size == expectedIds.size &&
+                after.upNext.map { it.id }.toSet() == expectedIds
+            if (reshuffled) break
+            delay(50L)
+        }
+        val reshuffled = after.shuffle &&
             after.currentTrack?.id == tracks.last().id &&
             after.currentIndex == 0 &&
             after.upNext.size == expectedIds.size &&
-            upNextIds == expectedIds
-        if (ok) {
-            logSmoke(
-                "PHOEBE_PLAYBACK_SMOKE_OK mode=shuffle-last-track " +
-                    "current=${after.currentTrack?.id.orEmpty().asSmokeValue()} upNext=${after.upNext.size} " +
-                    "file=${file.absolutePath.asSmokeValue()}",
-            )
-        } else {
+            after.upNext.map { it.id }.toSet() == expectedIds
+        if (!reshuffled) {
             logSmoke(
                 "PHOEBE_PLAYBACK_SMOKE_FAILED reason=shuffle-last-track-order " +
                     "shuffle=${after.shuffle} current=${after.currentTrack?.id.orEmpty().asSmokeValue()} " +
                     "currentIndex=${after.currentIndex} upNext=${after.upNext.map { it.id }.joinToString(",").asSmokeValue()} " +
                     "timeoutMs=$timeoutMs",
             )
+            return
         }
+
+        // Advance into the reshuffled Up Next so we exercise the Media3 queue rebase,
+        // not only the synchronous PlayerState update from setShuffle.
+        val upNextBeforeSkip = after.upNext.map { it.id }
+        smokePlayer.next()
+        var advanced = smokePlayer.state.value
+        val advanceDeadline = SystemClock.elapsedRealtime() + 10_000L
+        while (SystemClock.elapsedRealtime() <= advanceDeadline) {
+            advanced = smokePlayer.state.value
+            if (advanced.currentTrack?.id in expectedIds) break
+            delay(50L)
+        }
+        if (advanced.currentTrack?.id !in expectedIds) {
+            logSmoke(
+                "PHOEBE_PLAYBACK_SMOKE_FAILED reason=shuffle-last-track-next-failed " +
+                    "current=${advanced.currentTrack?.id.orEmpty().asSmokeValue()} " +
+                    "expectedUpNext=${upNextBeforeSkip.joinToString(",").asSmokeValue()} timeoutMs=$timeoutMs",
+            )
+            return
+        }
+
+        logSmoke(
+            "PHOEBE_PLAYBACK_SMOKE_OK mode=shuffle-last-track " +
+                "current=${after.currentTrack?.id.orEmpty().asSmokeValue()} upNext=${after.upNext.size} " +
+                "advanced=${advanced.currentTrack?.id.orEmpty().asSmokeValue()} " +
+                "file=${file.absolutePath.asSmokeValue()}",
+        )
     }
 
     override fun onDestroy() {

--- a/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
+++ b/playback/src/commonMain/kotlin/com/phoebe/app/player/SimpleAudioPlayer.kt
@@ -704,19 +704,31 @@ abstract class SimpleAudioPlayer(
             cancelGaplessPrepare()
             return
         }
-        // Pre-shuffle just the upcoming portion of the queue so the current track
-        // keeps playing and the user can see the new order in Up Next.
-        if (state.currentIndex < 0 || state.currentIndex >= state.queue.lastIndex) {
+        // Keep the current track playing and reshuffle what comes next so Up Next
+        // reflects the new order. When nothing is left upcoming (last track / ended
+        // queue), move the already-played tracks behind the current one in shuffled
+        // order — otherwise enabling shuffle is a no-op flag flip with no visible change.
+        if (state.currentIndex !in state.queue.indices || state.queue.size <= 1) {
             mutableState.value = state.copy(shuffle = true)
             cancelGaplessPrepare()
             return
         }
-        val head = state.queue.subList(0, state.currentIndex + 1).toList()
-        val tail = state.queue.subList(state.currentIndex + 1, state.queue.size).shuffled()
-        val nextQueue = head + tail
-        mutableState.value = state.copy(shuffle = true, queue = nextQueue)
+        val current = state.queue[state.currentIndex]
+        val nextQueue: List<Track>
+        val nextIndex: Int
+        if (state.currentIndex >= state.queue.lastIndex) {
+            val rest = state.queue.filterIndexed { index, _ -> index != state.currentIndex }.shuffled()
+            nextQueue = listOf(current) + rest
+            nextIndex = 0
+        } else {
+            val head = state.queue.subList(0, state.currentIndex + 1).toList()
+            val tail = state.queue.subList(state.currentIndex + 1, state.queue.size).shuffled()
+            nextQueue = head + tail
+            nextIndex = state.currentIndex
+        }
+        mutableState.value = state.copy(shuffle = true, queue = nextQueue, currentIndex = nextIndex)
         cancelGaplessPrepare()
-        onQueueEdited(nextQueue, state.currentIndex)
+        onQueueEdited(nextQueue, nextIndex)
     }
 
     override fun setRepeat(mode: RepeatMode) {

--- a/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
+++ b/playback/src/commonTest/kotlin/com/phoebe/app/PlayerStateTest.kt
@@ -1333,6 +1333,71 @@ class PlayerStateTest {
     }
 
     @Test
+    fun enablingShuffleOnLastTrackReshufflesPlayedTracksIntoUpNext() {
+        val player = QueueEditHookTestPlayer()
+        val tracks = listOf(
+            Track("t1", "One", "Artist", "Album", 60_000, "http://a", ""),
+            Track("t2", "Two", "Artist", "Album", 90_000, "http://b", ""),
+            Track("t3", "Three", "Artist", "Album", 120_000, "http://c", ""),
+            Track("t4", "Four", "Artist", "Album", 150_000, "http://d", ""),
+            Track("t5", "Five", "Artist", "Album", 180_000, "http://e", ""),
+        )
+
+        player.play(tracks, tracks.lastIndex)
+        assertTrue(player.state.value.upNext.isEmpty())
+
+        player.setShuffle(true)
+
+        val state = player.state.value
+        assertTrue(state.shuffle)
+        assertEquals(tracks.last(), state.currentTrack)
+        assertEquals(0, state.currentIndex)
+        assertEquals(tracks.size - 1, state.upNext.size)
+        assertEquals(tracks.dropLast(1).map { it.id }.toSet(), state.upNext.map { it.id }.toSet())
+        assertEquals(0, player.lastEditedCurrentIndex)
+        assertEquals(state.queue, player.lastEditedQueue)
+    }
+
+    @Test
+    fun enablingShuffleMidQueueOnlyReshufflesUpcomingTracks() {
+        val player = QueueEditHookTestPlayer()
+        val tracks = listOf(
+            Track("t1", "One", "Artist", "Album", 60_000, "http://a", ""),
+            Track("t2", "Two", "Artist", "Album", 90_000, "http://b", ""),
+            Track("t3", "Three", "Artist", "Album", 120_000, "http://c", ""),
+            Track("t4", "Four", "Artist", "Album", 150_000, "http://d", ""),
+            Track("t5", "Five", "Artist", "Album", 180_000, "http://e", ""),
+            Track("t6", "Six", "Artist", "Album", 210_000, "http://f", ""),
+        )
+
+        player.play(tracks, 1)
+        player.setShuffle(true)
+
+        val state = player.state.value
+        assertTrue(state.shuffle)
+        assertEquals(tracks[1], state.currentTrack)
+        assertEquals(1, state.currentIndex)
+        assertEquals(listOf("t1", "t2"), state.queue.take(2).map { it.id })
+        assertEquals(tracks.drop(2).map { it.id }.toSet(), state.upNext.map { it.id }.toSet())
+        assertEquals(1, player.lastEditedCurrentIndex)
+        assertEquals(state.queue, player.lastEditedQueue)
+    }
+
+    @Test
+    fun enablingShuffleOnSingleTrackOnlySetsFlag() {
+        val player = QueueEditHookTestPlayer()
+        val track = Track("t1", "One", "Artist", "Album", 60_000, "http://a", "")
+
+        player.play(listOf(track), 0)
+        player.setShuffle(true)
+
+        assertTrue(player.state.value.shuffle)
+        assertEquals(listOf("t1"), player.state.value.queue.map { it.id })
+        assertEquals(-2, player.lastEditedCurrentIndex)
+        assertTrue(player.lastEditedQueue.isEmpty())
+    }
+
+    @Test
     fun clearingQueueNotifiesPlatformToDropFutureItems() {
         val player = QueueEditHookTestPlayer()
         val tracks = listOf(


### PR DESCRIPTION
## Summary
- Enabling shuffle on the last track previously only set `shuffle=true` and left the queue unchanged, so after playing through an artist the order looked identical.
- `setShuffle(true)` now keeps the current track playing and moves the already-played tracks into Up Next in shuffled order when nothing was left upcoming.
- Adds unit coverage and an Android `shuffle-last-track` playback smoke mode.

## Test plan
- [x] `./gradlew :playback:desktopTest --tests 'com.phoebe.app.PlayerStateTest.enablingShuffle*' --tests 'com.phoebe.app.PlayerStateTest.shuffledStart*'`
- [x] Installed debug APK on connected SM-S921U and ran `AndroidPlaybackSmokeActivity` with `phoebe.playbackSmoke.mode=shuffle-last-track` → `PHOEBE_PLAYBACK_SMOKE_OK`
- [ ] Manual: play all tracks from an artist on Android, enable shuffle on the last/ended track, confirm Up Next reorders


Made with [Cursor](https://cursor.com)