### PR TITLE
Prefer native Media3 seeks so Android Auto stays on song detail

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/phoebe/app/CarPlayPlayback.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/phoebe/app/CarPlayPlayback.android.kt
@@ -7,7 +7,9 @@ import com.phoebe.app.domain.supportsRemotePlaylists
 import com.phoebe.app.player.AndroidPlaybackBridge
 
 actual fun bindCarPlayPlayback(state: AppState) {
-    AndroidPlaybackBridge.onToggleLikedTrack = { track -> state.toggleLikedTrack(track) }
+    AndroidPlaybackBridge.onToggleLikedTrack = { track ->
+        state.toggleLikedTrack(track).join()
+    }
     AndroidPlaybackBridge.isLikeAvailable = { track ->
         track.canTogglePlexLike() && state.session.value.supportsRemotePlaylists()
     }

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAudioPlayer.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidAudioPlayer.kt
@@ -309,12 +309,14 @@ class AndroidAudioPlayer(
                 val (platformIndex, mapping) = resolved
                 loadedPlatformQueue = mapping
                 expectControllerTarget(queueIds, platformIndex, generation)
-                player.pause()
+                // Do not pause before seek — a playWhenReady false dip is enough for some
+                // Android Auto head units to dismiss the song-detail surface.
                 player.seekTo(platformIndex, 0L)
                 updateOptimisticLocalBufferedPosition(track, generation)
                 player.volume = effectiveOutputVolume()
                 if (playWhenReady) {
                     markPendingAutoplay(generation)
+                    player.playWhenReady = true
                     player.play()
                 }
             } else {
@@ -1769,8 +1771,18 @@ class AndroidAudioPlayer(
         retryCount = 0
     }
 
+    private var localMediaSessionStatePublished = false
+
     private fun publishLocalMediaSessionState(player: Player, track: Track?) {
-        if (crossfadePlayer != null && crossfadePlayer !== player) return
+        // Routine local playback must expose ExoPlayer's timeline directly. Overlaying a
+        // LocalMediaSessionState rebuilds MediaSession state on every sync tick and fights
+        // native seeks — wide-screen Android Auto then flashes or leaves song detail.
+        // Only overlay while an owned crossfade player is the audible source.
+        if (crossfadePlayer == null || crossfadeOwnedTrackId == null) {
+            clearLocalMediaSessionState()
+            return
+        }
+        if (crossfadePlayer !== player) return
         val currentTrack = track ?: state.value.currentTrack
         if (currentTrack == null) {
             clearLocalMediaSessionState()
@@ -1781,6 +1793,7 @@ class AndroidAudioPlayer(
             .takeIf { it > 0L }
             ?.coerceAtLeast(currentTrack.durationMs)
             ?: currentTrack.durationMs
+        localMediaSessionStatePublished = true
         AndroidPlaybackBridge.onLocalMediaSessionState?.invoke(
             LocalMediaSessionState(
                 track = currentTrack,
@@ -1794,6 +1807,8 @@ class AndroidAudioPlayer(
     }
 
     private fun clearLocalMediaSessionState() {
+        if (!localMediaSessionStatePublished) return
+        localMediaSessionStatePublished = false
         AndroidPlaybackBridge.onLocalMediaSessionState?.invoke(null)
     }
 

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidPlaybackBridge.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/AndroidPlaybackBridge.kt
@@ -18,7 +18,7 @@ object AndroidPlaybackBridge {
     var onServicePlayerChanged: (() -> Unit)? = null
     var onPlayQueue: ((List<Track>, Int) -> Unit)? = null
     var onAdoptQueue: ((List<Track>, Int, Boolean) -> Unit)? = null
-    var onToggleLikedTrack: ((Track) -> Unit)? = null
+    var onToggleLikedTrack: (suspend (Track) -> Unit)? = null
     var isLikeAvailable: ((Track) -> Boolean)? = null
     var isTrackLiked: ((Track) -> Boolean)? = null
     var isCastActive: (() -> Boolean)? = null

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/CastMediaSessionPlayer.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/CastMediaSessionPlayer.kt
@@ -111,6 +111,7 @@ internal class CastMediaSessionPlayer(
             }
             return Futures.immediateVoidFuture()
         }
+        // Crossfade overlay: Phoebe owns transport until the ramp commits.
         if (localState != null) {
             when (seekCommand) {
                 Player.COMMAND_SEEK_TO_NEXT,
@@ -127,6 +128,13 @@ internal class CastMediaSessionPlayer(
             Player.COMMAND_SEEK_TO_NEXT,
             Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM,
             -> {
+                // Prefer a native Media3 seek whenever the session playlist already has a
+                // next item. Phoebe next()/play() is only for advancing past the platform
+                // window (or wrapping repeat) — that path is what kicks Android Auto off
+                // the song-detail page.
+                if (hasNextMediaItem()) {
+                    return super.handleSeek(mediaItemIndex, positionMs, seekCommand)
+                }
                 if (AndroidPlaybackBridge.hasNextTrack?.invoke() == true) {
                     AndroidPlaybackBridge.onSkipNext?.invoke()
                     return Futures.immediateVoidFuture()
@@ -135,6 +143,9 @@ internal class CastMediaSessionPlayer(
             Player.COMMAND_SEEK_TO_PREVIOUS,
             Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM,
             -> {
+                if (hasPreviousMediaItem()) {
+                    return super.handleSeek(mediaItemIndex, positionMs, seekCommand)
+                }
                 if (AndroidPlaybackBridge.hasPreviousTrack?.invoke() == true) {
                     AndroidPlaybackBridge.onSkipPrevious?.invoke()
                     return Futures.immediateVoidFuture()
@@ -189,15 +200,33 @@ internal class CastMediaSessionPlayer(
                 ?: currentMediaItemIndex.takeIf { it in delegatePlaylist.indices }
                 ?: 0
         }
-        val existing = delegatePlaylist.getOrNull(currentIndex)
-        val overrideItem = mediaSessionOverrideItem(
-            track = track,
-            durationMs = durationMs,
-            existing = existing,
-        )
         if (delegatePlaylist.isEmpty()) {
-            return MediaSessionOverridePlaylist(listOf(overrideItem), currentIndex)
+            return MediaSessionOverridePlaylist(
+                playlist = listOf(mediaSessionOverrideItem(track, durationMs, existing = null)),
+                currentIndex = currentIndex,
+            )
         }
+        val existing = delegatePlaylist[currentIndex]
+        // Keep the existing MediaItemData when the mediaId already matches. Rebuilding via
+        // playbackMediaItem() every publish creates a new MediaItem instance and makes
+        // Media3 report a playlist change — that flashes / dismisses Android Auto Now Playing.
+        if (existing.mediaItem.mediaId == track.id) {
+            val durationUs = durationMs.takeIf { it > 0L }?.times(1_000L) ?: C.TIME_UNSET
+            val item = if (durationUs != C.TIME_UNSET && existing.durationUs != durationUs) {
+                existing.buildUpon().setDurationUs(durationUs).setIsSeekable(true).build()
+            } else {
+                existing
+            }
+            return MediaSessionOverridePlaylist(
+                playlist = if (item === existing) {
+                    delegatePlaylist
+                } else {
+                    delegatePlaylist.toMutableList().also { it[currentIndex] = item }
+                },
+                currentIndex = currentIndex,
+            )
+        }
+        val overrideItem = mediaSessionOverrideItem(track, durationMs, existing)
         return MediaSessionOverridePlaylist(
             playlist = delegatePlaylist.toMutableList().also { it[currentIndex] = overrideItem },
             currentIndex = currentIndex,

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/PlaybackService.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/PlaybackService.kt
@@ -190,6 +190,8 @@ class PlaybackService : MediaLibraryService() {
                 if (AndroidPlaybackBridge.isLikeAvailable?.invoke(track) != true) {
                     return@listenableFuture SessionResult(SessionError.ERROR_NOT_SUPPORTED)
                 }
+                // Await the catalog mutation so the heart reflects the post-toggle state.
+                // Local MediaSession ticks no longer call updateLikeButton (they flash AA).
                 AndroidPlaybackBridge.onToggleLikedTrack?.invoke(track)
                 updateLikeButton(track)
                 SessionResult(SessionResult.RESULT_SUCCESS)

--- a/playback/src/androidMain/kotlin/com/phoebe/app/player/PlaybackService.kt
+++ b/playback/src/androidMain/kotlin/com/phoebe/app/player/PlaybackService.kt
@@ -314,7 +314,8 @@ class PlaybackService : MediaLibraryService() {
         }
         AndroidPlaybackBridge.onLocalMediaSessionState = { state ->
             sessionPlayer.updateLocalState(state)
-            updateLikeButton(state?.track)
+            // Like button is refreshed from media-item transitions / explicit track publishes,
+            // not on every position tick — setCustomLayout flashes wide-screen Android Auto.
         }
         AndroidPlaybackBridge.attachServicePlayer(player, servicePlayerListener)
 
@@ -421,10 +422,25 @@ class PlaybackService : MediaLibraryService() {
             ?: source.resolveTracks(listOf(item)).firstOrNull()
     }
 
+    private var lastLikeButtonTrackId: String? = null
+    private var lastLikeButtonLiked: Boolean = false
+    private var lastLikeButtonEnabled: Boolean = false
+
     private fun updateLikeButton(track: Track? = null) {
         val session = mediaLibrarySession ?: return
         serviceScope.launch {
             val resolved = track ?: runCatching { currentTrackForLike() }.getOrNull()
+            val liked = resolved?.let { AndroidPlaybackBridge.isTrackLiked?.invoke(it) } == true
+            val enabled = resolved?.let { AndroidPlaybackBridge.isLikeAvailable?.invoke(it) } == true
+            if (resolved?.id == lastLikeButtonTrackId &&
+                liked == lastLikeButtonLiked &&
+                enabled == lastLikeButtonEnabled
+            ) {
+                return@launch
+            }
+            lastLikeButtonTrackId = resolved?.id
+            lastLikeButtonLiked = liked
+            lastLikeButtonEnabled = enabled
             val layout = likeButtonLayout(resolved)
             session.setCustomLayout(layout)
             session.setMediaButtonPreferences(layout)
@@ -446,8 +462,9 @@ class PlaybackService : MediaLibraryService() {
         }
     }
 
-    private fun handledQueueNavigationCommand(playerCommand: Int): Int? =
-        handleExternalQueueNavigationCommand(
+    private fun handledQueueNavigationCommand(playerCommand: Int): Int? {
+        val player = mediaLibrarySession?.player
+        return handleExternalQueueNavigationCommand(
             playerCommand = playerCommand,
             isCastActive = AndroidPlaybackBridge.isCastActive?.invoke() == true,
             hasNextTrack = AndroidPlaybackBridge.hasNextTrack?.invoke() == true,
@@ -456,7 +473,10 @@ class PlaybackService : MediaLibraryService() {
             onSkipPrevious = AndroidPlaybackBridge.onSkipPrevious,
             onCastSkipNext = AndroidPlaybackBridge.onCastSkipNext,
             onCastSkipPrevious = AndroidPlaybackBridge.onCastSkipPrevious,
+            platformHasNext = player?.hasNextMediaItem() == true,
+            platformHasPrevious = player?.hasPreviousMediaItem() == true,
         )
+    }
 
     private fun List<MediaItem>.isInAppPlaybackQueue(): Boolean =
         isNotEmpty() && all { it.requestMetadata.extras?.getBoolean(InAppPlaybackExtra, false) == true }
@@ -600,7 +620,24 @@ internal fun handleExternalQueueNavigationCommand(
     onSkipPrevious: (() -> Unit)?,
     onCastSkipNext: (() -> Unit)?,
     onCastSkipPrevious: (() -> Unit)?,
+    platformHasNext: Boolean = false,
+    platformHasPrevious: Boolean = false,
 ): Int? {
+    // When the Media3 playlist already contains the next/previous item, let the session
+    // player seek natively. Routing through Phoebe next()/play() rebuilds app state and
+    // briefly mutates the MediaSession timeline — on wide-screen Android Auto that kicks
+    // the user off the song-detail / Now Playing surface back to browse.
+    if (!isCastActive) {
+        when (playerCommand) {
+            Player.COMMAND_SEEK_TO_NEXT,
+            Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM,
+            -> if (platformHasNext) return null
+            Player.COMMAND_SEEK_TO_PREVIOUS,
+            Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM,
+            -> if (platformHasPrevious) return null
+        }
+    }
+
     val handler = when (playerCommand) {
         Player.COMMAND_SEEK_TO_NEXT,
         Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM,

--- a/playback/src/androidUnitTest/kotlin/com/phoebe/app/player/BrowseMediaItemsTest.kt
+++ b/playback/src/androidUnitTest/kotlin/com/phoebe/app/player/BrowseMediaItemsTest.kt
@@ -194,11 +194,32 @@ class BrowseMediaItemsTest {
             onSkipPrevious = null,
             onCastSkipNext = { castNextCalls++ },
             onCastSkipPrevious = null,
+            platformHasNext = false,
         )
 
         assertEquals(SessionResult.RESULT_INFO_SKIPPED, result)
         assertEquals(1, localNextCalls)
         assertEquals(0, castNextCalls)
+    }
+
+    @Test
+    fun externalNextCommandUsesNativeSeekWhenPlatformPlaylistAlreadyHasNext() {
+        var localNextCalls = 0
+
+        val result = handleExternalQueueNavigationCommand(
+            playerCommand = Player.COMMAND_SEEK_TO_NEXT,
+            isCastActive = false,
+            hasNextTrack = true,
+            hasPreviousTrack = false,
+            onSkipNext = { localNextCalls++ },
+            onSkipPrevious = null,
+            onCastSkipNext = null,
+            onCastSkipPrevious = null,
+            platformHasNext = true,
+        )
+
+        assertNull(result)
+        assertEquals(0, localNextCalls)
     }
 
     @Test
@@ -234,6 +255,7 @@ class BrowseMediaItemsTest {
             onSkipPrevious = null,
             onCastSkipNext = { castNextCalls++ },
             onCastSkipPrevious = null,
+            platformHasNext = true,
         )
 
         assertEquals(SessionResult.RESULT_INFO_SKIPPED, result)

--- a/playback/src/androidUnitTest/kotlin/com/phoebe/app/player/CastMediaSessionPlayerTest.kt
+++ b/playback/src/androidUnitTest/kotlin/com/phoebe/app/player/CastMediaSessionPlayerTest.kt
@@ -26,6 +26,40 @@ import kotlin.test.assertTrue
 @Config(sdk = [35], application = Application::class)
 class CastMediaSessionPlayerTest {
     @Test
+    fun nativeSkipUsesDelegateSeekWhenPlaylistAlreadyHasNext() {
+        val delegate = FakeSessionDelegate()
+        val player = CastMediaSessionPlayer(delegate)
+        val first = testTrack("native-first")
+        val second = testTrack("native-second")
+        var skipNextCalls = 0
+        val previousHasNext = AndroidPlaybackBridge.hasNextTrack
+        val previousSkipNext = AndroidPlaybackBridge.onSkipNext
+
+        try {
+            AndroidPlaybackBridge.hasNextTrack = { true }
+            AndroidPlaybackBridge.onSkipNext = { skipNextCalls++ }
+            delegate.setStateForTest(
+                delegateState(
+                    tracks = listOf(first, second),
+                    currentIndex = 0,
+                ).build(),
+            )
+            shadowOf(Looper.getMainLooper()).idle()
+
+            player.seekToNext()
+            shadowOf(Looper.getMainLooper()).idle()
+
+            assertEquals(0, skipNextCalls)
+            assertEquals(1, player.currentMediaItemIndex)
+            assertEquals("native-second", player.currentMediaItem?.mediaId)
+        } finally {
+            AndroidPlaybackBridge.hasNextTrack = previousHasNext
+            AndroidPlaybackBridge.onSkipNext = previousSkipNext
+            player.release()
+        }
+    }
+
+    @Test
     fun localStateOverridesPausedDelegateForAndroidAuto() {
         val player = CastMediaSessionPlayer(FakeSessionDelegate())
         val track = testTrack("track-crossfade")
@@ -262,9 +296,20 @@ class CastMediaSessionPlayerTest {
             positionMs: Long,
             seekCommand: Int,
         ): ListenableFuture<*> {
+            val targetIndex = when (seekCommand) {
+                Player.COMMAND_SEEK_TO_NEXT,
+                Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM,
+                -> (state.currentMediaItemIndex + 1).takeIf { it < state.playlist.size }
+                Player.COMMAND_SEEK_TO_PREVIOUS,
+                Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM,
+                -> (state.currentMediaItemIndex - 1).takeIf { it >= 0 }
+                else -> mediaItemIndex.takeIf { it in state.playlist.indices }
+            } ?: state.currentMediaItemIndex
             state = state.buildUpon()
+                .setCurrentMediaItemIndex(targetIndex)
                 .setContentPositionMs(positionMs.coerceAtLeast(0L))
                 .build()
+            invalidateState()
             return Futures.immediateVoidFuture()
         }
 


### PR DESCRIPTION
## Summary
- Prefer native Media3 next/previous seeks when the session playlist already has a neighbor, instead of routing through Phoebe `next()`/`play()` which rebuilds MediaSession state and kicks wide-screen Android Auto off song detail.
- Limit local MediaSession overlays to owned crossfade, reuse existing MediaItem instances when the id matches, skip pause-before-seek dips, and debounce like-button custom layout updates so routine sync ticks no longer flash Now Playing.

## Test plan
- [x] `./gradlew :playback:testDebugUnitTest --tests BrowseMediaItemsTest --tests CastMediaSessionPlayerTest`
- [ ] On Android Auto (wide-screen), skip next/previous within a multi-track queue and confirm song detail / Now Playing stays up
- [ ] Confirm skip still works at end of platform window / when Phoebe queue extends past Media3 playlist
- [ ] Crossfade path still owns transport until ramp commits; cast skips unchanged


Made with [Cursor](https://cursor.com)