### PR TITLE
Show most-recently-added library items regardless of recency window

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/AppState.kt
@@ -2162,12 +2162,11 @@ class AppState(
         }
     }
 
-    fun warmRecentAlbumTracks(cutoffMs: Long, maxAlbums: Int = 10) {
+    fun warmRecentAlbumTracks(maxAlbums: Int = 10) {
         if (!session.value.canUsePlexBackgroundFetches()) return
         val snapshot = catalog.value
         val albumIds = snapshot.albums
             .asSequence()
-            .filter { (it.dateAddedMs ?: Long.MIN_VALUE) >= cutoffMs }
             .filter { snapshot.tracksByParent[it.id].isNullOrEmpty() }
             .sortedByDescending { it.dateAddedMs ?: 0L }
             .take(maxAlbums)
@@ -2178,7 +2177,7 @@ class AppState(
         if (signature == recentAlbumWarmSignature) return
         recentAlbumWarmSignature = signature
         scope.launch {
-            dependencies.catalogRepository.warmRecentAlbumTracks(session.value, cutoffMs, maxAlbums)
+            dependencies.catalogRepository.warmRecentAlbumTracks(session.value, maxAlbums)
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeRoot.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeRoot.kt
@@ -1108,7 +1108,7 @@ private fun PhoebeRootStateHolder(
             Unit
         }
     }
-    LaunchedEffect(screen, browseSection, catalog.albums, catalog.tracksByParent.keys, session?.selectedServer, trackHeavySectionsEnabled) {
+    LaunchedEffect(screen, browseSection, catalog.albums, session?.selectedServer, trackHeavySectionsEnabled) {
         if (!trackHeavySectionsEnabled) return@LaunchedEffect
         if (screen == AppScreen.Home && browseSection == BrowseSection.Home) {
             delay(1_500L)

--- a/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeRoot.kt
+++ b/composeApp/src/commonMain/kotlin/com/phoebe/app/ui/PhoebeRoot.kt
@@ -210,7 +210,6 @@ import com.phoebe.app.feature.home.RecentlyAddedNowPlayingState
 import com.phoebe.app.feature.home.RecentlyAddedRoute
 import com.phoebe.app.feature.home.RecentlyAddedRouteActions
 import com.phoebe.app.feature.home.RecentlyAddedRouteState
-import com.phoebe.app.feature.home.RecentlyAddedWindowMs
 import com.phoebe.app.feature.home.personalMix
 import com.phoebe.app.feature.home.personalMixIdentityKey
 import com.phoebe.app.feature.home.rememberHomeFeatureState
@@ -1109,11 +1108,11 @@ private fun PhoebeRootStateHolder(
             Unit
         }
     }
-    LaunchedEffect(screen, browseSection, catalog.albums, catalog.tracksByParent.keys, session?.selectedServer, nowMs, trackHeavySectionsEnabled) {
+    LaunchedEffect(screen, browseSection, catalog.albums, catalog.tracksByParent.keys, session?.selectedServer, trackHeavySectionsEnabled) {
         if (!trackHeavySectionsEnabled) return@LaunchedEffect
         if (screen == AppScreen.Home && browseSection == BrowseSection.Home) {
             delay(1_500L)
-            state.warmRecentAlbumTracks(cutoffMs = nowMs - RecentlyAddedWindowMs, maxAlbums = 10)
+            state.warmRecentAlbumTracks(maxAlbums = 10)
         }
     }
     LaunchedEffect(screen, browseSection, session?.selectedServer?.id, session?.selectedLibrary?.key) {

--- a/composeApp/src/desktopTest/kotlin/com/phoebe/app/CatalogRepositoryRefreshDesktopTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/phoebe/app/CatalogRepositoryRefreshDesktopTest.kt
@@ -1543,7 +1543,7 @@ class CatalogRepositoryRefreshDesktopTest {
         repo.dropInMemoryCollectionMetadataForTest()
         assertTrue(repo.catalog.value.tracksByParent["plex:a1"].isNullOrEmpty())
 
-        repo.warmRecentAlbumTracks(testSession(), cutoffMs = 1L, maxAlbums = 10)
+        repo.warmRecentAlbumTracks(testSession(), maxAlbums = 10)
 
         assertEquals(listOf("Angry"), db.catalogQueries.selectCollectionValues().executeAsList().map { it.value_ })
         assertEquals(listOf("plex:a1"), db.catalogQueries.selectCollectionTags().executeAsList().map { it.itemId })

--- a/data/catalog/src/commonMain/kotlin/com/phoebe/app/data/CatalogRepository.kt
+++ b/data/catalog/src/commonMain/kotlin/com/phoebe/app/data/CatalogRepository.kt
@@ -3972,17 +3972,16 @@ class CatalogRepository(
         return mutableCatalog.value.playableTrackCount() - startCount
     }
 
-    suspend fun warmRecentAlbumTracks(session: PlexSession?, cutoffMs: Long, maxAlbums: Int = 10) {
+    suspend fun warmRecentAlbumTracks(session: PlexSession?, maxAlbums: Int = 10) {
         val navidromeSession = session?.takeIf { it.isNavidrome() }
         if (navidromeSession != null) {
-            warmNavidromeRecentAlbumTracks(navidromeSession, cutoffMs, maxAlbums)
+            warmNavidromeRecentAlbumTracks(navidromeSession, maxAlbums)
             return
         }
         val server = session?.selectedServer ?: return
         val token = session.serverAuthToken() ?: return
         val albumsToFetch = mutableCatalog.value.albums
             .asSequence()
-            .filter { (it.dateAddedMs ?: Long.MIN_VALUE) >= cutoffMs }
             .filter { plexRatingKey(it.id) != null }
             .filter { mutableCatalog.value.tracksByParent[it.id].isNullOrEmpty() }
             .sortedByDescending { it.dateAddedMs ?: 0L }
@@ -4112,12 +4111,10 @@ class CatalogRepository(
 
     private suspend fun warmNavidromeRecentAlbumTracks(
         session: PlexSession,
-        cutoffMs: Long,
         maxAlbums: Int,
     ) {
         val albumsToFetch = mutableCatalog.value.albums
             .asSequence()
-            .filter { (it.dateAddedMs ?: Long.MIN_VALUE) >= cutoffMs }
             .filter { mutableCatalog.value.tracksByParent[it.id].isNullOrEmpty() }
             .sortedByDescending { it.dateAddedMs ?: 0L }
             .take(maxAlbums)

--- a/feature/home/src/commonMain/kotlin/com/phoebe/app/feature/home/HomeUiState.kt
+++ b/feature/home/src/commonMain/kotlin/com/phoebe/app/feature/home/HomeUiState.kt
@@ -19,7 +19,6 @@ import com.phoebe.app.domain.Track
 import com.phoebe.app.domain.playHistoryIdentityKey
 import kotlin.random.Random
 
-const val RecentlyAddedWindowMs = 7L * 24L * 60L * 60L * 1000L
 internal const val HeavyRotationWindowMs = 14L * 24L * 60L * 60L * 1000L
 private const val HeavyRotationMinimumRecentPlays = 2L
 
@@ -124,7 +123,6 @@ class HomeCatalogIndexCache {
     fun trackIndex(
         catalog: CatalogSnapshot,
         albumAddedByTitle: Map<String, Long>,
-        cutoffMs: Long,
         limit: Int,
     ): HomeTrackIndex {
         val key = catalog.trackIndexKey()
@@ -141,9 +139,9 @@ class HomeCatalogIndexCache {
             val changedParents = newCounts.keys.filter { parentId ->
                 (parentTrackCounts[parentId] ?: 0) != newCounts[parentId]
             }.toSet()
-            mergeParents(catalog, albumAddedByTitle, cutoffMs, limit, changedParents)
+            mergeParents(catalog, albumAddedByTitle, limit, changedParents)
         } else {
-            rebuild(catalog, albumAddedByTitle, cutoffMs, limit)
+            rebuild(catalog, albumAddedByTitle, limit)
         }
         parentTrackCounts = newCounts
         trackIndexKey = key
@@ -153,24 +151,22 @@ class HomeCatalogIndexCache {
     private fun rebuild(
         catalog: CatalogSnapshot,
         albumAddedByTitle: Map<String, Long>,
-        cutoffMs: Long,
         limit: Int,
     ) {
         tracksById = linkedMapOf()
         recentlyAdded = mutableListOf()
-        mergeParents(catalog, albumAddedByTitle, cutoffMs, limit, catalog.tracksByParent.keys.toSet())
+        mergeParents(catalog, albumAddedByTitle, limit, catalog.tracksByParent.keys.toSet())
     }
 
     private fun mergeParents(
         catalog: CatalogSnapshot,
         albumAddedByTitle: Map<String, Long>,
-        cutoffMs: Long,
         limit: Int,
         parentIds: Set<String>,
     ) {
         parentIds.forEach { parentId ->
             catalog.tracksByParent[parentId]?.forEach { track ->
-                ingestTrack(track, albumAddedByTitle, cutoffMs, limit)
+                ingestTrack(track, albumAddedByTitle, limit)
             }
         }
     }
@@ -178,15 +174,12 @@ class HomeCatalogIndexCache {
     private fun ingestTrack(
         track: Track,
         albumAddedByTitle: Map<String, Long>,
-        cutoffMs: Long,
         limit: Int,
     ) {
         if (track.id in tracksById) return
         tracksById[track.id] = track
         val addedAt = effectiveTrackDateAdded(track, albumAddedByTitle)
-        if (addedAt >= cutoffMs) {
-            insertBounded(recentlyAdded, track, addedAt, limit, descending = true)
-        }
+        insertBounded(recentlyAdded, track, addedAt, limit, descending = true)
     }
 }
 
@@ -202,24 +195,23 @@ fun deriveHomeUiState(
     includeTrackDerivedSections: Boolean = true,
     resolvedTracksById: Map<String, Track> = emptyMap(),
 ): HomeUiState {
-    val cutoffMs = nowMs - RecentlyAddedWindowMs
     val albumAddedByTitle = albumAddedByTitle(catalog)
     val artistAddedByTitle = artistAddedByTitle(catalog)
     val trackIndex = if (includeTrackDerivedSections) {
-        trackIndexCache?.trackIndex(catalog, albumAddedByTitle, cutoffMs, limit)
-            ?: homeTrackIndex(catalog, albumAddedByTitle, cutoffMs, limit)
+        trackIndexCache?.trackIndex(catalog, albumAddedByTitle, limit)
+            ?: homeTrackIndex(catalog, albumAddedByTitle, limit)
     } else {
         HomeTrackIndex(emptyMap(), emptyList())
     }
     val recentArtists = topBy(
-        catalog.artists.asSequence().filter { artist -> recentlyAddedAt(artist, artistAddedByTitle) >= cutoffMs },
+        catalog.artists.asSequence(),
         limit = limit,
         descending = true,
     ) { artist ->
         recentlyAddedAt(artist, artistAddedByTitle)
     }
     val recentAlbums = topBy(
-        catalog.albums.asSequence().filter { (it.dateAddedMs ?: Long.MIN_VALUE) >= cutoffMs },
+        catalog.albums.asSequence(),
         limit = limit,
         descending = true,
     ) { album ->
@@ -386,7 +378,6 @@ private fun mostFrequentGenre(tracks: List<Track>): String? {
 private fun homeTrackIndex(
     catalog: CatalogSnapshot,
     albumAddedByTitle: Map<String, Long>,
-    cutoffMs: Long,
     limit: Int,
 ): HomeTrackIndex {
     val tracksById = linkedMapOf<String, Track>()
@@ -396,9 +387,7 @@ private fun homeTrackIndex(
             if (track.id !in tracksById) {
                 tracksById[track.id] = track
                 val addedAt = effectiveTrackDateAdded(track, albumAddedByTitle)
-                if (addedAt >= cutoffMs) {
-                    insertBounded(recentlyAdded, track, addedAt, limit, descending = true)
-                }
+                insertBounded(recentlyAdded, track, addedAt, limit, descending = true)
             }
         }
     }

--- a/feature/home/src/commonMain/kotlin/com/phoebe/app/feature/home/RecentlyAddedScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/phoebe/app/feature/home/RecentlyAddedScreen.kt
@@ -81,8 +81,8 @@ fun RecentlyAddedScreen(
     onAddToUpNext: (Track) -> Unit,
     onDownload: (Track) -> Unit,
 ) {
-    val page = remember(kind, catalog, nowMs) {
-        RecentlyAddedPage.from(kind, catalog, nowMs)
+    val page = remember(kind, catalog) {
+        RecentlyAddedPage.from(kind, catalog)
     }
     Column(
         modifier
@@ -145,7 +145,7 @@ private fun RecentlyAddedHeader(page: RecentlyAddedPage, onBack: () -> Unit) {
                 letterSpacing = 0.08.em,
             )
             Text(page.title, color = PhoebeUi.primaryText, fontSize = 28.sp, fontWeight = FontWeight.Black)
-            Text("${page.count} from the last 7 days", color = PhoebeUi.secondaryText, fontSize = 13.sp)
+            Text("${page.count} most recently added", color = PhoebeUi.secondaryText, fontSize = 13.sp)
         }
     }
 }
@@ -160,7 +160,7 @@ private fun RecentlyAddedSongs(
     modifier: Modifier = Modifier,
 ) {
     if (tracks.isEmpty()) {
-        RecentlyAddedEmpty("No songs were added in the last 7 days.", modifier)
+        RecentlyAddedEmpty("No songs in your library yet.", modifier)
         return
     }
     LazyColumn(modifier, verticalArrangement = Arrangement.spacedBy(10.dp)) {
@@ -188,7 +188,7 @@ private fun RecentlyAddedArtists(
     modifier: Modifier = Modifier,
 ) {
     if (artists.isEmpty()) {
-        RecentlyAddedEmpty("No artists were added in the last 7 days.", modifier)
+        RecentlyAddedEmpty("No artists in your library yet.", modifier)
         return
     }
     LazyVerticalGrid(
@@ -222,7 +222,7 @@ private fun RecentlyAddedAlbums(
     modifier: Modifier = Modifier,
 ) {
     if (albums.isEmpty()) {
-        RecentlyAddedEmpty("No albums were added in the last 7 days.", modifier)
+        RecentlyAddedEmpty("No albums in your library yet.", modifier)
         return
     }
     LazyVerticalGrid(
@@ -426,22 +426,18 @@ private data class RecentlyAddedPage(
         get() = tracks.size + artists.size + albums.size
 
     companion object {
-        fun from(kind: RecentlyAddedKind, catalog: CatalogSnapshot, nowMs: Long): RecentlyAddedPage {
-            val cutoffMs = nowMs - RecentlyAddedWindowMs
+        fun from(kind: RecentlyAddedKind, catalog: CatalogSnapshot): RecentlyAddedPage {
             val albumAddedByTitle = albumAddedByTitle(catalog)
             val artistAddedByTitle = artistAddedByTitle(catalog)
             val tracks = catalog.tracksByParent.values
                 .asSequence()
                 .flatten()
                 .distinctBy { it.id }
-                .filter { effectiveTrackDateAdded(it, albumAddedByTitle) >= cutoffMs }
                 .sortedByDescending { effectiveTrackDateAdded(it, albumAddedByTitle) }
                 .toList()
             val albums = catalog.albums
-                .filter { (it.dateAddedMs ?: Long.MIN_VALUE) >= cutoffMs }
                 .sortedByDescending { it.dateAddedMs ?: 0L }
             val artists = catalog.artists
-                .filter { artist -> recentlyAddedAt(artist, artistAddedByTitle) >= cutoffMs }
                 .sortedByDescending { artist -> recentlyAddedAt(artist, artistAddedByTitle) }
             return when (kind) {
                 RecentlyAddedKind.Songs -> RecentlyAddedPage("Songs", tracks = tracks)


### PR DESCRIPTION
## Summary

Removes the 7-day "Recently Added" recency window so Recently Added sections and the album-track warm fetch surface the most recently added items across the whole library, rather than only items added in the last 7 days.

## Changes

- Drop `RecentlyAddedWindowMs` and `cutoffMs` plumbing from `HomeUiState`, the Recently Added screen, `AppState` warm fetch, and `CatalogRepository` (Plex and Navidrome paths).
- Sort candidates by `dateAdded` descending so the bounded limit keeps the newest items.
- Update empty-state copy ("No songs in your library yet", etc.) and the header count text.
- Update the desktop refresh test to the new signature.

## Tests

- Desktop tests (linux/macos/windows), Android host tests, instrumented tests, Roborazzi screenshots (android/desktop/web), wasm tests, iOS build, backend tests.

## Risks

- Changes the Recently Added page to no longer be time-windowed; users with older libraries will see the newest items overall. No data migrations or API changes.