### PR TITLE
Keep Android Auto on Now Playing across skips

### DIFF
--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAudioPlayer.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAudioPlayer.kt
@@ -69,7 +69,7 @@ private data class PendingControllerTarget(
     val generation: Int,
 )
 
-private data class LoadedPlatformQueue(
+internal data class LoadedPlatformQueue(
     val queueIds: List<String>,
     val firstAppIndex: Int,
     val itemCount: Int,
@@ -79,6 +79,44 @@ private data class LoadedPlatformQueue(
 
     fun appIndexFor(platformIndex: Int): Int? =
         (firstAppIndex + platformIndex).takeIf { platformIndex in 0 until itemCount }
+}
+
+/**
+ * Where [targetIndex] sits in the live Media3 playlist, without replacing that playlist.
+ *
+ * Android Auto adopts a full queue onto the session player and never goes through
+ * [AndroidAudioPlayer.loadQueueOnPlayer], so [loaded] can be missing. Scanning by mediaId
+ * recovers the mapping so skip stays a seekTo. Calling setMediaItems on every skip replaces
+ * the MediaSession timeline and kicks Auto off Now Playing back to the browse page.
+ */
+internal fun resolvePlatformQueueIndex(
+    loaded: LoadedPlatformQueue?,
+    queueIds: List<String>,
+    targetIndex: Int,
+    platformMediaIds: List<String>,
+): Pair<Int, LoadedPlatformQueue>? {
+    loaded
+        ?.takeIf { it.queueIds == queueIds && platformMediaIds.size == it.itemCount }
+        ?.platformIndexFor(targetIndex)
+        ?.let { return it to loaded }
+
+    val targetId = queueIds.getOrNull(targetIndex) ?: return null
+    for (platformIndex in platformMediaIds.indices) {
+        if (platformMediaIds[platformIndex] != targetId) continue
+        val firstAppIndex = targetIndex - platformIndex
+        if (firstAppIndex < 0) continue
+        if (firstAppIndex + platformMediaIds.size > queueIds.size) continue
+        val aligned = platformMediaIds.indices.all { offset ->
+            queueIds[firstAppIndex + offset] == platformMediaIds[offset]
+        }
+        if (!aligned) continue
+        return platformIndex to LoadedPlatformQueue(
+            queueIds = queueIds,
+            firstAppIndex = firstAppIndex,
+            itemCount = platformMediaIds.size,
+        )
+    }
+    return null
 }
 
 private data class PendingPlatformSeek(
@@ -188,7 +226,17 @@ class AndroidAudioPlayer(
         AndroidPlaybackBridge.onServicePlayerChanged = { scope.launch { syncFromController() } }
         AndroidPlaybackBridge.onPlayQueue = { queue, index -> play(queue, index) }
         AndroidPlaybackBridge.onAdoptQueue = { queue, index, playing ->
-            loadedPlatformQueue = null
+            // MediaSession is about to install this full queue on the player. Remember it so
+            // Auto skip-to-next can seek inside the existing timeline instead of setMediaItems.
+            loadedPlatformQueue = if (queue.isEmpty()) {
+                null
+            } else {
+                LoadedPlatformQueue(
+                    queueIds = queue.map { it.id },
+                    firstAppIndex = 0,
+                    itemCount = queue.size,
+                )
+            }
             adoptPlatformPlayIntent(playing)
             adoptQueueState(queue, index, playing)
         }
@@ -250,11 +298,16 @@ class AndroidAudioPlayer(
         runPlatformLoad(generation) { player ->
             val targetIndex = startIndex.coerceIn(queue.indices)
             val queueIds = queue.map { it.id }
-            val loaded = loadedPlatformQueue
-            val platformIndex = loaded
-                ?.takeIf { it.queueIds == queueIds && player.mediaItemCount == it.itemCount }
-                ?.platformIndexFor(targetIndex)
-            if (platformIndex != null) {
+            val platformMediaIds = (0 until player.mediaItemCount).map { player.getMediaItemAt(it).mediaId }
+            val resolved = resolvePlatformQueueIndex(
+                loaded = loadedPlatformQueue,
+                queueIds = queueIds,
+                targetIndex = targetIndex,
+                platformMediaIds = platformMediaIds,
+            )
+            if (resolved != null) {
+                val (platformIndex, mapping) = resolved
+                loadedPlatformQueue = mapping
                 expectControllerTarget(queueIds, platformIndex, generation)
                 player.pause()
                 player.seekTo(platformIndex, 0L)
@@ -299,7 +352,10 @@ class AndroidAudioPlayer(
         pendingPlatformQueueRebase = null
         androidGaplessPrepareGeneration = -1
         clearPendingAutoplay()
-        clearLocalMediaSessionState()
+        // Do not clear local MediaSession state here. play() calls this before every same-queue
+        // skip; runPlatformLoad cancels this job before clearMediaItems runs. Clearing the
+        // session overlay early swaps playlist item UIDs twice per skip and can push Android
+        // Auto off the Now Playing screen even when the ExoPlayer timeline is reused.
         platformStopJob?.cancel()
         platformStopJob = scope.launch {
             priorLoad?.cancelAndJoin()
@@ -311,6 +367,7 @@ class AndroidAudioPlayer(
                     stop()
                     clearMediaItems()
                 }
+                clearLocalMediaSessionState()
                 // Forget the playlist only once it is actually gone. play() silences output
                 // before every load, including same-queue skips, and runPlatformLoad cancels
                 // this job before it runs — clearing the record synchronously above made
@@ -898,9 +955,14 @@ class AndroidAudioPlayer(
         crossfadeIncomingPlayer = null
         val owned = crossfadePlayer
         crossfadePlayer = null
+        val hadOwnedCrossfade = owned != null || incoming != null
         incoming?.release()
         owned?.release()
-        clearLocalMediaSessionState()
+        if (hadOwnedCrossfade) {
+            // Drop only a real crossfade overlay. Clearing on every runPlatformLoad (including
+            // same-queue Auto skips with no crossfade) rewrites MediaSession playlist identity.
+            clearLocalMediaSessionState()
+        }
     }
 
     private fun ownedCrossfadePlayer(): ExoPlayer? =

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/CastMediaSessionPlayer.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/CastMediaSessionPlayer.kt
@@ -189,10 +189,11 @@ internal class CastMediaSessionPlayer(
                 ?: currentMediaItemIndex.takeIf { it in delegatePlaylist.indices }
                 ?: 0
         }
+        val existing = delegatePlaylist.getOrNull(currentIndex)
         val overrideItem = mediaSessionOverrideItem(
             track = track,
             durationMs = durationMs,
-            index = currentIndex,
+            existing = existing,
         )
         if (delegatePlaylist.isEmpty()) {
             return MediaSessionOverridePlaylist(listOf(overrideItem), currentIndex)
@@ -206,10 +207,14 @@ internal class CastMediaSessionPlayer(
     private fun mediaSessionOverrideItem(
         track: Track,
         durationMs: Long,
-        index: Int,
+        existing: SimpleBasePlayer.MediaItemData?,
     ): SimpleBasePlayer.MediaItemData {
         val mediaItem = playbackMediaItem(track, inAppPlayback = true)
-        return SimpleBasePlayer.MediaItemData.Builder("${track.id}:media-session:$index")
+        // Keep the delegate UID when present. Minting a new uid per track/index made every
+        // local-state publish look like a playlist rewrite to Android Auto.
+        val builder = existing?.buildUpon()
+            ?: SimpleBasePlayer.MediaItemData.Builder(track.id)
+        return builder
             .setMediaItem(mediaItem)
             .setMediaMetadata(mediaItem.mediaMetadata)
             .setDurationUs(durationMs.takeIf { it > 0L }?.times(1_000L) ?: C.TIME_UNSET)

--- a/playback/src/androidUnitTest/kotlin/com/phoebe/app/player/CastMediaSessionCrossfadeTest.kt
+++ b/playback/src/androidUnitTest/kotlin/com/phoebe/app/player/CastMediaSessionCrossfadeTest.kt
@@ -6,6 +6,7 @@ import androidx.annotation.OptIn
 import androidx.media3.common.C
 import androidx.media3.common.Player
 import androidx.media3.common.SimpleBasePlayer
+import androidx.media3.common.Timeline
 import androidx.media3.common.util.UnstableApi
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
@@ -207,6 +208,9 @@ class CastMediaSessionCrossfadeTest {
             shadowOf(Looper.getMainLooper()).idle()
             assertEquals(2, player.currentTimeline.windowCount)
             assertEquals(0, player.currentMediaItemIndex)
+            val window = Timeline.Window()
+            val firstWindowUid = player.currentTimeline.getWindow(0, window).uid
+            val secondWindowUid = player.currentTimeline.getWindow(1, window).uid
 
             player.updateLocalState(
                 LocalMediaSessionState(
@@ -223,6 +227,9 @@ class CastMediaSessionCrossfadeTest {
             assertEquals(2, player.currentTimeline.windowCount)
             assertEquals(1, player.currentMediaItemIndex)
             assertEquals("delegate-second", player.currentMediaItem?.mediaId)
+            // Stable window UIDs keep Android Auto on Now Playing across skips.
+            assertEquals(firstWindowUid, player.currentTimeline.getWindow(0, window).uid)
+            assertEquals(secondWindowUid, player.currentTimeline.getWindow(1, window).uid)
         } finally {
             player.release()
         }

--- a/playback/src/androidUnitTest/kotlin/com/phoebe/app/player/PlatformQueueIndexTest.kt
+++ b/playback/src/androidUnitTest/kotlin/com/phoebe/app/player/PlatformQueueIndexTest.kt
@@ -1,0 +1,90 @@
+package com.phoebe.app.player
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class PlatformQueueIndexTest {
+    @Test
+    fun usesLoadedMappingWhenPlaylistCountsMatch() {
+        val queueIds = listOf("a", "b", "c", "d")
+        val loaded = LoadedPlatformQueue(queueIds = queueIds, firstAppIndex = 1, itemCount = 3)
+
+        val resolved = resolvePlatformQueueIndex(
+            loaded = loaded,
+            queueIds = queueIds,
+            targetIndex = 2,
+            platformMediaIds = listOf("b", "c", "d"),
+        )
+
+        assertNotNull(resolved)
+        assertEquals(1, resolved.first)
+        assertEquals(loaded, resolved.second)
+    }
+
+    @Test
+    fun recoversMappingFromAndroidAutoAdoptedPlaylistWhenLoadedIsMissing() {
+        val queueIds = listOf("a", "b", "c", "d")
+
+        val resolved = resolvePlatformQueueIndex(
+            loaded = null,
+            queueIds = queueIds,
+            targetIndex = 2,
+            platformMediaIds = listOf("a", "b", "c", "d"),
+        )
+
+        assertNotNull(resolved)
+        assertEquals(2, resolved.first)
+        assertEquals(0, resolved.second.firstAppIndex)
+        assertEquals(4, resolved.second.itemCount)
+        assertEquals(queueIds, resolved.second.queueIds)
+    }
+
+    @Test
+    fun recoversCompactedWindowAfterGaplessPrepare() {
+        val queueIds = listOf("a", "b", "c", "d", "e")
+        val stale = LoadedPlatformQueue(queueIds = queueIds, firstAppIndex = 0, itemCount = 5)
+
+        val resolved = resolvePlatformQueueIndex(
+            loaded = stale,
+            queueIds = queueIds,
+            targetIndex = 3,
+            platformMediaIds = listOf("c", "d", "e"),
+        )
+
+        assertNotNull(resolved)
+        assertEquals(1, resolved.first)
+        assertEquals(2, resolved.second.firstAppIndex)
+        assertEquals(3, resolved.second.itemCount)
+    }
+
+    @Test
+    fun returnsNullWhenTargetIsNotOnThePlatformPlaylist() {
+        val queueIds = listOf("a", "b", "c", "d")
+
+        val resolved = resolvePlatformQueueIndex(
+            loaded = null,
+            queueIds = queueIds,
+            targetIndex = 3,
+            platformMediaIds = listOf("a", "b"),
+        )
+
+        assertNull(resolved)
+    }
+
+    @Test
+    fun ignoresMisalignedPartialPlaylistMatches() {
+        val queueIds = listOf("a", "b", "c", "d")
+
+        val resolved = resolvePlatformQueueIndex(
+            loaded = null,
+            queueIds = queueIds,
+            targetIndex = 1,
+            // "b" appears, but neighbors do not match the app queue at that offset.
+            platformMediaIds = listOf("x", "b", "y"),
+        )
+
+        assertNull(resolved)
+    }
+}


### PR DESCRIPTION
## Summary
Fixes Android Auto getting kicked off the Now Playing screen back to the browse page on every track skip, caused by rebuilding the MediaSession timeline identity on each skip.

## Changes
- **AndroidAudioPlayer**: remember the queue adopted onto the session player (`onAdoptQueue`) and recover the platform skip index by scanning `mediaId`s when `loaded` is missing, so skip stays a `seekTo` instead of a `setMediaItems` that replaces the Auto timeline. Added `resolvePlatformQueueIndex` recovery path.
- **AndroidAudioPlayer**: stop clearing local MediaSession state on every same-queue skip and on non-crossfade `runPlatformLoad`; only clear on a real crossfade overlay or actual queue teardown.
- **CastMediaSessionPlayer**: preserve the delegate MediaItemData UID when present instead of minting a fresh uid per track/index on every local-state publish (which looked like a playlist rewrite to Auto).

## Tests
- `CastMediaSessionCrossfadeTest`: asserts window UIDs stay stable across a skip/local-state update.
- New `PlatformQueueIndexTest`: covers the `resolvePlatformQueueIndex` recovery paths (loaded mapping, Auto-adopted recovery, gapless-compacted window, missing target, misaligned partial match).

Ran locally: `:playback:testAndroidHostTest` for both test classes — green.

## Risks
Android Auto playback behavior is hard to reproduce in CI; the fix is validated via unit tests on the mapping/timeline-stability logic rather than an on-device Auto integration test.