### PR TITLE
Defer Android platform teardown so same-queue Auto skips reuse the timeline

### DIFF
--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAudioPlayer.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAudioPlayer.kt
@@ -356,8 +356,15 @@ class AndroidAudioPlayer(
         // skip; runPlatformLoad cancels this job before clearMediaItems runs. Clearing the
         // session overlay early swaps playlist item UIDs twice per skip and can push Android
         // Auto off the Now Playing screen even when the ExoPlayer timeline is reused.
+        //
+        // Launch on plain Dispatchers.Main (not Main.immediate): with the immediate dispatcher a
+        // call arriving on the main looper runs this block inline, so pause/stop/clearMediaItems,
+        // clearLocalMediaSessionState, and loadedPlatformQueue = null all execute before the
+        // following runPlatformLoad can cancel the job — and the same-queue skip then still
+        // rebuilds the timeline. Deferring a dispatch makes that cancellation reliable, which is
+        // what lets skipToInQueueOnPlatform resolve and seek within the existing timeline.
         platformStopJob?.cancel()
-        platformStopJob = scope.launch {
+        platformStopJob = scope.launch(Dispatchers.Main) {
             priorLoad?.cancelAndJoin()
             crossfadeJob?.cancelAndJoin()
             stopAndroidCrossfade()


### PR DESCRIPTION
## Summary
Follow-up to #204 (which the Codex review flagged as incomplete). `stopCurrentPlaybackImmediately` launched its teardown on the scope's `Dispatchers.Main.immediate`, so a call arriving on the main looper ran the block inline before the following `runPlatformLoad` could cancel it — defeating the adopted-queue reuse for the always-main Android Auto skip path.

## Change
Launch the teardown job on plain `Dispatchers.Main` (queued, not immediate). `runPlatformLoad` cancels it synchronously before it starts, keeping the ExoPlayer timeline, local MediaSession state, and `loadedPlatformQueue` intact so `skipToInQueueOnPlatform` resolves and `seekTo`s inside the existing playlist instead of rebuilding it.

Behavior for real stops (stop/suspend/prepare with no follow-up load) is unchanged: with nothing to cancel it, the queued job still clears on the next main dispatch.

## Tests
- `:playback:testAndroidHostTest` green locally (covers the existing `PlatformQueueIndexTest` reuse-mapping and `CastMediaSessionCrossfadeTest` uid-stability).
- No new concurrency test added: the deferral is a dispatch-ordering property that would be a brittle timing test; the reuse logic it enables is already unit-tested.